### PR TITLE
fix: emit bot#start asap when the script executes

### DIFF
--- a/apps/electron/src/renderer/game/api/Bot.ts
+++ b/apps/electron/src/renderer/game/api/Bot.ts
@@ -177,39 +177,6 @@ export class Bot extends EventEmitter {
 	}
 
 	/**
-	 * Raises the running flag.
-	 *
-	 * This does not start a script, rather merely declares that a script is running.
-	 *
-	 * For example, the auto relogin background task runs if the bot is running.
-	 */
-	// @ts-expect-error - internal method
-	private _start(): void {
-		if (this.ac) {
-			throw new Error('Bot is already running');
-		}
-
-		this.emit('start');
-		this.ac = new AbortController();
-	}
-
-	/**
-	 * Lowers the running flag.
-	 *
-	 * While this does not stop a script, it removes any background tasks that were set up on start.
-	 */
-	// @ts-expect-error - internal method
-	private _stop(): void {
-		if (!this.ac) {
-			throw new Error('Bot is already stopped or not running');
-		}
-
-		this.emit('stop');
-		this.ac.abort();
-		this.ac = null;
-	}
-
-	/**
 	 * Whether the bot is "running".
 	 */
 	public isRunning(): boolean {

--- a/apps/electron/src/renderer/game/script.ui.ts
+++ b/apps/electron/src/renderer/game/script.ui.ts
@@ -74,11 +74,14 @@ window.addEventListener('DOMContentLoaded', async () => {
 
 							await bot.sleep(500);
 
-							bot._start();
-							bot.settings.infiniteRange=true;
-							bot.settings.lagKiller=true;
-							bot.settings.skipCutscenes=true;
+							bot.settings.infiniteRange = true;
+							bot.settings.lagKiller = true;
+							bot.settings.skipCutscenes = true;
 							bot.settings.setFPS(10);
+
+							bot.ac = new AbortController();
+
+							process.nextTick(() => bot.emit('start'));
 
 							const abortPromise = new Promise((_, reject) => {
 								bot.signal.addEventListener('abort', () => {
@@ -87,7 +90,10 @@ window.addEventListener('DOMContentLoaded', async () => {
 							});
 
 							await Promise.race([
-								(async () => { ${b64_out} })(),
+								(async () => {
+									while (!bot.isRunning()) { await bot.sleep(1000); }
+									${b64_out}
+								})(),
 								abortPromise
 							]);
 
@@ -99,11 +105,16 @@ window.addEventListener('DOMContentLoaded', async () => {
 								console.error('An error occurred while executing the script:', error);
 							}
 						} finally {
-							bot._stop();
-							bot.settings.infiniteRange=false;
-							bot.settings.lagKiller=false;
-							bot.settings.skipCutscenes=false;
-							bot.settings.setFPS(30);
+							process.nextTick(() => {
+								if (bot.ac) {
+									bot.ac.abort();
+									bot.ac = null;
+								}
+							 	bot.settings.infiniteRange = false;
+							 	bot.settings.lagKiller = false;
+							 	bot.settings.skipCutscenes = false;
+						 		bot.settings.setFPS(30);
+        					});
 						}
 					})();
 				\`);


### PR DESCRIPTION
Closes #83 
- Use process.nextTick() to emit the start event before the beginning of the next tick in the event loop
- Removed `bot._start()`, `bot._stop()`