### PR TITLE
feat(settings): add appearance motion and cursor controls

### DIFF
--- a/app/src/main/settings-service.ts
+++ b/app/src/main/settings-service.ts
@@ -159,6 +159,14 @@ export const updateAppearance = (patch: AppearancePatch): AppSettings => {
     themeMode: isThemeMode(patch.themeMode)
       ? patch.themeMode
       : current.themeMode,
+    disableAnimations:
+      typeof patch.disableAnimations === "boolean"
+        ? patch.disableAnimations
+        : current.disableAnimations,
+    useCursorPointers:
+      typeof patch.useCursorPointers === "boolean"
+        ? patch.useCursorPointers
+        : current.useCursorPointers,
     themes: {
       light,
       dark,

--- a/app/src/main/settings/Appearance.test.ts
+++ b/app/src/main/settings/Appearance.test.ts
@@ -13,6 +13,8 @@ describe("appearance settings", () => {
       }),
     ).toEqual({
       themeMode: "system",
+      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      useCursorPointers: Appearance.DEFAULT.useCursorPointers,
       themes: {
         light: Appearance.DEFAULT.themes.light,
         dark: Appearance.DEFAULT.themes.dark,
@@ -52,6 +54,8 @@ describe("appearance settings", () => {
       }),
     ).toEqual({
       themeMode: "dark",
+      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      useCursorPointers: Appearance.DEFAULT.useCursorPointers,
       themes: {
         light: {
           tokens: {
@@ -116,6 +120,8 @@ describe("appearance settings", () => {
       }),
     ).toEqual({
       themeMode: Appearance.DEFAULT.themeMode,
+      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      useCursorPointers: Appearance.DEFAULT.useCursorPointers,
       themes: {
         light: Appearance.DEFAULT.themes.light,
         dark: Appearance.DEFAULT.themes.dark,
@@ -148,6 +154,61 @@ describe("appearance settings", () => {
         monoFontSize: 16,
       },
     });
+  });
+
+  it("normalizes app motion and cursor pointer toggles", () => {
+    expect(
+      Appearance.normalize({
+        themeMode: "dark",
+        disableAnimations: true,
+        useCursorPointers: true,
+        themes: {},
+      }),
+    ).toMatchObject({
+      disableAnimations: true,
+      useCursorPointers: true,
+    });
+
+    expect(
+      Appearance.normalize({
+        themeMode: "dark",
+        disableAnimations: "yes",
+        useCursorPointers: 1,
+        themes: {},
+      }),
+    ).toMatchObject({
+      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      useCursorPointers: Appearance.DEFAULT.useCursorPointers,
+    });
+  });
+
+  it("writes app motion and cursor pointer toggles", async () => {
+    const previous = process.env["VEXED_HOME"];
+    const testDir = await mkdtemp(join(tmpdir(), "vexed-appearance-"));
+    process.env["VEXED_HOME"] = testDir;
+
+    try {
+      Appearance.write({
+        ...Appearance.DEFAULT,
+        disableAnimations: true,
+        useCursorPointers: true,
+      });
+
+      const source = await readFile(Appearance.path(), "utf8");
+      expect(source).toContain("disableAnimations: true");
+      expect(source).toContain("useCursorPointers: true");
+      expect(Appearance.read()).toMatchObject({
+        disableAnimations: true,
+        useCursorPointers: true,
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env["VEXED_HOME"];
+      } else {
+        process.env["VEXED_HOME"] = previous;
+      }
+      await rm(testDir, { recursive: true, force: true });
+    }
   });
 
   it("does not rewrite partial hex color config on ensure", async () => {

--- a/app/src/main/settings/Appearance.ts
+++ b/app/src/main/settings/Appearance.ts
@@ -160,6 +160,14 @@ export const normalize = (value: unknown): Appearance => {
     themeMode: isThemeMode(record["themeMode"])
       ? record["themeMode"]
       : DEFAULT.themeMode,
+    disableAnimations:
+      typeof record["disableAnimations"] === "boolean"
+        ? record["disableAnimations"]
+        : DEFAULT.disableAnimations,
+    useCursorPointers:
+      typeof record["useCursorPointers"] === "boolean"
+        ? record["useCursorPointers"]
+        : DEFAULT.useCursorPointers,
     themes: {
       light: normalizeThemeProfile(rawThemes["light"]),
       dark: normalizeThemeProfile(rawThemes["dark"]),
@@ -205,6 +213,8 @@ const serialize = (appearance: Appearance): PersistedAppearance => {
   const normalized = normalize(appearance);
   return {
     themeMode: normalized.themeMode,
+    disableAnimations: normalized.disableAnimations,
+    useCursorPointers: normalized.useCursorPointers,
     themes: {
       light: serializeThemeProfile(normalized.themes.light),
       dark: serializeThemeProfile(normalized.themes.dark),

--- a/app/src/renderer/windows/account-manager/style.css
+++ b/app/src/renderer/windows/account-manager/style.css
@@ -388,7 +388,7 @@
   border: 0;
   border-radius: var(--radius-sm);
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: grid;
   gap: 0.25rem;
   margin: -0.25rem -0.375rem;

--- a/app/src/renderer/windows/settings/App.tsx
+++ b/app/src/renderer/windows/settings/App.tsx
@@ -979,6 +979,40 @@ function AppearanceSettings(props: {
         description="Use light, dark, or match your system appearance."
         title="Theme"
       />
+      <SettingsRow
+        action={
+          <Switch
+            aria-label="Disable animations"
+            checked={props.settings.appearance.disableAnimations}
+            onChange={(event) =>
+              props.onAppearancePatch({
+                disableAnimations: event.currentTarget.checked,
+              })
+            }
+            size="default"
+          />
+        }
+        class="settings-row--switch"
+        description="Turn off app animations regardless of system motion settings."
+        title="Disable animations"
+      />
+      <SettingsRow
+        action={
+          <Switch
+            aria-label="Use cursor pointers"
+            checked={props.settings.appearance.useCursorPointers}
+            onChange={(event) =>
+              props.onAppearancePatch({
+                useCursorPointers: event.currentTarget.checked,
+              })
+            }
+            size="default"
+          />
+        }
+        class="settings-row--switch"
+        description="Change the cursor to a pointer when hovering over interactive elements."
+        title="Use cursor pointers"
+      />
       <div class="theme-profile-panel">
         {renderProfileEditor(activeThemeVariant())}
       </div>

--- a/app/src/renderer/windows/settings/style.css
+++ b/app/src/renderer/windows/settings/style.css
@@ -92,9 +92,13 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .settings-content-wrapper {
+  :root:not([data-disable-animations="true"]) .settings-content-wrapper {
     scroll-behavior: smooth;
   }
+}
+
+:root[data-disable-animations="true"] .settings-content-wrapper {
+  scroll-behavior: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/src/shared/appearance-snapshot.test.ts
+++ b/app/src/shared/appearance-snapshot.test.ts
@@ -79,6 +79,7 @@ describe("appearance snapshot", () => {
 
   it("uses custom background tokens for the Electron background color", () => {
     const appearance: Appearance = {
+      ...DEFAULT_APPEARANCE,
       themeMode: "light",
       themes: {
         ...DEFAULT_APPEARANCE.themes,
@@ -120,14 +121,24 @@ describe("appearance snapshot", () => {
   });
 
   it("applies the snapshot to a document root before renderer mount", () => {
-    const snapshot = createAppearanceSnapshot(DEFAULT_APPEARANCE, false);
+    const snapshot = createAppearanceSnapshot(
+      {
+        ...DEFAULT_APPEARANCE,
+        disableAnimations: true,
+        useCursorPointers: true,
+      },
+      false,
+    );
     const root = createFakeRoot();
 
     applyAppearanceSnapshotToDocument(root as unknown as HTMLElement, snapshot);
 
     expect(root.dataset["theme"]).toBe("dark");
+    expect(root.dataset["disableAnimations"]).toBe("true");
+    expect(root.dataset["useCursorPointers"]).toBe("true");
     expect(root.hasClass("dark")).toBe(true);
     expect(root.style.getPropertyValue("--background")).toBe("14, 14, 15");
+    expect(root.style.getPropertyValue("--cursor-interactive")).toBe("pointer");
     expect(root.style.getPropertyValue("--font-sans")).toBe(
       DEFAULT_THEME_PROFILE.sansFont,
     );

--- a/app/src/shared/appearance-snapshot.test.ts
+++ b/app/src/shared/appearance-snapshot.test.ts
@@ -21,13 +21,41 @@ const systemAppearance: Appearance = {
   themeMode: "system",
 };
 
+const datasetAttributeName = (key: string): string =>
+  `data-${key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)}`;
+
 const createFakeRoot = () => {
   const properties = new Map<string, string>();
   const classes = new Set<string>();
-  const dataset: Record<string, string> = {};
+  const attributes = new Map<string, string>();
+  const dataset = new Proxy({} as DOMStringMap, {
+    get(_target, key) {
+      return typeof key === "string"
+        ? attributes.get(datasetAttributeName(key))
+        : undefined;
+    },
+    set(_target, key, value) {
+      if (typeof key === "string") {
+        attributes.set(datasetAttributeName(key), String(value));
+      }
+      return true;
+    },
+    deleteProperty(_target, key) {
+      if (typeof key === "string") {
+        attributes.delete(datasetAttributeName(key));
+      }
+      return true;
+    },
+  });
 
   return {
     dataset,
+    getAttribute(name: string) {
+      return attributes.get(name) ?? null;
+    },
+    hasAttribute(name: string) {
+      return attributes.has(name);
+    },
     classList: {
       toggle(name: string, force?: boolean) {
         if (force) {
@@ -136,6 +164,8 @@ describe("appearance snapshot", () => {
     expect(root.dataset["theme"]).toBe("dark");
     expect(root.dataset["disableAnimations"]).toBe("true");
     expect(root.dataset["useCursorPointers"]).toBe("true");
+    expect(root.getAttribute("data-disable-animations")).toBe("true");
+    expect(root.getAttribute("data-use-cursor-pointers")).toBe("true");
     expect(root.hasClass("dark")).toBe(true);
     expect(root.style.getPropertyValue("--background")).toBe("14, 14, 15");
     expect(root.style.getPropertyValue("--cursor-interactive")).toBe("pointer");
@@ -143,5 +173,18 @@ describe("appearance snapshot", () => {
       DEFAULT_THEME_PROFILE.sansFont,
     );
     expect(root.style.getPropertyValue("color-scheme")).toBe("dark");
+  });
+
+  it("omits inactive app preference attributes", () => {
+    const snapshot = createAppearanceSnapshot(DEFAULT_APPEARANCE, false);
+    const root = createFakeRoot();
+
+    root.dataset["disableAnimations"] = "true";
+    root.dataset["useCursorPointers"] = "true";
+    applyAppearanceSnapshotToDocument(root as unknown as HTMLElement, snapshot);
+
+    expect(root.hasAttribute("data-disable-animations")).toBe(false);
+    expect(root.hasAttribute("data-use-cursor-pointers")).toBe(false);
+    expect(root.style.getPropertyValue("--cursor-interactive")).toBe("default");
   });
 });

--- a/app/src/shared/appearance-snapshot.ts
+++ b/app/src/shared/appearance-snapshot.ts
@@ -51,6 +51,8 @@ export interface AppearanceSnapshot {
   readonly sansFontSize: number;
   readonly monoFontSize: number;
   readonly rounding: number;
+  readonly disableAnimations: boolean;
+  readonly useCursorPointers: boolean;
   readonly backgroundColor: string;
 }
 
@@ -113,6 +115,8 @@ export const createAppearanceSnapshot = (
     sansFontSize: profile.sansFontSize,
     monoFontSize: profile.monoFontSize,
     rounding: profile.rounding,
+    disableAnimations: appearance.disableAnimations,
+    useCursorPointers: appearance.useCursorPointers,
     backgroundColor: rgbToHex(tokens.background),
   };
 };
@@ -159,6 +163,8 @@ export const isAppearanceSnapshot = (
     Number.isFinite(value["monoFontSize"]) &&
     typeof value["rounding"] === "number" &&
     Number.isFinite(value["rounding"]) &&
+    typeof value["disableAnimations"] === "boolean" &&
+    typeof value["useCursorPointers"] === "boolean" &&
     typeof value["backgroundColor"] === "string"
   );
 };
@@ -222,8 +228,18 @@ export const applyAppearanceSnapshotToDocument = (
   const style = root.style;
 
   root.dataset["theme"] = snapshot.variant;
+  root.dataset["disableAnimations"] = snapshot.disableAnimations
+    ? "true"
+    : "false";
+  root.dataset["useCursorPointers"] = snapshot.useCursorPointers
+    ? "true"
+    : "false";
   root.classList.toggle("dark", snapshot.variant === "dark");
   style.setProperty("color-scheme", snapshot.variant);
+  style.setProperty(
+    "--cursor-interactive",
+    snapshot.useCursorPointers ? "pointer" : "default",
+  );
 
   for (const name of THEME_TOKEN_NAMES) {
     const cssName = tokenCssNames.get(name);

--- a/app/src/shared/appearance-snapshot.ts
+++ b/app/src/shared/appearance-snapshot.ts
@@ -228,12 +228,16 @@ export const applyAppearanceSnapshotToDocument = (
   const style = root.style;
 
   root.dataset["theme"] = snapshot.variant;
-  root.dataset["disableAnimations"] = snapshot.disableAnimations
-    ? "true"
-    : "false";
-  root.dataset["useCursorPointers"] = snapshot.useCursorPointers
-    ? "true"
-    : "false";
+  if (snapshot.disableAnimations) {
+    root.dataset["disableAnimations"] = "true";
+  } else {
+    delete root.dataset["disableAnimations"];
+  }
+  if (snapshot.useCursorPointers) {
+    root.dataset["useCursorPointers"] = "true";
+  } else {
+    delete root.dataset["useCursorPointers"];
+  }
   root.classList.toggle("dark", snapshot.variant === "dark");
   style.setProperty("color-scheme", snapshot.variant);
   style.setProperty(

--- a/app/src/shared/settings.ts
+++ b/app/src/shared/settings.ts
@@ -58,6 +58,8 @@ export interface ThemeProfile {
 
 export interface Appearance {
   readonly themeMode: ThemeMode;
+  readonly disableAnimations: boolean;
+  readonly useCursorPointers: boolean;
   readonly themes: {
     readonly light: ThemeProfile;
     readonly dark: ThemeProfile;
@@ -139,6 +141,8 @@ export const DEFAULT_THEME_PROFILE: ThemeProfile = {
 
 export const DEFAULT_APPEARANCE: Appearance = {
   themeMode: "dark",
+  disableAnimations: false,
+  useCursorPointers: false,
   themes: {
     light: DEFAULT_THEME_PROFILE,
     dark: DEFAULT_THEME_PROFILE,
@@ -167,6 +171,8 @@ export interface ThemeProfilePatch {
 
 export interface AppearancePatch {
   readonly themeMode?: ThemeMode;
+  readonly disableAnimations?: boolean;
+  readonly useCursorPointers?: boolean;
   readonly themes?: Partial<Record<ThemeVariant, ThemeProfilePatch>>;
 }
 

--- a/packages/ui/src/styles/components.css
+++ b/packages/ui/src/styles/components.css
@@ -104,11 +104,27 @@ body::-webkit-scrollbar-corner,
 
 /* Button */
 
+:root[data-use-cursor-pointers="true"] a[href],
+:root[data-use-cursor-pointers="true"] button:not(:disabled),
+:root[data-use-cursor-pointers="true"] select:not(:disabled),
+:root[data-use-cursor-pointers="true"] summary,
+:root[data-use-cursor-pointers="true"]
+  [role="button"]:not([aria-disabled="true"]),
+:root[data-use-cursor-pointers="true"]
+  [role="checkbox"]:not([aria-disabled="true"]),
+:root[data-use-cursor-pointers="true"]
+  [role="menuitem"]:not([aria-disabled="true"]),
+:root[data-use-cursor-pointers="true"]
+  [role="switch"]:not([aria-disabled="true"]),
+:root[data-use-cursor-pointers="true"] [role="tab"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+
 .button {
   align-items: center;
   border: 1px solid transparent;
   border-radius: var(--radius-md);
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: inline-flex;
   flex-shrink: 0;
   font-family: var(--font-sans);
@@ -500,7 +516,7 @@ body::-webkit-scrollbar-corner,
   align-items: center;
   border: 1px solid rgba(var(--black), 0.1);
   border-radius: 9999px;
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: inline-flex;
   gap: 0.5rem;
   height: var(--control-height-md);
@@ -538,7 +554,7 @@ body::-webkit-scrollbar-corner,
   background: transparent;
   border: 0;
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: inline-flex;
   flex-shrink: 0;
   height: 1.125rem;
@@ -958,7 +974,7 @@ body::-webkit-scrollbar-corner,
 .switch {
   align-items: center;
   color: rgb(var(--foreground));
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: inline-flex;
   font-family: var(--font-sans);
   font-size: var(--text-base);
@@ -1287,7 +1303,7 @@ body::-webkit-scrollbar-corner,
 
 button.badge,
 a.badge {
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
 }
 
 .badge svg {
@@ -2088,7 +2104,7 @@ a.badge--destructive:hover {
 }
 
 .select__trigger {
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
 }
 
 .select__trigger:focus-visible,
@@ -2271,7 +2287,7 @@ a.badge--destructive:hover {
   border: 0;
   border-radius: var(--radius-sm);
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: inline-flex;
   flex-shrink: 0;
   height: 1.5rem;
@@ -2293,7 +2309,7 @@ a.badge--destructive:hover {
 .dropdown .combobox__input,
 .dropdown__input {
   caret-color: transparent;
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
 }
 
 /* Menu and Tooltip Positioners */
@@ -2479,7 +2495,7 @@ a.badge--destructive:hover {
   border: 1px solid transparent;
   border-radius: var(--radius-md);
   color: inherit;
-  cursor: pointer;
+  cursor: var(--cursor-interactive);
   display: inline-flex;
   font-family: var(--font-sans);
   font-size: var(--text-base);
@@ -2869,9 +2885,33 @@ a.badge--destructive:hover {
   *,
   *::before,
   *::after {
+    animation-delay: 0s !important;
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
+    transition-delay: 0s !important;
     transition-duration: 0.001ms !important;
+  }
+}
+
+:root[data-disable-animations="true"] *,
+:root[data-disable-animations="true"] *::before,
+:root[data-disable-animations="true"] *::after {
+  animation-delay: 0s !important;
+  animation-duration: 0.001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-delay: 0s !important;
+  transition-duration: 0.001ms !important;
+}
+
+:root[data-disable-animations="true"] {
+  scroll-behavior: auto !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
   }
 }
 

--- a/packages/ui/src/styles/styles.test.ts
+++ b/packages/ui/src/styles/styles.test.ts
@@ -62,6 +62,14 @@ describe("CSS color tokens", () => {
     expect(tokens).toContain("--text-5xl: 28px;");
     expect(tokens).not.toMatch(/--text-[\w-]+:\s*calc\([^;]*\*/);
   });
+
+  it("defines cursor pointer preference tokens", () => {
+    const tokens = readStyle("tokens.css");
+
+    expect(tokens).toContain("--cursor-interactive: default;");
+    expect(tokens).toContain(':root[data-use-cursor-pointers="true"]');
+    expect(tokens).toContain("--cursor-interactive: pointer;");
+  });
 });
 
 describe("component color usage", () => {
@@ -135,6 +143,15 @@ describe("component color usage", () => {
     );
     expect(components).toContain("@media (forced-colors: active)");
     expect(components).toContain("scrollbar-color: auto;");
+  });
+
+  it("supports app-controlled motion and cursor pointer preferences", () => {
+    const components = readStyle("components.css");
+
+    expect(components).toContain("cursor: var(--cursor-interactive);");
+    expect(components).toContain(':root[data-disable-animations="true"] *');
+    expect(components).toContain("animation-delay: 0s !important;");
+    expect(components).toContain("transition-delay: 0s !important;");
   });
 
   it("does not use forbidden Chrome 87-incompatible CSS syntax", () => {

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -111,10 +111,15 @@
   --control-height-md: 1.875rem;
   --control-height-lg: 2.125rem;
   --control-height-xl: 2.375rem;
+  --cursor-interactive: default;
   --duration-fast: 120ms;
   --duration-normal: 180ms;
   --shadow-xs: 0 1px 2px rgba(var(--black), 0.05);
   --shadow-sm: 0 1px 3px rgba(var(--black), 0.08);
+}
+
+:root[data-use-cursor-pointers="true"] {
+  --cursor-interactive: pointer;
 }
 
 .dark,


### PR DESCRIPTION
## Summary
- add persisted appearance settings for disabling app animations and opting into cursor pointers
- apply motion and cursor preferences through pre-paint appearance snapshots
- add Settings UI toggles and shared CSS coverage for the new preferences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Disable animations" and "Use cursor pointers" toggles in appearance settings.

* **Style**
  * Interactive cursors now follow the new cursor preference and CSS variables.
  * App-wide animation and scroll behavior respect the disable-animations preference.

* **Tests**
  * Updated and added tests to cover appearance normalization, snapshot application, and stylesheet behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/370)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->