### PR TITLE
feat: AutoRelogin

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -17,7 +17,6 @@
     "compile:watch": "tsx esbuild.config.js --watch",
     "compile:prod": "cross-env NODE_ENV=production tsx esbuild.config.js",
     "electron": "node scripts/start-electron.mjs",
-    "electron:raw": "electron .",
     "build": "npm-run-all --sequential clean typecheck compile:prod \"electron-builder build\"",
     "build:fast": "npm-run-all --sequential compile:prod \"electron-builder build\"",
     "build:all": "npm-run-all --sequential clean typecheck compile:prod \"electron-builder -mwl\"",

--- a/app/src/renderer/game/App.tsx
+++ b/app/src/renderer/game/App.tsx
@@ -18,6 +18,7 @@ import { Jobs } from "./flash/Services/Jobs";
 import { Player } from "./flash/Services/Player";
 import { Shops } from "./flash/Services/Shops";
 import { TempInventory } from "./flash/Services/TempInventory";
+import { AutoRelogin } from "./features/Services/AutoRelogin";
 import { demoScriptName, demoScriptSource } from "./scripting/demoScript";
 import type { ScriptDiagnostic } from "./scripting/Types";
 
@@ -155,6 +156,13 @@ export default function App() {
   const [infiniteRangeEnabled, setInfiniteRangeEnabled] = createSignal(false);
   const [provokeCellEnabled, setProvokeCellEnabled] = createSignal(false);
   const [skipCutscenesEnabled, setSkipCutscenesEnabled] = createSignal(false);
+  const [autoReloginEnabled, setAutoReloginEnabled] = createSignal(false);
+  const [autoReloginCaptured, setAutoReloginCaptured] = createSignal(false);
+  const [autoReloginAttempting, setAutoReloginAttempting] = createSignal(false);
+  const [autoReloginDelayMs, setAutoReloginDelayMs] = createSignal("3000");
+  const [autoReloginUsername, setAutoReloginUsername] = createSignal("");
+  const [autoReloginServer, setAutoReloginServer] = createSignal("");
+  const [autoReloginLastError, setAutoReloginLastError] = createSignal("");
   const [testClientPacket, setTestClientPacket] = createSignal("%xt%hello%");
   const [testServerPacket, setTestServerPacket] = createSignal("%xt%zm%cmd%");
   const [clientPacketType, setClientPacketType] = createSignal<
@@ -172,6 +180,7 @@ export default function App() {
   let activeCombatFiber: Fiber.Fiber<void, unknown> | undefined;
   let packetLogDisposer: (() => void) | undefined;
   let settingsStateDisposer: (() => void) | undefined;
+  let autoReloginStateDisposer: (() => void) | undefined;
 
   const [scriptOverlayVisible, setScriptOverlayVisible] = createSignal(false);
   const [scriptOverlayPosition, setScriptOverlayPosition] = createSignal(
@@ -260,6 +269,7 @@ export default function App() {
 
   const makeFlashServiceDebugApi = Effect.gen(function* () {
     const auth = yield* Auth;
+    const autoRelogin = yield* AutoRelogin;
     const autoZone = yield* AutoZone;
     const bank = yield* Bank;
     const combat = yield* Combat;
@@ -277,6 +287,7 @@ export default function App() {
 
     return {
       Auth: auth,
+      AutoRelogin: autoRelogin,
       AutoZone: autoZone,
       Bank: bank,
       Combat: combat,
@@ -293,6 +304,7 @@ export default function App() {
       World: world,
       api: {
         auth,
+        autoRelogin,
         autoZone,
         bank,
         combat,
@@ -309,6 +321,7 @@ export default function App() {
         world,
       },
       auth,
+      autoRelogin,
       autoZone,
       bank,
       combat,
@@ -343,6 +356,7 @@ export default function App() {
                 `"use strict";
 const {
   Auth,
+  AutoRelogin,
   AutoZone,
   Bank,
   Combat,
@@ -882,6 +896,69 @@ ${source}
       });
   };
 
+  const refreshAutoReloginState = () => {
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoRelogin = yield* AutoRelogin;
+          return yield* autoRelogin.getState();
+        }),
+      )
+      .then((state) => {
+        setAutoReloginEnabled(state.enabled);
+        setAutoReloginCaptured(state.captured);
+        setAutoReloginAttempting(state.attempting);
+        setAutoReloginDelayMs(String(state.delayMs));
+        setAutoReloginUsername(state.username ?? "");
+        setAutoReloginServer(state.server ?? "");
+        setAutoReloginLastError(state.lastError ?? "");
+      })
+      .catch((error) => {
+        console.error("Refresh autorelogin state error:", error);
+      });
+  };
+
+  const handleToggleAutoRelogin = () => {
+    const nextEnabled = !autoReloginEnabled();
+    setAutoReloginEnabled(nextEnabled);
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoRelogin = yield* AutoRelogin;
+          const action = nextEnabled
+            ? autoRelogin.enable()
+            : autoRelogin.disable();
+          return yield* action;
+        }),
+      )
+      .catch((error) => {
+        console.error("Toggle autorelogin error:", error);
+        refreshAutoReloginState();
+      });
+  };
+
+  const handleSetAutoReloginDelay = () => {
+    const delayMs = Number.parseInt(autoReloginDelayMs(), 10);
+    if (!Number.isFinite(delayMs) || delayMs < 0) {
+      console.error("Invalid autorelogin delay");
+      refreshAutoReloginState();
+      return;
+    }
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoRelogin = yield* AutoRelogin;
+          return yield* autoRelogin.setDelayMs(delayMs);
+        }),
+      )
+      .catch((error) => {
+        console.error("Set autorelogin delay error:", error);
+        refreshAutoReloginState();
+      });
+  };
+
   const testSendClientPacket = () => {
     const packet = testClientPacket().trim();
     if (packet === "") {
@@ -979,12 +1056,35 @@ ${source}
       .catch((error) => {
         console.error("Settings state subscription error:", error);
       });
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoRelogin = yield* AutoRelogin;
+          return yield* autoRelogin.onState((state) => {
+            setAutoReloginEnabled(state.enabled);
+            setAutoReloginCaptured(state.captured);
+            setAutoReloginAttempting(state.attempting);
+            setAutoReloginDelayMs(String(state.delayMs));
+            setAutoReloginUsername(state.username ?? "");
+            setAutoReloginServer(state.server ?? "");
+            setAutoReloginLastError(state.lastError ?? "");
+          });
+        }),
+      )
+      .then((dispose) => {
+        autoReloginStateDisposer = dispose;
+      })
+      .catch((error) => {
+        console.error("AutoRelogin state subscription error:", error);
+      });
   });
 
   onCleanup(() => {
     stopCombatTask();
     packetLogDisposer?.();
     settingsStateDisposer?.();
+    autoReloginStateDisposer?.();
   });
 
   const refreshMeta = async () => {
@@ -1411,6 +1511,61 @@ ${source}
                 <option value="magnumopus">magnumopus</option>
                 <option value="queeniona">queeniona</option>
               </select>
+            </div>
+            <div
+              style={{
+                display: "flex",
+                "align-items": "center",
+                gap: "10px",
+                "margin-top": "10px",
+                "flex-wrap": "wrap",
+              }}
+            >
+              <label
+                style={{ display: "flex", "align-items": "center", gap: "5px" }}
+              >
+                <input
+                  type="checkbox"
+                  checked={autoReloginEnabled()}
+                  onChange={handleToggleAutoRelogin}
+                  style={{ cursor: "pointer" }}
+                />
+                Auto Relogin
+              </label>
+              <input
+                type="text"
+                value={autoReloginDelayMs()}
+                onInput={(e) => setAutoReloginDelayMs(e.currentTarget.value)}
+                placeholder="Delay ms"
+                style={{
+                  padding: "5px",
+                  "border-radius": "4px",
+                  border: "1px solid #ccc",
+                  background: "white",
+                  color: "black",
+                  width: "100px",
+                }}
+              />
+              <button
+                onClick={handleSetAutoReloginDelay}
+                style={{
+                  padding: "5px 10px",
+                  cursor: "pointer",
+                  background: "#6366f1",
+                  border: "none",
+                  color: "white",
+                  "border-radius": "4px",
+                }}
+              >
+                Set Delay
+              </button>
+              <span style={{ "font-size": "12px", opacity: 0.85 }}>
+                {autoReloginCaptured()
+                  ? `${autoReloginUsername()} @ ${autoReloginServer()}`
+                  : "not captured"}
+                {autoReloginAttempting() ? " - attempting" : ""}
+                {autoReloginLastError() ? ` - ${autoReloginLastError()}` : ""}
+              </span>
             </div>
             <div
               style={{

--- a/app/src/renderer/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/game/features/Layers/AutoRelogin.test.ts
@@ -1,0 +1,582 @@
+import { Server, type ServerData } from "@vexed/game";
+import { Effect, Fiber, Layer } from "effect";
+import { expect, test } from "vitest";
+import { SwfCallError } from "../../flash/Errors";
+import { Auth, type AuthShape } from "../../flash/Services/Auth";
+import { Bridge, type BridgeShape } from "../../flash/Services/Bridge";
+import {
+  Jobs,
+  type JobsShape,
+  type PeriodicJobDefinition,
+} from "../../flash/Services/Jobs";
+import { Player, type PlayerShape } from "../../flash/Services/Player";
+import { Settings, type SettingsShape } from "../../flash/Services/Settings";
+import { AutoRelogin, type AutoReloginShape } from "../Services/AutoRelogin";
+import { AutoReloginLive } from "./AutoRelogin";
+
+const twigServer: ServerData = {
+  bOnline: 1,
+  bUpg: 0,
+  iChat: 0,
+  iCount: 212,
+  iLevel: 0,
+  iMax: 1000,
+  iPort: 5589,
+  sIP: "sock8.aq.com",
+  sLang: "xx",
+  sName: "Twig",
+};
+
+const yorumiServer: ServerData = {
+  ...twigServer,
+  sName: "Yorumi",
+};
+
+type HarnessOptions = {
+  readonly bridgeLoggedIn?: boolean;
+  readonly iUpgDays?: number;
+  readonly password?: string;
+  readonly playerReadyFailures?: number;
+  readonly serverInfo?: string;
+  readonly serverSelectStalls?: boolean;
+  readonly servers?: readonly ServerData[];
+  readonly settingsApplyFails?: boolean;
+};
+
+type Harness = {
+  readonly authCalls: string[];
+  readonly jobsState: {
+    readonly definition: PeriodicJobDefinition | undefined;
+    readonly task: Effect.Effect<void, unknown> | undefined;
+  };
+  readonly emitConnection: (status: ConnectionStatus) => void;
+  readonly manualLogin: (server?: ServerData) => void;
+  readonly settingsPatches: readonly unknown[];
+};
+
+const withAutoRelogin = async <A>(
+  options: HarnessOptions,
+  body: (
+    autoRelogin: AutoReloginShape,
+    harness: Harness,
+  ) => Effect.Effect<A, unknown>,
+): Promise<A> => {
+  const authCalls: string[] = [];
+  const settingsPatches: unknown[] = [];
+  const connectionHandlers = new Set<(status: ConnectionStatus) => void>();
+  const jobsState: {
+    definition: PeriodicJobDefinition | undefined;
+    task: Effect.Effect<void, unknown> | undefined;
+  } = {
+    definition: undefined,
+    task: undefined,
+  };
+  let phase: "login" | "servers" | "game" = "login";
+  let playerReady = false;
+
+  const bridgeLoggedIn = options.bridgeLoggedIn ?? true;
+  let serverInfo = options.serverInfo ?? JSON.stringify(twigServer);
+  const iUpgDays = options.iUpgDays ?? 30;
+  const password = options.password ?? "secret-password";
+  const servers = options.servers ?? [twigServer];
+  let remainingPlayerReadyFailures = options.playerReadyFailures ?? 0;
+
+  const bridge = {
+    call<K extends keyof Window["swf"]>(
+      path: K,
+      args?: Parameters<Window["swf"][K]>,
+    ) {
+      return Effect.sync(() => {
+        if (path === "auth.isLoggedIn") {
+          return bridgeLoggedIn as ReturnType<Window["swf"][K]>;
+        }
+
+        if (path === "flash.getGameObject") {
+          const key = args?.[0];
+          if (key === "objServerInfo") {
+            return serverInfo as ReturnType<Window["swf"][K]>;
+          }
+
+          if (key === "mcLogin.currentLabel") {
+            return (
+              phase === "servers" && options.serverSelectStalls !== true
+                ? "Servers"
+                : "Login"
+            ) as ReturnType<Window["swf"][K]>;
+          }
+
+          if (key === "currentLabel") {
+            return (phase === "game" ? "Game" : "Login") as ReturnType<
+              Window["swf"][K]
+            >;
+          }
+        }
+
+        if (path === "flash.isNull") {
+          return true as ReturnType<Window["swf"][K]>;
+        }
+
+        if (path === "flash.getConnMcText") {
+          return "loading" as ReturnType<Window["swf"][K]>;
+        }
+
+        if (path === "flash.isConnMcBackButtonVisible") {
+          return false as ReturnType<Window["swf"][K]>;
+        }
+
+        throw new Error(`unexpected bridge call: ${String(path)}`);
+      });
+    },
+    callGameFunction() {
+      return Effect.void;
+    },
+    onConnection(handler: (status: ConnectionStatus) => void) {
+      connectionHandlers.add(handler);
+      return Effect.succeed(() => {
+        connectionHandlers.delete(handler);
+      });
+    },
+  } satisfies BridgeShape;
+
+  const auth = {
+    connectTo(server: string) {
+      authCalls.push(`connectTo:${server}`);
+      phase = "game";
+      playerReady = true;
+      return Effect.succeed(true);
+    },
+    getServers() {
+      return Effect.succeed(servers.map((server) => new Server(server)));
+    },
+    getUsername() {
+      return Effect.succeed("Hero");
+    },
+    getPassword() {
+      return Effect.succeed(password);
+    },
+    getLoginInfo() {
+      return Effect.succeed({
+        ...twigServer,
+        bSuccess: 1,
+        iUpgDays,
+        iUpg: 1,
+        servers: [],
+        sToken: "",
+        unm: "Hero",
+      });
+    },
+    isLoggedIn() {
+      return Effect.succeed(bridgeLoggedIn);
+    },
+    isTemporarilyKicked() {
+      return Effect.succeed(false);
+    },
+    login(username: string, loginPassword: string) {
+      authCalls.push(`login:${username}:${loginPassword}`);
+      phase = "servers";
+      return Effect.void;
+    },
+    logout() {
+      authCalls.push("logout");
+      return Effect.void;
+    },
+  } satisfies AuthShape;
+
+  const jobs = {
+    start() {
+      return Effect.succeed(true);
+    },
+    startPeriodic() {
+      return Effect.succeed(true);
+    },
+    startPeriodicJob(definition: PeriodicJobDefinition) {
+      jobsState.definition = definition;
+      jobsState.task = definition.task;
+      return Effect.succeed(true);
+    },
+    stop() {
+      jobsState.definition = undefined;
+      return Effect.succeed(true);
+    },
+    stopAll() {
+      jobsState.definition = undefined;
+      return Effect.void;
+    },
+    isRunning() {
+      return Effect.succeed(jobsState.definition !== undefined);
+    },
+    getRunningKeys() {
+      return Effect.succeed(
+        jobsState.definition === undefined ? [] : [jobsState.definition.key],
+      );
+    },
+  } satisfies JobsShape;
+
+  const player = {
+    isReady() {
+      return Effect.gen(function* () {
+        if (remainingPlayerReadyFailures > 0) {
+          remainingPlayerReadyFailures -= 1;
+          return yield* new SwfCallError({
+            method: "player.isLoaded",
+            cause: "player not ready",
+          });
+        }
+        return playerReady;
+      });
+    },
+  } as unknown as PlayerShape;
+
+  const settings = {
+    getState() {
+      return Effect.succeed({
+        collisionsEnabled: true,
+        deathAdsVisible: true,
+        effectsEnabled: true,
+        enemyMagnetEnabled: false,
+        frameRate: 24,
+        infiniteRangeEnabled: false,
+        lagKillerEnabled: true,
+        otherPlayersVisible: true,
+        provokeCellEnabled: false,
+        skipCutscenesEnabled: true,
+        walkSpeed: 8,
+      });
+    },
+    apply(patch: unknown) {
+      settingsPatches.push(patch);
+      if (options.settingsApplyFails === true) {
+        return Effect.fail(
+          new SwfCallError({
+            method: "settings.setLagKillerEnabled",
+            cause: "world unavailable",
+          }),
+        );
+      }
+      return Effect.void;
+    },
+  } as unknown as SettingsShape;
+
+  return await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const autoRelogin = yield* AutoRelogin;
+        return yield* body(autoRelogin, {
+          authCalls,
+          emitConnection(status) {
+            for (const handler of connectionHandlers) {
+              handler(status);
+            }
+          },
+          jobsState,
+          manualLogin(server = twigServer) {
+            serverInfo = JSON.stringify(server);
+            phase = "game";
+            playerReady = true;
+            for (const handler of connectionHandlers) {
+              handler("OnConnection");
+            }
+          },
+          settingsPatches,
+        });
+      }),
+    ).pipe(
+      Effect.provide(
+        AutoReloginLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.succeed(Auth)(auth),
+              Layer.succeed(Bridge)(bridge),
+              Layer.succeed(Jobs)(jobs),
+              Layer.succeed(Player)(player),
+              Layer.succeed(Settings)(settings),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+};
+
+test("captures current session from objServerInfo without exposing password", async () => {
+  const state = await withAutoRelogin({}, (autoRelogin) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      return yield* autoRelogin.getState();
+    }),
+  );
+
+  expect(state).toMatchObject({
+    captured: true,
+    enabled: true,
+    server: "Twig",
+    username: "Hero",
+  });
+  expect(JSON.stringify(state)).not.toContain("secret-password");
+});
+
+test("ignores null objServerInfo", async () => {
+  const state = await withAutoRelogin({ serverInfo: "null" }, (autoRelogin) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      return yield* autoRelogin.getState();
+    }),
+  );
+
+  expect(state.captured).toBe(false);
+  expect(state.lastError).toBe("current session is not capturable");
+});
+
+test("captures current session automatically on connection", async () => {
+  const state = await withAutoRelogin({}, (autoRelogin, harness) =>
+    Effect.gen(function* () {
+      harness.emitConnection("OnConnection");
+      yield* Effect.sleep("10 millis");
+      return yield* autoRelogin.getState();
+    }),
+  );
+
+  expect(state).toMatchObject({
+    captured: true,
+    enabled: false,
+    server: "Twig",
+    username: "Hero",
+  });
+});
+
+test("successful task logs in and connects to captured server", async () => {
+  const harness = await withAutoRelogin({}, (autoRelogin, currentHarness) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      yield* autoRelogin.setDelayMs(0);
+      yield* currentHarness.jobsState.task!;
+      return currentHarness;
+    }),
+  );
+
+  expect(harness.authCalls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
+  expect(harness.settingsPatches).toEqual([
+    { lagKillerEnabled: false, skipCutscenesEnabled: false },
+    { lagKillerEnabled: true, skipCutscenesEnabled: true },
+  ]);
+});
+
+test("waits delayMs after logout before attempting", async () => {
+  const result = await withAutoRelogin({}, (autoRelogin, harness) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      yield* autoRelogin.setDelayMs(50);
+      yield* harness.jobsState.task!;
+      const beforeDelay = [...harness.authCalls];
+      yield* Effect.sleep("60 millis");
+      yield* harness.jobsState.task!;
+      return {
+        beforeDelay,
+        calls: harness.authCalls,
+      };
+    }),
+  );
+
+  expect(result.beforeDelay).toEqual([]);
+  expect(result.calls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
+});
+
+test("does not start logout delay while connected but still loading", async () => {
+  const harness = await withAutoRelogin({}, (autoRelogin, currentHarness) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      yield* autoRelogin.setDelayMs(0);
+      currentHarness.emitConnection("OnConnection");
+      yield* Effect.sleep("10 millis");
+      yield* currentHarness.jobsState.task!;
+      return currentHarness;
+    }),
+  );
+
+  expect(harness.authCalls).toEqual([]);
+});
+
+test("starts delay from connection lost event", async () => {
+  const result = await withAutoRelogin({}, (autoRelogin, harness) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      yield* autoRelogin.setDelayMs(50);
+      harness.emitConnection("OnConnection");
+      yield* Effect.sleep("10 millis");
+      harness.emitConnection("OnConnectionLost");
+      yield* Effect.sleep("60 millis");
+      yield* harness.jobsState.task!;
+      return harness.authCalls;
+    }),
+  );
+
+  expect(result).toEqual(["login:Hero:secret-password", "connectTo:Twig"]);
+});
+
+test("transient player readiness bridge failures do not fail relogin", async () => {
+  const result = await withAutoRelogin(
+    { playerReadyFailures: 2 },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
+  expect(result.state.lastError).toBeUndefined();
+});
+
+test("temporary setting failures do not block relogin", async () => {
+  const result = await withAutoRelogin(
+    { settingsApplyFails: true },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
+  expect(result.state.lastError).toBeUndefined();
+});
+
+test("manual login during attempt interrupts without reconnecting captured server", async () => {
+  const result = await withAutoRelogin(
+    { serverSelectStalls: true },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        const fiber = yield* Effect.forkDetach(harness.jobsState.task!, {
+          startImmediately: true,
+        });
+        yield* Effect.sleep("10 millis");
+        harness.manualLogin(yorumiServer);
+        yield* Fiber.join(fiber);
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state).toMatchObject({
+    attempting: false,
+    server: "Yorumi",
+  });
+  expect(result.state.lastError).toBeUndefined();
+});
+
+test("disable during attempt interrupts without reconnecting", async () => {
+  const result = await withAutoRelogin(
+    { serverSelectStalls: true },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        const fiber = yield* Effect.forkDetach(harness.jobsState.task!, {
+          startImmediately: true,
+        });
+        yield* Effect.sleep("10 millis");
+        yield* autoRelogin.disable();
+        yield* Fiber.join(fiber);
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state).toMatchObject({
+    attempting: false,
+    enabled: false,
+  });
+  expect(result.state.lastError).toBeUndefined();
+});
+
+test("does not choose another server when captured server is unavailable", async () => {
+  const result = await withAutoRelogin(
+    { servers: [yorumiServer] },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state.lastError).toContain("captured server is unavailable");
+});
+
+test("rejects member-only server when iUpgDays is negative", async () => {
+  const memberServer = {
+    ...twigServer,
+    bUpg: 1,
+  };
+
+  const result = await withAutoRelogin(
+    {
+      iUpgDays: -1,
+      serverInfo: JSON.stringify(memberServer),
+      servers: [memberServer],
+    },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state.lastError).toContain("captured server is not eligible");
+});
+
+test("missing captured session does not attempt login", async () => {
+  const harness = await withAutoRelogin(
+    { serverInfo: "null" },
+    (autoRelogin, currentHarness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        yield* currentHarness.jobsState.task!;
+        return currentHarness;
+      }),
+  );
+
+  expect(harness.authCalls).toEqual([]);
+});

--- a/app/src/renderer/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/game/features/Layers/AutoRelogin.test.ts
@@ -1,5 +1,5 @@
 import { Server, type ServerData } from "@vexed/game";
-import { Effect, Fiber, Layer } from "effect";
+import { Effect, Exit, Fiber, Layer } from "effect";
 import { expect, test } from "vitest";
 import { SwfCallError } from "../../flash/Errors";
 import { Auth, type AuthShape } from "../../flash/Services/Auth";
@@ -34,8 +34,10 @@ const yorumiServer: ServerData = {
 
 type HarnessOptions = {
   readonly bridgeLoggedIn?: boolean;
+  readonly emitConnectionOnConnect?: boolean;
   readonly iUpgDays?: number;
   readonly password?: string;
+  readonly playerReadyAfterConnectDelayMs?: number;
   readonly playerReadyFailures?: number;
   readonly serverInfo?: string;
   readonly serverSelectStalls?: boolean;
@@ -140,10 +142,23 @@ const withAutoRelogin = async <A>(
 
   const auth = {
     connectTo(server: string) {
-      authCalls.push(`connectTo:${server}`);
-      phase = "game";
-      playerReady = true;
-      return Effect.succeed(true);
+      return Effect.gen(function* () {
+        authCalls.push(`connectTo:${server}`);
+        phase = "game";
+        if (options.emitConnectionOnConnect === true) {
+          for (const handler of connectionHandlers) {
+            handler("OnConnection");
+          }
+        }
+
+        if (options.playerReadyAfterConnectDelayMs !== undefined) {
+          yield* Effect.sleep(
+            `${options.playerReadyAfterConnectDelayMs} millis`,
+          );
+        }
+        playerReady = true;
+        return true;
+      });
     },
     getServers() {
       return Effect.succeed(servers.map((server) => new Server(server)));
@@ -344,6 +359,30 @@ test("captures current session automatically on connection", async () => {
   });
 });
 
+test("removes listener when initial state emit throws", async () => {
+  const result = await withAutoRelogin({}, (autoRelogin) =>
+    Effect.gen(function* () {
+      let failingCalls = 0;
+      const exit = yield* Effect.exit(
+        autoRelogin.onState(() => {
+          failingCalls += 1;
+          throw new Error("listener failed");
+        }),
+      );
+
+      yield* autoRelogin.enable();
+
+      return {
+        failed: Exit.isFailure(exit),
+        failingCalls,
+      };
+    }),
+  );
+
+  expect(result.failed).toBe(true);
+  expect(result.failingCalls).toBe(1);
+});
+
 test("successful task logs in and connects to captured server", async () => {
   const harness = await withAutoRelogin({}, (autoRelogin, currentHarness) =>
     Effect.gen(function* () {
@@ -362,6 +401,35 @@ test("successful task logs in and connects to captured server", async () => {
     { lagKillerEnabled: false, skipCutscenesEnabled: false },
     { lagKillerEnabled: true, skipCutscenesEnabled: true },
   ]);
+});
+
+test("socket connection during relogin does not interrupt before player ready", async () => {
+  const result = await withAutoRelogin(
+    {
+      emitConnectionOnConnect: true,
+      playerReadyAfterConnectDelayMs: 150,
+    },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
+  expect(result.state).toMatchObject({
+    attempting: false,
+    server: "Twig",
+  });
+  expect(result.state.lastError).toBeUndefined();
 });
 
 test("waits delayMs after logout before attempting", async () => {
@@ -484,6 +552,40 @@ test("manual login during attempt interrupts without reconnecting captured serve
   );
 
   expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state).toMatchObject({
+    attempting: false,
+    server: "Yorumi",
+  });
+  expect(result.state.lastError).toBeUndefined();
+});
+
+test("manual login during owned connection interrupts when server changes", async () => {
+  const result = await withAutoRelogin(
+    {
+      emitConnectionOnConnect: true,
+      playerReadyAfterConnectDelayMs: 500,
+    },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        const fiber = yield* Effect.forkDetach(harness.jobsState.task!, {
+          startImmediately: true,
+        });
+        yield* Effect.sleep("1100 millis");
+        harness.manualLogin(yorumiServer);
+        yield* Fiber.join(fiber);
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
   expect(result.state).toMatchObject({
     attempting: false,
     server: "Yorumi",

--- a/app/src/renderer/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/game/features/Layers/AutoRelogin.test.ts
@@ -154,7 +154,7 @@ const withAutoRelogin = async <A>(
     getPassword() {
       return Effect.succeed(password);
     },
-    getLoginInfo() {
+    getLoginSession() {
       return Effect.succeed({
         ...twigServer,
         bSuccess: 1,

--- a/app/src/renderer/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/game/features/Layers/AutoRelogin.ts
@@ -1,0 +1,953 @@
+import { Server, type ServerData } from "@vexed/game";
+import {
+  Data,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  Schedule,
+  SynchronizedRef,
+} from "effect";
+import {
+  SwfCallError,
+  SwfMethodNotFoundError,
+  SwfUnavailableError,
+} from "../../flash/Errors";
+import { Auth } from "../../flash/Services/Auth";
+import { Bridge } from "../../flash/Services/Bridge";
+import { Jobs } from "../../flash/Services/Jobs";
+import { Player } from "../../flash/Services/Player";
+import { Settings } from "../../flash/Services/Settings";
+import type { SettingsState } from "../../flash/Services/Settings";
+import type { LoginInfo } from "../../flash/Types";
+import { waitFor } from "../../utils/waitFor";
+import {
+  AutoRelogin,
+  type AutoReloginShape,
+  type AutoReloginState,
+  type AutoReloginStateListener,
+} from "../Services/AutoRelogin";
+
+const JOB_KEY = "features/autorelogin";
+const JOB_INTERVAL = "1 second";
+const DEFAULT_DELAY_MS = 3_000;
+const TEMP_KICK_TIMEOUT = "70 seconds";
+const SERVER_SELECT_TIMEOUT = "10 seconds";
+const SERVERS_LOAD_TIMEOUT = "5 seconds";
+const GAME_ENTRY_TIMEOUT = "15 seconds";
+const PLAYER_READY_TIMEOUT = "10 seconds";
+const MIN_FAILURE_COOLDOWN_MS = 5_000;
+const MAX_FAILURE_COOLDOWN_MS = 60_000;
+const MAX_RELOGIN_RETRIES = 3;
+
+class AutoReloginAttemptError extends Data.TaggedError(
+  "AutoReloginAttemptError",
+)<{
+  readonly message: string;
+  readonly retryable: boolean;
+}> {}
+
+class AutoReloginInterrupted extends Data.TaggedError(
+  "AutoReloginInterrupted",
+)<{
+  readonly reason: string;
+}> {}
+
+type CapturedSession = {
+  readonly username: string;
+  readonly password: string;
+  readonly server: ServerData;
+};
+
+type ReservedAttempt = {
+  readonly captured: CapturedSession;
+  // Prevents stale attempts from continuing after a manual or successful reconnect.
+  readonly connectionSeq: number;
+};
+
+type RuntimeState = {
+  enabled: boolean;
+  captured: CapturedSession | null;
+  attempting: boolean;
+  delayMs: number;
+  lastError: string | undefined;
+  // Retry spacing anchor; first-attempt delay is anchored by loggedOutSince.
+  lastAttemptAt: number;
+  // Set from the real disconnect event so delayMs means "after logout".
+  loggedOutSince: number | undefined;
+  // SmartFox can be connected while player.isReady() is still false.
+  connected: boolean;
+  // Bumped on each connection so long waits can be interrupted safely.
+  connectionSeq: number;
+};
+
+type LogoutObservation = {
+  readonly firstObserved: boolean;
+  readonly loggedOutSince: number;
+};
+
+const initialState = (): RuntimeState => ({
+  enabled: false,
+  captured: null,
+  attempting: false,
+  delayMs: DEFAULT_DELAY_MS,
+  lastError: undefined,
+  lastAttemptAt: 0,
+  loggedOutSince: undefined,
+  connected: false,
+  connectionSeq: 0,
+});
+
+const toPublicState = (state: RuntimeState): AutoReloginState => ({
+  enabled: state.enabled,
+  captured: state.captured !== null,
+  attempting: state.attempting,
+  ...(state.captured !== null ? { username: state.captured.username } : {}),
+  ...(state.captured !== null ? { server: state.captured.server.sName } : {}),
+  delayMs: state.delayMs,
+  ...(state.lastError !== undefined ? { lastError: state.lastError } : {}),
+});
+
+const isServerData = (value: unknown): value is ServerData => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record["sName"] === "string" &&
+    typeof record["sIP"] === "string" &&
+    typeof record["sLang"] === "string" &&
+    typeof record["bOnline"] === "number" &&
+    typeof record["bUpg"] === "number" &&
+    typeof record["iChat"] === "number" &&
+    typeof record["iCount"] === "number" &&
+    typeof record["iLevel"] === "number" &&
+    typeof record["iMax"] === "number" &&
+    typeof record["iPort"] === "number"
+  );
+};
+
+const parseServerInfo = (value: string): ServerData | null => {
+  // objServerInfo is exposed as JSON text, with literal "null" before capture.
+  if (value === "null" || value.trim() === "") {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isServerData(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const decodeFlashValue = (value: string): unknown => {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+};
+
+const flashStringEquals = (value: string, expected: string): boolean =>
+  decodeFlashValue(value) === expected || value === expected;
+
+const normalizeDelayMs = (delayMs: number): number =>
+  Number.isFinite(delayMs)
+    ? Math.max(0, Math.trunc(delayMs))
+    : DEFAULT_DELAY_MS;
+
+const redacted = (message: string, secret: string | undefined): string =>
+  secret === undefined || secret === ""
+    ? message
+    : message.replaceAll(secret, "[redacted]");
+
+const formatReloginError = (error: unknown): string => {
+  if (error instanceof AutoReloginAttemptError) {
+    return error.message;
+  }
+
+  if (error instanceof SwfUnavailableError) {
+    return `Flash bridge unavailable while calling ${error.method}`;
+  }
+
+  if (error instanceof SwfMethodNotFoundError) {
+    return `Flash bridge method missing: ${error.method}`;
+  }
+
+  if (error instanceof SwfCallError) {
+    return `Flash bridge call failed: ${error.method}`;
+  }
+
+  if (error instanceof Error && error.message !== "") {
+    return error.message;
+  }
+
+  if (typeof error === "string" && error !== "") {
+    return error;
+  }
+
+  return "autorelogin failed";
+};
+
+const isServerEligible = (
+  server: Server,
+  loginInfo: LoginInfo | null,
+): boolean => {
+  if (!server.isOnline() || server.isFull()) {
+    return false;
+  }
+
+  if (server.name.toLowerCase().includes("test")) {
+    return false;
+  }
+
+  if (loginInfo === null) {
+    return true;
+  }
+
+  const hasActiveMembership =
+    typeof loginInfo.iUpgDays === "number" && loginInfo.iUpgDays >= 0;
+  const upgradeOnly = server.isUpgrade() && !hasActiveMembership;
+  const chatRestricted = server.data.iChat > 0 && loginInfo.bCCOnly === 1;
+  const underageNonMember =
+    server.data.iChat > 0 &&
+    typeof loginInfo.iAge === "number" &&
+    loginInfo.iAge < 13 &&
+    !hasActiveMembership;
+  const emailUnconfirmed =
+    server.data.iLevel > 0 &&
+    typeof loginInfo.iEmailStatus === "number" &&
+    loginInfo.iEmailStatus <= 2;
+
+  return !(
+    upgradeOnly ||
+    chatRestricted ||
+    underageNonMember ||
+    emailUnconfirmed
+  );
+};
+
+const findCapturedServer = (
+  servers: readonly Server[],
+  captured: ServerData,
+): Server | undefined => {
+  const capturedName = captured.sName.toLowerCase();
+  const exact = servers.find(
+    (server) => server.name.toLowerCase() === capturedName,
+  );
+
+  if (exact !== undefined) {
+    return exact;
+  }
+
+  return servers.find((server) =>
+    server.name.toLowerCase().includes(capturedName),
+  );
+};
+
+const make = Effect.gen(function* () {
+  const auth = yield* Auth;
+  const bridge = yield* Bridge;
+  const jobs = yield* Jobs;
+  const player = yield* Player;
+  const settings = yield* Settings;
+
+  const runFork = Effect.runForkWith(yield* Effect.services());
+  const stateRef = yield* SynchronizedRef.make<RuntimeState>(initialState());
+  const listenersRef = yield* SynchronizedRef.make<
+    Set<AutoReloginStateListener>
+  >(new Set());
+
+  const emitState = (state: AutoReloginState) =>
+    Effect.gen(function* () {
+      const listeners = yield* SynchronizedRef.get(listenersRef);
+      if (listeners.size === 0) {
+        return;
+      }
+
+      yield* Effect.forEach(
+        Array.from(listeners),
+        (listener, listenerIndex) =>
+          Effect.sync(() => listener(state)).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logError({
+                message: "autorelogin listener failed",
+                listenerIndex,
+                cause,
+              }),
+            ),
+          ),
+        { discard: true },
+      );
+    });
+
+  const getState: AutoReloginShape["getState"] = () =>
+    SynchronizedRef.get(stateRef).pipe(Effect.map(toPublicState));
+
+  const emitCurrentState = getState().pipe(Effect.flatMap(emitState));
+
+  const logStage = (stage: string, details?: Record<string, unknown>) =>
+    Effect.logInfo({
+      message: "autorelogin",
+      stage,
+      ...(details ?? {}),
+    });
+
+  const updateState = (
+    update: (state: RuntimeState) => void,
+  ): Effect.Effect<AutoReloginState> =>
+    Effect.gen(function* () {
+      const publicState = yield* SynchronizedRef.modify(stateRef, (state) => {
+        update(state);
+        return [toPublicState(state), state] as const;
+      });
+      yield* emitState(publicState);
+      return publicState;
+    });
+
+  const markFailure = (error: unknown) =>
+    Effect.gen(function* () {
+      const publicState = yield* updateState((state) => {
+        state.lastError = redacted(
+          formatReloginError(error),
+          state.captured?.password,
+        );
+        state.attempting = false;
+      });
+      yield* Effect.logWarning({
+        message: "autorelogin failed",
+        error: publicState.lastError,
+      });
+      return publicState;
+    });
+
+  const markSuccess = () =>
+    updateState((state) => {
+      state.lastError = undefined;
+      state.attempting = false;
+    });
+
+  const markInterrupted = (interrupt: AutoReloginInterrupted) =>
+    markSuccess().pipe(
+      Effect.tap(() =>
+        Effect.logInfo({
+          message: "autorelogin interrupted",
+          reason: interrupt.reason,
+        }),
+      ),
+    );
+
+  const clearAttempting = () =>
+    updateState((state) => {
+      state.attempting = false;
+    });
+
+  const markLoggedIn = () =>
+    SynchronizedRef.update(stateRef, (state) => {
+      // A ready player closes the disconnect window.
+      state.connected = true;
+      state.loggedOutSince = undefined;
+      state.lastAttemptAt = 0;
+      return state;
+    });
+
+  const markLoggedOut = (now: number): Effect.Effect<LogoutObservation> =>
+    SynchronizedRef.modify(
+      stateRef,
+      (state): readonly [LogoutObservation, RuntimeState] => {
+        // Keep the first logout timestamp stable across periodic job ticks.
+        state.connected = false;
+        if (state.loggedOutSince !== undefined) {
+          return [
+            { firstObserved: false, loggedOutSince: state.loggedOutSince },
+            state,
+          ] as const;
+        }
+
+        state.loggedOutSince = now;
+        state.lastAttemptAt = 0;
+        return [{ firstObserved: true, loggedOutSince: now }, state] as const;
+      },
+    );
+
+  const isPlayerReady = () =>
+    player.isReady().pipe(Effect.catchCause(() => Effect.succeed(false)));
+
+  const getInterruptReason = (connectionSeq: number) =>
+    Effect.gen(function* () {
+      const state = yield* SynchronizedRef.get(stateRef);
+      if (!state.enabled) {
+        return Option.some("disabled");
+      }
+
+      // A new connection means this attempt no longer owns the login flow.
+      if (state.connectionSeq !== connectionSeq) {
+        return Option.some("connection changed");
+      }
+
+      return Option.none<string>();
+    });
+
+  const interruptSignal = (connectionSeq: number) =>
+    waitFor(getInterruptReason(connectionSeq).pipe(Effect.map(Option.isSome)), {
+      schedule: Schedule.spaced("100 millis"),
+    }).pipe(
+      Effect.flatMap(() => getInterruptReason(connectionSeq)),
+      Effect.flatMap((reason) =>
+        Option.match(reason, {
+          onNone: () => Effect.never,
+          onSome: (value) =>
+            Effect.fail(new AutoReloginInterrupted({ reason: value })),
+        }),
+      ),
+    );
+
+  const interruptible = <A, E>(
+    connectionSeq: number,
+    effect: Effect.Effect<A, E>,
+  ) => Effect.raceFirst(effect, interruptSignal(connectionSeq));
+
+  const captureCurrentSession: AutoReloginShape["captureCurrentSession"] = () =>
+    Effect.gen(function* () {
+      yield* logStage("capture start");
+      const loggedIn = yield* bridge
+        .call("auth.isLoggedIn")
+        .pipe(Effect.catchCause(() => Effect.succeed(false)));
+      if (!loggedIn) {
+        yield* logStage("capture skipped", { reason: "not logged in" });
+        yield* updateState((state) => {
+          state.lastError = "not logged in";
+        });
+        return false;
+      }
+
+      // Hydrates Auth's cached credentials and membership flags.
+      yield* auth.getLoginInfo();
+
+      const [username, password, serverInfo] = yield* Effect.all([
+        auth.getUsername(),
+        auth.getPassword(),
+        bridge.call("flash.getGameObject", ["objServerInfo"]),
+      ]);
+      const server = parseServerInfo(serverInfo);
+
+      if (username.trim() === "" || password === "" || server === null) {
+        yield* logStage("capture skipped", {
+          reason: "current session is not capturable",
+          hasUsername: username.trim() !== "",
+          hasPassword: password !== "",
+          hasServer: server !== null,
+        });
+        yield* updateState((state) => {
+          state.lastError = "current session is not capturable";
+        });
+        return false;
+      }
+
+      yield* updateState((state) => {
+        state.captured = {
+          username,
+          password,
+          server,
+        };
+        state.lastError = undefined;
+      });
+
+      yield* logStage("capture succeeded", { server: server.sName });
+      return true;
+    }).pipe(
+      Effect.catchCause(() =>
+        Effect.gen(function* () {
+          yield* Effect.logError({
+            message: "autorelogin capture failed",
+            error: "failed to capture current session",
+          });
+          yield* updateState((state) => {
+            state.lastError = "failed to capture current session";
+          });
+          return false;
+        }),
+      ),
+    );
+
+  const waitForServerSelect = waitFor(
+    bridge
+      .call("flash.getGameObject", ["mcLogin.currentLabel"])
+      .pipe(Effect.map((label) => flashStringEquals(label, "Servers"))),
+    {
+      timeout: SERVER_SELECT_TIMEOUT,
+      schedule: Schedule.spaced("100 millis"),
+    },
+  );
+
+  const waitForServers = waitFor(
+    auth.getServers().pipe(Effect.map((servers) => servers.length > 0)),
+    {
+      timeout: SERVERS_LOAD_TIMEOUT,
+      schedule: Schedule.spaced("100 millis"),
+    },
+  );
+
+  const waitForGameEntry = waitFor(
+    Effect.gen(function* () {
+      const [label, connStageNull, connText, backButtonVisible] =
+        yield* Effect.all([
+          bridge.call("flash.getGameObject", ["currentLabel"]),
+          bridge.call("flash.isNull", ["mcConnDetail.stage"]),
+          bridge.call("flash.getConnMcText"),
+          bridge.call("flash.isConnMcBackButtonVisible"),
+        ]);
+
+      if (flashStringEquals(label, "Game") && connStageNull) {
+        return true;
+      }
+
+      // Treat visible connect errors as terminal so the caller can inspect success.
+      const normalizedConnText = connText.toLowerCase();
+      if (
+        connText === "null" ||
+        normalizedConnText.includes("server is full") ||
+        backButtonVisible
+      ) {
+        return true;
+      }
+
+      return false;
+    }),
+    {
+      timeout: GAME_ENTRY_TIMEOUT,
+      schedule: Schedule.spaced("500 millis"),
+    },
+  );
+
+  const isGameEntrySuccessful = Effect.gen(function* () {
+    const [label, connStageNull] = yield* Effect.all([
+      bridge.call("flash.getGameObject", ["currentLabel"]),
+      bridge.call("flash.isNull", ["mcConnDetail.stage"]),
+    ]);
+    return flashStringEquals(label, "Game") && connStageNull;
+  });
+
+  const reloginRetrySchedule = Schedule.exponential(
+    `${MIN_FAILURE_COOLDOWN_MS} millis`,
+  ).pipe(
+    Schedule.jittered,
+    Schedule.modifyDelay((_, delay) =>
+      Effect.succeed(
+        Duration.min(
+          Duration.fromInputUnsafe(delay),
+          Duration.millis(MAX_FAILURE_COOLDOWN_MS),
+        ),
+      ),
+    ),
+    Schedule.take(MAX_RELOGIN_RETRIES),
+  );
+
+  const failAttempt = (message: string, retryable: boolean) =>
+    Effect.fail(new AutoReloginAttemptError({ message, retryable }));
+
+  const restoreLoginSettings = (previousSettings: SettingsState) =>
+    logStage("temporary settings restore").pipe(
+      Effect.andThen(
+        settings
+          .apply({
+            lagKillerEnabled: previousSettings.lagKillerEnabled,
+            skipCutscenesEnabled: previousSettings.skipCutscenesEnabled,
+          })
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning({
+                message: "failed to restore autorelogin settings",
+                cause,
+              }),
+            ),
+          ),
+      ),
+    );
+
+  const withTemporaryLoginSettings = <A, E>(
+    effect: Effect.Effect<A, E>,
+  ): Effect.Effect<A, E> =>
+    Effect.gen(function* () {
+      // These Flash settings improve login reliability but are non-critical.
+      const previousSettings = yield* settings.getState().pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning({
+            message: "failed to read autorelogin settings",
+            cause,
+          }).pipe(Effect.as(null)),
+        ),
+      );
+      yield* logStage("temporary settings apply");
+      yield* settings
+        .apply({
+          lagKillerEnabled: false,
+          skipCutscenesEnabled: false,
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning({
+              message: "failed to apply temporary autorelogin settings",
+              cause,
+            }),
+          ),
+        );
+
+      return yield* effect.pipe(
+        Effect.ensuring(
+          previousSettings === null
+            ? Effect.void
+            : restoreLoginSettings(previousSettings),
+        ),
+      );
+    });
+
+  const performRelogin = (attempt: ReservedAttempt) =>
+    withTemporaryLoginSettings(
+      interruptible(
+        attempt.connectionSeq,
+        Effect.gen(function* () {
+          const captured = attempt.captured;
+          yield* logStage("attempt start", {
+            server: captured.server.sName,
+            connectionSeq: attempt.connectionSeq,
+          });
+          yield* logStage("waiting for temporary kick clear");
+          const tempKickCleared = yield* waitFor(
+            auth
+              .isTemporarilyKicked()
+              .pipe(Effect.map((temporarilyKicked) => !temporarilyKicked)),
+            {
+              timeout: TEMP_KICK_TIMEOUT,
+              schedule: Schedule.spaced("1 second"),
+            },
+          );
+          if (!tempKickCleared) {
+            return yield* failAttempt("temporary kick did not clear", true);
+          }
+
+          yield* logStage("login start");
+          const loginCompleted = yield* auth
+            .login(captured.username, captured.password)
+            .pipe(Effect.timeoutOption("15 seconds"));
+          if (Option.isNone(loginCompleted)) {
+            return yield* failAttempt("login timed out", true);
+          }
+
+          yield* logStage("waiting for server select");
+          if (!(yield* waitForServerSelect)) {
+            return yield* failAttempt("server select did not load", true);
+          }
+
+          yield* logStage("waiting for server list");
+          if (!(yield* waitForServers)) {
+            return yield* failAttempt("servers did not load", true);
+          }
+
+          const servers = yield* auth.getServers();
+          yield* logStage("server list loaded", { count: servers.length });
+          const targetServer = findCapturedServer(servers, captured.server);
+          if (targetServer === undefined) {
+            return yield* failAttempt(
+              `captured server is unavailable: ${captured.server.sName}`,
+              false,
+            );
+          }
+
+          const loginInfo = yield* auth
+            .getLoginInfo()
+            .pipe(Effect.catchCause(() => Effect.succeed(null)));
+          if (!isServerEligible(targetServer, loginInfo)) {
+            return yield* failAttempt(
+              `captured server is not eligible: ${captured.server.sName}`,
+              false,
+            );
+          }
+
+          // Let Flash finish server-list click handlers before invoking connectTo.
+          yield* Effect.sleep("1 second");
+
+          yield* logStage("connect start", { server: targetServer.name });
+          const didConnect = yield* auth.connectTo(targetServer.name);
+          if (!didConnect) {
+            return yield* failAttempt(
+              `failed to select captured server: ${captured.server.sName}`,
+              true,
+            );
+          }
+
+          yield* logStage("waiting for game entry");
+          if (!(yield* waitForGameEntry) || !(yield* isGameEntrySuccessful)) {
+            return yield* failAttempt("game entry failed", true);
+          }
+
+          yield* logStage("waiting for player ready");
+          const ready = yield* waitFor(isPlayerReady(), {
+            timeout: PLAYER_READY_TIMEOUT,
+            schedule: Schedule.spaced("250 millis"),
+          });
+          if (!ready) {
+            return yield* failAttempt("player did not become ready", true);
+          }
+        }),
+      ),
+    );
+
+  const reserveAttempt = (now: number) =>
+    Effect.gen(function* () {
+      const skipped = yield* SynchronizedRef.get(stateRef).pipe(
+        Effect.map((state) => {
+          const waitAnchor = Math.max(
+            state.loggedOutSince ?? now,
+            state.lastAttemptAt,
+          );
+          const remainingMs = Math.max(0, waitAnchor + state.delayMs - now);
+          return {
+            captured: state.captured !== null,
+            enabled: state.enabled,
+            remainingMs,
+          };
+        }),
+      );
+
+      const attempt = yield* SynchronizedRef.modify(stateRef, (state) => {
+        const captured = state.captured;
+        // First attempt waits from logout; retries wait from the previous attempt.
+        const waitAnchor = Math.max(
+          state.loggedOutSince ?? now,
+          state.lastAttemptAt,
+        );
+        const readyForAttempt =
+          state.enabled &&
+          captured !== null &&
+          !state.attempting &&
+          state.loggedOutSince !== undefined &&
+          now >= waitAnchor + state.delayMs;
+
+        if (!readyForAttempt) {
+          return [null, state] as const;
+        }
+
+        state.attempting = true;
+        state.lastError = undefined;
+        state.lastAttemptAt = now;
+        return [
+          {
+            captured,
+            connectionSeq: state.connectionSeq,
+          },
+          state,
+        ] as const;
+      });
+
+      if (attempt !== null) {
+        yield* emitCurrentState;
+        yield* logStage("attempt reserved", {
+          server: attempt.captured.server.sName,
+          connectionSeq: attempt.connectionSeq,
+        });
+      } else if (
+        skipped.enabled &&
+        skipped.captured &&
+        skipped.remainingMs > 0
+      ) {
+        yield* logStage("waiting for logout delay", {
+          remainingMs: skipped.remainingMs,
+        });
+      }
+
+      return attempt;
+    });
+
+  const runAttemptCycle = Effect.gen(function* () {
+    const now = Date.now();
+    const ready = yield* isPlayerReady();
+    if (ready) {
+      yield* markLoggedIn();
+      return;
+    }
+
+    const connectionState = yield* SynchronizedRef.get(stateRef).pipe(
+      Effect.map((state) => ({
+        connected: state.connected,
+        loggedOutSince: state.loggedOutSince,
+      })),
+    );
+    // Jobs maps "loggedOut" to !player.isReady(); ignore connected loading.
+    if (connectionState.connected) {
+      return;
+    }
+
+    const logoutState =
+      connectionState.loggedOutSince === undefined
+        ? yield* markLoggedOut(now)
+        : {
+            firstObserved: false,
+            loggedOutSince: connectionState.loggedOutSince,
+          };
+    if (logoutState.firstObserved) {
+      yield* logStage("logged out observed", {
+        delayMs: (yield* getState()).delayMs,
+      });
+    }
+
+    const attempt = yield* reserveAttempt(now);
+    if (attempt === null) {
+      return;
+    }
+
+    yield* interruptible(
+      attempt.connectionSeq,
+      performRelogin(attempt).pipe(
+        Effect.retry({
+          schedule: reloginRetrySchedule,
+          while: (error) =>
+            error instanceof AutoReloginAttemptError && error.retryable,
+        }),
+      ),
+    ).pipe(
+      Effect.matchEffect({
+        onFailure: (error) =>
+          error instanceof AutoReloginInterrupted
+            ? markInterrupted(error).pipe(Effect.asVoid)
+            : markFailure(error).pipe(Effect.asVoid),
+        onSuccess: () =>
+          logStage("attempt succeeded").pipe(
+            Effect.andThen(markSuccess()),
+            Effect.asVoid,
+          ),
+      }),
+    );
+  }).pipe(
+    Effect.catchCause(() =>
+      Effect.gen(function* () {
+        yield* clearAttempting();
+        yield* Effect.logError({
+          message: "autorelogin task crashed",
+          error: "unexpected task failure",
+        });
+      }),
+    ),
+  );
+
+  const startJob = jobs.startPeriodicJob({
+    key: JOB_KEY,
+    interval: JOB_INTERVAL,
+    // Internal connection tracking filters out false positives from player readiness.
+    runWhen: "loggedOut",
+    runOnStart: false,
+    replace: false,
+    task: runAttemptCycle,
+  });
+
+  const stopJob = jobs.stop(JOB_KEY);
+
+  const enable: AutoReloginShape["enable"] = () =>
+    Effect.gen(function* () {
+      yield* logStage("enable");
+      yield* updateState((state) => {
+        state.enabled = true;
+        state.lastError = undefined;
+      });
+      yield* captureCurrentSession();
+      yield* startJob;
+      return yield* getState();
+    });
+
+  const disable: AutoReloginShape["disable"] = () =>
+    Effect.gen(function* () {
+      yield* logStage("disable");
+      yield* stopJob;
+      return yield* updateState((state) => {
+        state.enabled = false;
+        state.attempting = false;
+        state.lastError = undefined;
+      });
+    });
+
+  const setDelayMs: AutoReloginShape["setDelayMs"] = (delayMs) =>
+    Effect.gen(function* () {
+      const normalizedDelayMs = normalizeDelayMs(delayMs);
+      yield* logStage("set delay", { delayMs: normalizedDelayMs });
+      return yield* updateState((state) => {
+        state.delayMs = normalizedDelayMs;
+      });
+    });
+
+  const onState: AutoReloginShape["onState"] = (listener, options) =>
+    Effect.gen(function* () {
+      yield* SynchronizedRef.update(listenersRef, (listeners) => {
+        listeners.add(listener);
+        return listeners;
+      });
+
+      if (options?.emitCurrent ?? true) {
+        const state = yield* getState();
+        yield* Effect.sync(() => listener(state));
+      }
+
+      return () => {
+        runFork(
+          SynchronizedRef.update(listenersRef, (listeners) => {
+            listeners.delete(listener);
+            return listeners;
+          }),
+        );
+      };
+    });
+
+  const disposeConnection = yield* bridge.onConnection((status) => {
+    if (status === "OnConnection") {
+      runFork(
+        SynchronizedRef.update(stateRef, (state) => {
+          // objServerInfo is refreshed after SmartFox connects.
+          state.connected = true;
+          state.connectionSeq += 1;
+          state.loggedOutSince = undefined;
+          state.lastAttemptAt = 0;
+          return state;
+        }).pipe(
+          Effect.tap(() => logStage("connection observed")),
+          Effect.andThen(captureCurrentSession()),
+          Effect.asVoid,
+        ),
+      );
+    } else if (status === "OnConnectionLost") {
+      runFork(
+        // Anchor delayMs at the disconnect event, not the next job tick.
+        markLoggedOut(Date.now()).pipe(
+          Effect.tap((logoutState) =>
+            logoutState.firstObserved
+              ? SynchronizedRef.get(stateRef).pipe(
+                  Effect.flatMap((state) =>
+                    logStage("logged out observed", { delayMs: state.delayMs }),
+                  ),
+                )
+              : Effect.void,
+          ),
+          Effect.asVoid,
+        ),
+      );
+    }
+  });
+
+  yield* Effect.addFinalizer(() =>
+    Effect.gen(function* () {
+      disposeConnection();
+      yield* stopJob.pipe(Effect.asVoid);
+    }),
+  );
+
+  return {
+    getState,
+    onState,
+    enable,
+    disable,
+    setDelayMs,
+    captureCurrentSession,
+  } satisfies AutoReloginShape;
+});
+
+export const AutoReloginLive = Layer.effect(AutoRelogin, make);

--- a/app/src/renderer/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/game/features/Layers/AutoRelogin.ts
@@ -77,7 +77,9 @@ type RuntimeState = {
   loggedOutSince: number | undefined;
   // SmartFox can be connected while player.isReady() is still false.
   connected: boolean;
-  // Bumped on each connection so long waits can be interrupted safely.
+  // Prevents the relogin attempt's own socket connection from interrupting itself.
+  ownedConnectionServerName: string | undefined;
+  // Bumped on external connections so long waits can be interrupted safely.
   connectionSeq: number;
 };
 
@@ -95,6 +97,7 @@ const initialState = (): RuntimeState => ({
   lastAttemptAt: 0,
   loggedOutSince: undefined,
   connected: false,
+  ownedConnectionServerName: undefined,
   connectionSeq: 0,
 });
 
@@ -260,6 +263,18 @@ const make = Effect.gen(function* () {
     Set<AutoReloginStateListener>
   >(new Set());
 
+  const addStateListener = (listener: AutoReloginStateListener) =>
+    SynchronizedRef.update(listenersRef, (listeners) => {
+      listeners.add(listener);
+      return listeners;
+    });
+
+  const removeStateListener = (listener: AutoReloginStateListener) =>
+    SynchronizedRef.update(listenersRef, (listeners) => {
+      listeners.delete(listener);
+      return listeners;
+    });
+
   const emitState = (state: AutoReloginState) =>
     Effect.gen(function* () {
       const listeners = yield* SynchronizedRef.get(listenersRef);
@@ -315,6 +330,8 @@ const make = Effect.gen(function* () {
           state.captured?.password,
         );
         state.attempting = false;
+        state.connected = false;
+        state.ownedConnectionServerName = undefined;
       });
       yield* Effect.logWarning({
         message: "autorelogin failed",
@@ -327,6 +344,17 @@ const make = Effect.gen(function* () {
     updateState((state) => {
       state.lastError = undefined;
       state.attempting = false;
+      state.ownedConnectionServerName = undefined;
+    });
+
+  const markReloginSuccess = () =>
+    updateState((state) => {
+      state.lastError = undefined;
+      state.attempting = false;
+      state.connected = true;
+      state.ownedConnectionServerName = undefined;
+      state.loggedOutSince = undefined;
+      state.lastAttemptAt = 0;
     });
 
   const markInterrupted = (interrupt: AutoReloginInterrupted) =>
@@ -342,12 +370,14 @@ const make = Effect.gen(function* () {
   const clearAttempting = () =>
     updateState((state) => {
       state.attempting = false;
+      state.ownedConnectionServerName = undefined;
     });
 
   const markLoggedIn = () =>
     SynchronizedRef.update(stateRef, (state) => {
       // A ready player closes the disconnect window.
       state.connected = true;
+      state.ownedConnectionServerName = undefined;
       state.loggedOutSince = undefined;
       state.lastAttemptAt = 0;
       return state;
@@ -359,6 +389,7 @@ const make = Effect.gen(function* () {
       (state): readonly [LogoutObservation, RuntimeState] => {
         // Keep the first logout timestamp stable across periodic job ticks.
         state.connected = false;
+        state.ownedConnectionServerName = undefined;
         if (state.loggedOutSince !== undefined) {
           return [
             { firstObserved: false, loggedOutSince: state.loggedOutSince },
@@ -408,6 +439,30 @@ const make = Effect.gen(function* () {
     connectionSeq: number,
     effect: Effect.Effect<A, E>,
   ) => Effect.raceFirst(effect, interruptSignal(connectionSeq));
+
+  const setOwnedConnectionServerName = (serverName: string | undefined) =>
+    SynchronizedRef.update(stateRef, (state) => {
+      state.ownedConnectionServerName = serverName;
+      return state;
+    });
+
+  const interruptIfOwnedConnectionChanged = (
+    ownedConnectionServerName: string | undefined,
+  ) =>
+    ownedConnectionServerName === undefined
+      ? Effect.void
+      : SynchronizedRef.update(stateRef, (state) => {
+          const currentServerName = state.captured?.server.sName;
+          if (
+            currentServerName !== undefined &&
+            currentServerName.toLowerCase() !==
+              ownedConnectionServerName.toLowerCase()
+          ) {
+            state.ownedConnectionServerName = undefined;
+            state.connectionSeq += 1;
+          }
+          return state;
+        });
 
   const captureCurrentSession: AutoReloginShape["captureCurrentSession"] = () =>
     Effect.gen(function* () {
@@ -670,27 +725,33 @@ const make = Effect.gen(function* () {
           yield* Effect.sleep("1 second");
 
           yield* logStage("connect start", { server: targetServer.name });
-          const didConnect = yield* auth.connectTo(targetServer.name);
-          if (!didConnect) {
-            return yield* failAttempt(
-              `failed to select captured server: ${captured.server.sName}`,
-              true,
-            );
-          }
+          yield* setOwnedConnectionServerName(targetServer.name);
+          yield* Effect.gen(function* () {
+            const didConnect = yield* auth.connectTo(targetServer.name);
+            if (!didConnect) {
+              return yield* failAttempt(
+                `failed to select captured server: ${captured.server.sName}`,
+                true,
+              );
+            }
 
-          yield* logStage("waiting for game entry");
-          if (!(yield* waitForGameEntry) || !(yield* isGameEntrySuccessful)) {
-            return yield* failAttempt("game entry failed", true);
-          }
+            yield* logStage("waiting for game entry");
+            if (
+              !(yield* waitForGameEntry) ||
+              !(yield* isGameEntrySuccessful)
+            ) {
+              return yield* failAttempt("game entry failed", true);
+            }
 
-          yield* logStage("waiting for player ready");
-          const ready = yield* waitFor(isPlayerReady(), {
-            timeout: PLAYER_READY_TIMEOUT,
-            schedule: Schedule.spaced("250 millis"),
-          });
-          if (!ready) {
-            return yield* failAttempt("player did not become ready", true);
-          }
+            yield* logStage("waiting for player ready");
+            const ready = yield* waitFor(isPlayerReady(), {
+              timeout: PLAYER_READY_TIMEOUT,
+              schedule: Schedule.spaced("250 millis"),
+            });
+            if (!ready) {
+              return yield* failAttempt("player did not become ready", true);
+            }
+          }).pipe(Effect.ensuring(setOwnedConnectionServerName(undefined)));
         }),
       ),
     );
@@ -775,7 +836,6 @@ const make = Effect.gen(function* () {
         loggedOutSince: state.loggedOutSince,
       })),
     );
-    // Jobs maps "loggedOut" to !player.isReady(); ignore connected loading.
     if (connectionState.connected) {
       return;
     }
@@ -815,7 +875,7 @@ const make = Effect.gen(function* () {
             : markFailure(error).pipe(Effect.asVoid),
         onSuccess: () =>
           logStage("attempt succeeded").pipe(
-            Effect.andThen(markSuccess()),
+            Effect.andThen(markReloginSuccess()),
             Effect.asVoid,
           ),
       }),
@@ -863,6 +923,7 @@ const make = Effect.gen(function* () {
       return yield* updateState((state) => {
         state.enabled = false;
         state.attempting = false;
+        state.ownedConnectionServerName = undefined;
         state.lastError = undefined;
       });
     });
@@ -878,39 +939,46 @@ const make = Effect.gen(function* () {
 
   const onState: AutoReloginShape["onState"] = (listener, options) =>
     Effect.gen(function* () {
-      yield* SynchronizedRef.update(listenersRef, (listeners) => {
-        listeners.add(listener);
-        return listeners;
-      });
+      yield* addStateListener(listener);
 
       if (options?.emitCurrent ?? true) {
-        const state = yield* getState();
-        yield* Effect.sync(() => listener(state));
+        yield* getState().pipe(
+          Effect.flatMap((state) => Effect.sync(() => listener(state))),
+          Effect.catchCause((cause) =>
+            removeStateListener(listener).pipe(
+              Effect.andThen(Effect.failCause(cause)),
+            ),
+          ),
+        );
       }
 
       return () => {
-        runFork(
-          SynchronizedRef.update(listenersRef, (listeners) => {
-            listeners.delete(listener);
-            return listeners;
-          }),
-        );
+        runFork(removeStateListener(listener));
       };
     });
 
   const disposeConnection = yield* bridge.onConnection((status) => {
     if (status === "OnConnection") {
       runFork(
-        SynchronizedRef.update(stateRef, (state) => {
+        SynchronizedRef.modify(stateRef, (state) => {
+          const ownedConnectionServerName = state.ownedConnectionServerName;
           // objServerInfo is refreshed after SmartFox connects.
-          state.connected = true;
-          state.connectionSeq += 1;
           state.loggedOutSince = undefined;
           state.lastAttemptAt = 0;
-          return state;
+          state.connected = true;
+          if (ownedConnectionServerName === undefined) {
+            state.connectionSeq += 1;
+          }
+          return [ownedConnectionServerName, state] as const;
         }).pipe(
           Effect.tap(() => logStage("connection observed")),
-          Effect.andThen(captureCurrentSession()),
+          Effect.flatMap((ownedConnectionServerName) =>
+            captureCurrentSession().pipe(
+              Effect.andThen(
+                interruptIfOwnedConnectionChanged(ownedConnectionServerName),
+              ),
+            ),
+          ),
           Effect.asVoid,
         ),
       );

--- a/app/src/renderer/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/game/features/Layers/AutoRelogin.ts
@@ -19,7 +19,7 @@ import { Jobs } from "../../flash/Services/Jobs";
 import { Player } from "../../flash/Services/Player";
 import { Settings } from "../../flash/Services/Settings";
 import type { SettingsState } from "../../flash/Services/Settings";
-import type { LoginInfo } from "../../flash/Types";
+import type { LoginSession } from "../../flash/Types";
 import { waitFor } from "../../utils/waitFor";
 import {
   AutoRelogin,
@@ -193,7 +193,7 @@ const formatReloginError = (error: unknown): string => {
 
 const isServerEligible = (
   server: Server,
-  loginInfo: LoginInfo | null,
+  loginSession: LoginSession | null,
 ): boolean => {
   if (!server.isOnline() || server.isFull()) {
     return false;
@@ -203,23 +203,23 @@ const isServerEligible = (
     return false;
   }
 
-  if (loginInfo === null) {
+  if (loginSession === null) {
     return true;
   }
 
   const hasActiveMembership =
-    typeof loginInfo.iUpgDays === "number" && loginInfo.iUpgDays >= 0;
+    typeof loginSession.iUpgDays === "number" && loginSession.iUpgDays >= 0;
   const upgradeOnly = server.isUpgrade() && !hasActiveMembership;
-  const chatRestricted = server.data.iChat > 0 && loginInfo.bCCOnly === 1;
+  const chatRestricted = server.data.iChat > 0 && loginSession.bCCOnly === 1;
   const underageNonMember =
     server.data.iChat > 0 &&
-    typeof loginInfo.iAge === "number" &&
-    loginInfo.iAge < 13 &&
+    typeof loginSession.iAge === "number" &&
+    loginSession.iAge < 13 &&
     !hasActiveMembership;
   const emailUnconfirmed =
     server.data.iLevel > 0 &&
-    typeof loginInfo.iEmailStatus === "number" &&
-    loginInfo.iEmailStatus <= 2;
+    typeof loginSession.iEmailStatus === "number" &&
+    loginSession.iEmailStatus <= 2;
 
   return !(
     upgradeOnly ||
@@ -424,7 +424,7 @@ const make = Effect.gen(function* () {
       }
 
       // Hydrates Auth's cached credentials and membership flags.
-      yield* auth.getLoginInfo();
+      yield* auth.getLoginSession();
 
       const [username, password, serverInfo] = yield* Effect.all([
         auth.getUsername(),
@@ -656,10 +656,10 @@ const make = Effect.gen(function* () {
             );
           }
 
-          const loginInfo = yield* auth
-            .getLoginInfo()
+          const loginSession = yield* auth
+            .getLoginSession()
             .pipe(Effect.catchCause(() => Effect.succeed(null)));
-          if (!isServerEligible(targetServer, loginInfo)) {
+          if (!isServerEligible(targetServer, loginSession)) {
             return yield* failAttempt(
               `captured server is not eligible: ${captured.server.sName}`,
               false,

--- a/app/src/renderer/game/features/Layers/Features.ts
+++ b/app/src/renderer/game/features/Layers/Features.ts
@@ -1,0 +1,4 @@
+import { Layer } from "effect";
+import { AutoReloginLive } from "./AutoRelogin";
+
+export const FeaturesLive = Layer.mergeAll(AutoReloginLive);

--- a/app/src/renderer/game/features/Services/AutoRelogin.ts
+++ b/app/src/renderer/game/features/Services/AutoRelogin.ts
@@ -1,0 +1,36 @@
+import { Effect, ServiceMap } from "effect";
+
+export interface AutoReloginState {
+  readonly enabled: boolean;
+  readonly captured: boolean;
+  readonly attempting: boolean;
+  readonly username?: string;
+  readonly server?: string;
+  readonly delayMs: number;
+  readonly lastError?: string;
+}
+
+export type AutoReloginStateDisposer = () => void;
+
+export type AutoReloginStateListener = (state: AutoReloginState) => void;
+
+export interface AutoReloginStateSubscriptionOptions {
+  readonly emitCurrent?: boolean;
+}
+
+export interface AutoReloginShape {
+  getState(): Effect.Effect<AutoReloginState>;
+  onState(
+    listener: AutoReloginStateListener,
+    options?: AutoReloginStateSubscriptionOptions,
+  ): Effect.Effect<AutoReloginStateDisposer>;
+  enable(): Effect.Effect<AutoReloginState>;
+  disable(): Effect.Effect<AutoReloginState>;
+  setDelayMs(delayMs: number): Effect.Effect<AutoReloginState>;
+  captureCurrentSession(): Effect.Effect<boolean>;
+}
+
+export class AutoRelogin extends ServiceMap.Service<
+  AutoRelogin,
+  AutoReloginShape
+>()("features/Services/AutoRelogin") {}

--- a/app/src/renderer/game/flash/Layers/Auth.ts
+++ b/app/src/renderer/game/flash/Layers/Auth.ts
@@ -3,14 +3,14 @@ import { Effect, Layer, Schedule, SynchronizedRef } from "effect";
 import type { AuthShape } from "../Services/Auth";
 import { Auth } from "../Services/Auth";
 import { Bridge } from "../Services/Bridge";
-import type { LoginResponse, LoginCredentials } from "../Types";
+import type { LoginInfo, LoginCredentials } from "../Types";
 import { waitFor } from "../../utils/waitFor";
 
 type RuntimeState = {
   readonly servers: Map<string, Server>;
   username: string;
   password: string;
-  loginInfo: LoginResponse | undefined;
+  loginInfo: LoginInfo | undefined;
 };
 
 const initialState = (): RuntimeState => ({
@@ -86,7 +86,7 @@ const make = Effect.gen(function* () {
           bridge.call("flash.getGameObjectS", ["loginInfo"]),
         ]);
 
-        const loginResponse = JSON.parse(loginResponseStr) as LoginResponse;
+        const loginResponse = JSON.parse(loginResponseStr) as LoginInfo;
         const loginCredentials = JSON.parse(
           loginCredentialsStr,
         ) as LoginCredentials;

--- a/app/src/renderer/game/flash/Layers/Auth.ts
+++ b/app/src/renderer/game/flash/Layers/Auth.ts
@@ -3,27 +3,27 @@ import { Effect, Layer, Schedule, SynchronizedRef } from "effect";
 import type { AuthShape } from "../Services/Auth";
 import { Auth } from "../Services/Auth";
 import { Bridge } from "../Services/Bridge";
-import type { LoginInfo, LoginCredentials } from "../Types";
+import type { LoginSession, LoginCredentials } from "../Types";
 import { waitFor } from "../../utils/waitFor";
 
 type RuntimeState = {
   readonly servers: Map<string, Server>;
   username: string;
   password: string;
-  loginInfo: LoginInfo | undefined;
+  loginSession: LoginSession | undefined;
 };
 
 const initialState = (): RuntimeState => ({
   servers: new Map<string, Server>(),
   username: "",
   password: "",
-  loginInfo: undefined,
+  loginSession: undefined,
 });
 
 const clearSession = (state: RuntimeState): RuntimeState => {
   state.username = "";
   state.password = "";
-  state.loginInfo = undefined;
+  state.loginSession = undefined;
   return state;
 };
 
@@ -74,10 +74,10 @@ const make = Effect.gen(function* () {
     SynchronizedRef.get(stateRef).pipe(Effect.map((state) => state.password));
 
   // Account credentials, initial server info, and other account-related metadata
-  const getLoginInfo: AuthShape["getLoginInfo"] = () =>
+  const getLoginSession: AuthShape["getLoginSession"] = () =>
     SynchronizedRef.modifyEffect(stateRef, (state) => {
-      if (state.loginInfo !== undefined) {
-        return Effect.succeed([state.loginInfo, state] as const);
+      if (state.loginSession !== undefined) {
+        return Effect.succeed([state.loginSession, state] as const);
       }
 
       return Effect.gen(function* () {
@@ -86,21 +86,21 @@ const make = Effect.gen(function* () {
           bridge.call("flash.getGameObjectS", ["loginInfo"]),
         ]);
 
-        const loginResponse = JSON.parse(loginResponseStr) as LoginInfo;
+        const loginSession = JSON.parse(loginResponseStr) as LoginSession;
         const loginCredentials = JSON.parse(
           loginCredentialsStr,
         ) as LoginCredentials;
 
-        state.loginInfo = loginResponse;
-        state.username = loginResponse.unm;
+        state.loginSession = loginSession;
+        state.username = loginSession.unm;
         state.password = loginCredentials.strPassword;
-        return [loginResponse, state] as const;
+        return [loginSession, state] as const;
       });
     });
 
   const isLoggedIn: AuthShape["isLoggedIn"] = () =>
     SynchronizedRef.get(stateRef).pipe(
-      Effect.map((state) => state.loginInfo !== undefined),
+      Effect.map((state) => state.loginSession !== undefined),
     );
 
   const isTemporarilyKicked: AuthShape["isTemporarilyKicked"] = () =>
@@ -130,7 +130,7 @@ const make = Effect.gen(function* () {
 
   const dispose = yield* bridge.onConnection((status) => {
     if (status === "OnConnection") {
-      runFork(getLoginInfo().pipe(Effect.asVoid));
+      runFork(getLoginSession().pipe(Effect.asVoid));
     } else if (status === "OnConnectionLost") {
       runFork(clearSessionState);
     }
@@ -143,7 +143,7 @@ const make = Effect.gen(function* () {
     getServers,
     getUsername,
     getPassword,
-    getLoginInfo,
+    getLoginSession,
     isLoggedIn,
     isTemporarilyKicked,
     login,

--- a/app/src/renderer/game/flash/Layers/Flash.ts
+++ b/app/src/renderer/game/flash/Layers/Flash.ts
@@ -16,6 +16,7 @@ import { SettingsLive } from "./Settings";
 import { ShopsLive } from "./Shops";
 import { TempInventoryLive } from "./TempInventory";
 import { WorldLive } from "./World";
+import { FeaturesLive } from "../../features/Layers/Features";
 
 const BridgeCoreLive = BridgeLive;
 const PacketRuntimeLive = PacketLive.pipe(Layer.provide(BridgeCoreLive));
@@ -44,15 +45,29 @@ const DomainRuntimeLive = Layer.mergeAll(
   QuestsLive,
 ).pipe(Layer.provide(CoreRuntimeLive));
 
-const FeatureRuntimeLive = Layer.mergeAll(
-  CombatLive,
-  AutoZoneLive,
-  JobsLive,
-).pipe(Layer.provide(Layer.mergeAll(CoreRuntimeLive, DomainRuntimeLive)));
+const InfrastructureRuntimeLive = JobsLive.pipe(
+  Layer.provide(Layer.mergeAll(CoreRuntimeLive, DomainRuntimeLive)),
+);
+
+const FlashFeatureRuntimeLive = Layer.mergeAll(CombatLive, AutoZoneLive).pipe(
+  Layer.provide(Layer.mergeAll(CoreRuntimeLive, DomainRuntimeLive)),
+);
+
+const FeatureRuntimeLive = FeaturesLive.pipe(
+  Layer.provide(
+    Layer.mergeAll(
+      CoreRuntimeLive,
+      DomainRuntimeLive,
+      InfrastructureRuntimeLive,
+    ),
+  ),
+);
 
 export const FlashLive = Layer.mergeAll(
   CoreRuntimeLive,
   DomainRuntimeLive,
+  InfrastructureRuntimeLive,
+  FlashFeatureRuntimeLive,
   FeatureRuntimeLive,
 ).pipe(
   Layer.tapCause((cause) =>

--- a/app/src/renderer/game/flash/Services/Auth.ts
+++ b/app/src/renderer/game/flash/Services/Auth.ts
@@ -1,13 +1,14 @@
 import { ServiceMap } from "effect";
 import type { BridgeEffect } from "./Bridge";
 import type { Server } from "@vexed/game";
+import type { LoginInfo } from "../Types";
 
 export interface AuthShape {
   connectTo(server: string): BridgeEffect<boolean>;
   getServers(): BridgeEffect<Server[]>;
   getUsername(): BridgeEffect<string>;
   getPassword(): BridgeEffect<string>;
-  getLoginInfo(): BridgeEffect<unknown>;
+  getLoginInfo(): BridgeEffect<LoginInfo>;
   isLoggedIn(): BridgeEffect<boolean>;
   isTemporarilyKicked(): BridgeEffect<boolean>;
   login(username: string, password: string): BridgeEffect<void>;

--- a/app/src/renderer/game/flash/Services/Auth.ts
+++ b/app/src/renderer/game/flash/Services/Auth.ts
@@ -1,14 +1,14 @@
 import { ServiceMap } from "effect";
 import type { BridgeEffect } from "./Bridge";
 import type { Server } from "@vexed/game";
-import type { LoginInfo } from "../Types";
+import type { LoginSession } from "../Types";
 
 export interface AuthShape {
   connectTo(server: string): BridgeEffect<boolean>;
   getServers(): BridgeEffect<Server[]>;
   getUsername(): BridgeEffect<string>;
   getPassword(): BridgeEffect<string>;
-  getLoginInfo(): BridgeEffect<LoginInfo>;
+  getLoginSession(): BridgeEffect<LoginSession>;
   isLoggedIn(): BridgeEffect<boolean>;
   isTemporarilyKicked(): BridgeEffect<boolean>;
   login(username: string, password: string): BridgeEffect<void>;

--- a/app/src/renderer/game/flash/Types.ts
+++ b/app/src/renderer/game/flash/Types.ts
@@ -1,6 +1,7 @@
 import type { AvatarData, ServerData } from "@vexed/game";
 
-export type LoginResponse = {
+// objLogin
+export type LoginSession = {
   servers: ServerData[];
   bSuccess: number;
   bCCOnly?: number;
@@ -13,8 +14,7 @@ export type LoginResponse = {
   sToken: string; // password
 };
 
-export type LoginInfo = LoginResponse;
-
+// loginInfo
 export type LoginCredentials = {
   strUsername: string;
   strPassword: string;

--- a/app/src/renderer/game/flash/Types.ts
+++ b/app/src/renderer/game/flash/Types.ts
@@ -3,10 +3,17 @@ import type { AvatarData, ServerData } from "@vexed/game";
 export type LoginResponse = {
   servers: ServerData[];
   bSuccess: number;
+  bCCOnly?: number;
+  iAccess?: number;
+  iAge?: number;
+  iEmailStatus?: number;
   iUpg: number;
+  iUpgDays?: number;
   unm: string; // username
   sToken: string; // password
 };
+
+export type LoginInfo = LoginResponse;
 
 export type LoginCredentials = {
   strUsername: string;

--- a/app/src/renderer/game/scripting/COMMAND_PORT_TODO.md
+++ b/app/src/renderer/game/scripting/COMMAND_PORT_TODO.md
@@ -145,8 +145,8 @@
 - [x] use_autozone_queeniona
 - [x] close_window
 - [x] beep
-- [ ] use_autorelogin - Not ported: no current AutoRelogin service/runtime API exists.
-- [ ] disable_autorelogin - Not ported: no current AutoRelogin service/runtime API exists.
+- [x] use_autorelogin
+- [x] disable_autorelogin
 - [x] register_task
 - [x] unregister_task
 - [ ] do_looptaunt - Not ported: loop-taunt strategy runtime/event API is not backported.

--- a/app/src/renderer/game/scripting/Commands/customCommand.ts
+++ b/app/src/renderer/game/scripting/Commands/customCommand.ts
@@ -94,6 +94,7 @@ type RuntimeApiSource = Omit<
   Pick<
     ScriptExecutionContext,
     | "auth"
+    | "autoRelogin"
     | "autoZone"
     | "bank"
     | "bridge"
@@ -173,6 +174,7 @@ export const createCustomScriptRuntimeApi = (
 ): CustomScriptRuntimeApi => {
   const source: RuntimeApiSource = {
     auth: context.auth,
+    autoRelogin: context.autoRelogin,
     autoZone: context.autoZone,
     bank: context.bank,
     bridge: context.bridge,
@@ -208,6 +210,7 @@ export const createCustomScriptEffectRuntimeApi = (
 ): CustomScriptEffectRuntimeApi => {
   const source: RuntimeApiSource = {
     auth: context.auth,
+    autoRelogin: context.autoRelogin,
     autoZone: context.autoZone,
     bank: context.bank,
     bridge: context.bridge,

--- a/app/src/renderer/game/scripting/Commands/misc.ts
+++ b/app/src/renderer/game/scripting/Commands/misc.ts
@@ -90,6 +90,8 @@ type MiscScriptCommandArguments = {
   use_autozone_astralshrine: [];
   use_autozone_queeniona: [];
   use_autozone_magnumopus: [];
+  use_autorelogin: [];
+  disable_autorelogin: [];
   close_window: [];
   beep: [times?: number];
   register_task: [name: string, taskFn: () => void | Promise<void>];
@@ -848,6 +850,12 @@ const miscCommandHandlerMap = miscCommandDomain.defineHandlers({
   use_autozone_astralshrine: autoZoneCommand("astralshrine"),
   use_autozone_queeniona: autoZoneCommand("queeniona"),
   use_autozone_magnumopus: autoZoneCommand("magnumopus"),
+  use_autorelogin: createCommandHandler((context) =>
+    Effect.asVoid(context.autoRelogin.enable()),
+  ),
+  disable_autorelogin: createCommandHandler((context) =>
+    Effect.asVoid(context.autoRelogin.disable()),
+  ),
   close_window: createCommandHandler(() => Effect.sync(() => window.close())),
   beep: beepCommand,
   register_task: registerTaskCommand,
@@ -1293,6 +1301,18 @@ export const createMiscScriptDsl = (
      */
     use_autozone_magnumopus() {
       recordMiscInstruction("use_autozone_magnumopus");
+    },
+    /**
+     * Enables current-session auto relogin.
+     */
+    use_autorelogin() {
+      recordMiscInstruction("use_autorelogin");
+    },
+    /**
+     * Disables current-session auto relogin.
+     */
+    disable_autorelogin() {
+      recordMiscInstruction("disable_autorelogin");
     },
     /**
      * Closes the game window.

--- a/app/src/renderer/game/scripting/Layers/ScriptRunner.ts
+++ b/app/src/renderer/game/scripting/Layers/ScriptRunner.ts
@@ -2,6 +2,7 @@ import { Cause, Effect, Fiber, Layer, Option, Ref, Semaphore } from "effect";
 import { type ScriptExecutePayload } from "../ipc";
 import { Auth } from "../../flash/Services/Auth";
 import { AutoZone } from "../../flash/Services/AutoZone";
+import { AutoRelogin } from "../../features/Services/AutoRelogin";
 import { Bank } from "../../flash/Services/Bank";
 import { Bridge } from "../../flash/Services/Bridge";
 import { Combat } from "../../flash/Services/Combat";
@@ -373,6 +374,7 @@ const compileProgram = (
 
 const make = Effect.gen(function* () {
   const auth = yield* Auth;
+  const autoRelogin = yield* AutoRelogin;
   const autoZone = yield* AutoZone;
   const bank = yield* Bank;
   const bridge = yield* Bridge;
@@ -554,6 +556,7 @@ const make = Effect.gen(function* () {
       const api = createScriptRuntimeApiProxy(
         {
           auth,
+          autoRelogin,
           autoZone,
           bank,
           bridge,
@@ -701,6 +704,7 @@ const make = Effect.gen(function* () {
       context = {
         sourceName: program.sourceName,
         auth: api.auth,
+        autoRelogin: api.autoRelogin,
         autoZone: api.autoZone,
         bank: api.bank,
         bridge: api.bridge,

--- a/app/src/renderer/game/scripting/Types.ts
+++ b/app/src/renderer/game/scripting/Types.ts
@@ -25,6 +25,7 @@ import type { QuestsShape } from "../flash/Services/Quests";
 import type { WorldShape } from "../flash/Services/World";
 import type { ScriptEffect } from "./scriptEffect";
 import type { ScriptRuntimeValue } from "./scriptRuntimeApi";
+import type { AutoReloginShape } from "../features/Services/AutoRelogin";
 
 export interface ScriptInstructionControlFlow {
   readonly falseJumpIndex?: number;
@@ -120,6 +121,7 @@ type CustomScriptPacketApi = Pick<
 
 export interface CustomScriptRuntimeApi {
   readonly auth: CustomScriptRuntimeValue<AuthShape>;
+  readonly autoRelogin: CustomScriptRuntimeValue<AutoReloginShape>;
   readonly autoZone: CustomScriptRuntimeValue<AutoZoneShape>;
   readonly bank: CustomScriptRuntimeValue<BankShape>;
   readonly bridge: CustomScriptRuntimeValue<BridgeShape>;
@@ -139,6 +141,7 @@ export interface CustomScriptRuntimeApi {
 
 export interface CustomScriptEffectRuntimeApi {
   readonly auth: CustomScriptEffectRuntimeValue<AuthShape>;
+  readonly autoRelogin: CustomScriptEffectRuntimeValue<AutoReloginShape>;
   readonly autoZone: CustomScriptEffectRuntimeValue<AutoZoneShape>;
   readonly bank: CustomScriptEffectRuntimeValue<BankShape>;
   readonly bridge: CustomScriptEffectRuntimeValue<BridgeShape>;
@@ -247,6 +250,7 @@ export type ScriptPacketHandler = (
 export interface ScriptExecutionContext {
   readonly sourceName: string;
   readonly auth: ScriptRuntimeValue<AuthShape>;
+  readonly autoRelogin: ScriptRuntimeValue<AutoReloginShape>;
   readonly autoZone: ScriptRuntimeValue<AutoZoneShape>;
   readonly bank: ScriptRuntimeValue<BankShape>;
   readonly bridge: ScriptRuntimeValue<BridgeShape>;


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconnection that restores your login session if connection is lost, with configurable retry timing.
  * Added interface options to toggle automatic reconnection and adjust retry delays.
  * Added script commands to control reconnection behavior.

* **Tests**
  * Comprehensive test coverage for auto reconnection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements an `AutoRelogin` feature that automatically re-establishes a game session after a disconnect, backed by a comprehensive test suite and scripting API. The core implementation is well-structured — it uses a `SynchronizedRef`-based state machine, a connection-sequence guard to prevent stale attempts from continuing after a manual reconnect, exponential-backoff retries, and careful password redaction in error messages.
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
app/src/renderer/game/App.tsx:134-135
**`parseInt` silently accepts trailing non-numeric characters**

`Number.parseInt("3000abc", 10)` returns `3000` without error, so a user who types something like `"2000ms"` will have the `ms` suffix silently ignored. The current guard only rejects `NaN` and negative values. Consider using a stricter check that rejects any input that isn't a purely numeric string:

```suggestion
    const delayMs = Number.parseInt(autoReloginDelayMs(), 10);
    if (
      !Number.isFinite(delayMs) ||
      delayMs < 0 ||
      String(delayMs) !== autoReloginDelayMs().trim()
    ) {
```

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["Handle owned relogin connections safely"](https://github.com/toommyliu/vexed/commit/e25b7b651d1c74056e759a4b7f1c7201540f3639) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30584186)</sub>

<!-- /greptile_comment -->