### PR TITLE
fix: prevent Auto Relogin server changes mid-attempt

### DIFF
--- a/app/src/renderer/windows/game/TopNav.tsx
+++ b/app/src/renderer/windows/game/TopNav.tsx
@@ -246,6 +246,12 @@ export function TopNav(props: TopNavProps): JSX.Element {
     }
   });
 
+  createEffect(() => {
+    if (props.autoReloginAttempting()) {
+      setAutoReloginServerMenuOpen(false);
+    }
+  });
+
   const setMenuOpen =
     (menu: GameTopNavMenu) =>
     (details: { readonly open: boolean }): void => {
@@ -775,7 +781,11 @@ export function TopNav(props: TopNavProps): JSX.Element {
                 closeOnSelect={false}
               >
                 <MenuSubTrigger
+                  aria-disabled={
+                    props.autoReloginAttempting() ? "true" : undefined
+                  }
                   class="game-menu__item game-menu__server-trigger"
+                  disabled={props.autoReloginAttempting()}
                   inset
                 >
                   <span class="game-menu__item-label">Server</span>
@@ -810,7 +820,10 @@ export function TopNav(props: TopNavProps): JSX.Element {
                         {(serverName) => (
                           <MenuRadioItem
                             class="game-menu__item"
-                            disabled={!props.autoReloginCaptured()}
+                            disabled={
+                              !props.autoReloginCaptured() ||
+                              props.autoReloginAttempting()
+                            }
                             value={serverName}
                           >
                             <span class="game-menu__item-label">

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
@@ -651,6 +651,40 @@ test("non-retryable connect outcome stops relogin after one attempt", async () =
   expect(result.state.lastError).toContain("member-only");
 });
 
+test("server selection during attempt is ignored", async () => {
+  const result = await withAutoRelogin(
+    { serverSelectStalls: true, servers: [twigServer, yorumiServer] },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelayMs(0);
+        const fiber = yield* Effect.forkDetach(harness.jobsState.task!, {
+          startImmediately: true,
+        });
+        yield* Effect.sleep("10 millis");
+        const selectedState = yield* autoRelogin.setServer("Yorumi");
+        yield* autoRelogin.disable();
+        yield* Fiber.join(fiber);
+        return {
+          calls: harness.authCalls,
+          selectedState,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.selectedState).toMatchObject({
+    attempting: true,
+    server: "Twig",
+    lastError: "cannot change server while reconnecting",
+  });
+  expect(result.state).toMatchObject({
+    attempting: false,
+    server: "Twig",
+  });
+});
+
 test("manual login during attempt interrupts without reconnecting captured server", async () => {
   const result = await withAutoRelogin(
     { serverSelectStalls: true },

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
@@ -1087,6 +1087,13 @@ const make = Effect.gen(function* () {
         });
       }
 
+      const currentState = yield* SynchronizedRef.get(stateRef);
+      if (currentState.attempting) {
+        return yield* updateState((state) => {
+          state.lastError = "cannot change server while reconnecting";
+        });
+      }
+
       const servers = yield* auth
         .getServers()
         .pipe(Effect.catchCause(() => Effect.succeed([])));

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
@@ -1102,6 +1102,11 @@ const make = Effect.gen(function* () {
       }
 
       return yield* updateState((state) => {
+        if (state.attempting) {
+          state.lastError = "cannot change server while reconnecting";
+          return;
+        }
+
         if (state.captured === null) {
           state.lastError = "capture a session before selecting a server";
           state.attemptsRemaining = undefined;


### PR DESCRIPTION
## Summary
- prevent Auto Relogin server changes while reconnecting
- disable and close the server submenu during active attempts
- add regression coverage for ignored mid-attempt selections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Auto Relogin server submenu now automatically closes when a reconnection attempt starts
  * Server selection options are disabled during active reconnection attempts to prevent invalid state changes
  * Server selection is blocked while auto-relogin is actively attempting to reconnect

* **Tests**
  * Added test case verifying that server selection requests are properly ignored during reconnection attempts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/372)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->