### PR TITLE
refactor(settings): rename animation setting to reduce motion

### DIFF
--- a/app/src/main/settings-service.ts
+++ b/app/src/main/settings-service.ts
@@ -6,6 +6,7 @@ import {
   type Appearance,
   type AppearancePatch,
   type HotkeysPatch,
+  type MotionMode,
   type Preferences,
   type PreferencesPatch,
   type ThemeMode,
@@ -29,6 +30,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isThemeMode = (value: unknown): value is ThemeMode =>
   value === "light" || value === "dark" || value === "system";
+
+const isMotionMode = (value: unknown): value is MotionMode =>
+  value === "system" || value === "on" || value === "off";
 
 const isThemeVariant = (value: string): value is ThemeVariant =>
   value === "light" || value === "dark";
@@ -159,10 +163,9 @@ export const updateAppearance = (patch: AppearancePatch): AppSettings => {
     themeMode: isThemeMode(patch.themeMode)
       ? patch.themeMode
       : current.themeMode,
-    disableAnimations:
-      typeof patch.disableAnimations === "boolean"
-        ? patch.disableAnimations
-        : current.disableAnimations,
+    reduceMotion: isMotionMode(patch.reduceMotion)
+      ? patch.reduceMotion
+      : current.reduceMotion,
     useCursorPointers:
       typeof patch.useCursorPointers === "boolean"
         ? patch.useCursorPointers

--- a/app/src/main/settings-service.ts
+++ b/app/src/main/settings-service.ts
@@ -2,11 +2,11 @@ import { BrowserWindow, nativeTheme } from "electron";
 import { SettingsIpcChannels } from "../shared/ipc";
 import {
   THEME_TOKEN_NAMES,
+  isMotionMode,
   type AppSettings,
   type Appearance,
   type AppearancePatch,
   type HotkeysPatch,
-  type MotionMode,
   type Preferences,
   type PreferencesPatch,
   type ThemeMode,
@@ -30,9 +30,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const isThemeMode = (value: unknown): value is ThemeMode =>
   value === "light" || value === "dark" || value === "system";
-
-const isMotionMode = (value: unknown): value is MotionMode =>
-  value === "system" || value === "on" || value === "off";
 
 const isThemeVariant = (value: string): value is ThemeVariant =>
   value === "light" || value === "dark";

--- a/app/src/main/settings/Appearance.test.ts
+++ b/app/src/main/settings/Appearance.test.ts
@@ -13,7 +13,7 @@ describe("appearance settings", () => {
       }),
     ).toEqual({
       themeMode: "system",
-      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      reduceMotion: Appearance.DEFAULT.reduceMotion,
       useCursorPointers: Appearance.DEFAULT.useCursorPointers,
       themes: {
         light: Appearance.DEFAULT.themes.light,
@@ -54,7 +54,7 @@ describe("appearance settings", () => {
       }),
     ).toEqual({
       themeMode: "dark",
-      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      reduceMotion: Appearance.DEFAULT.reduceMotion,
       useCursorPointers: Appearance.DEFAULT.useCursorPointers,
       themes: {
         light: {
@@ -120,7 +120,7 @@ describe("appearance settings", () => {
       }),
     ).toEqual({
       themeMode: Appearance.DEFAULT.themeMode,
-      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      reduceMotion: Appearance.DEFAULT.reduceMotion,
       useCursorPointers: Appearance.DEFAULT.useCursorPointers,
       themes: {
         light: Appearance.DEFAULT.themes.light,
@@ -156,33 +156,33 @@ describe("appearance settings", () => {
     });
   });
 
-  it("normalizes app motion and cursor pointer toggles", () => {
+  it("normalizes app motion mode and cursor pointer toggles", () => {
     expect(
       Appearance.normalize({
         themeMode: "dark",
-        disableAnimations: true,
+        reduceMotion: "on",
         useCursorPointers: true,
         themes: {},
       }),
     ).toMatchObject({
-      disableAnimations: true,
+      reduceMotion: "on",
       useCursorPointers: true,
     });
 
     expect(
       Appearance.normalize({
         themeMode: "dark",
-        disableAnimations: "yes",
+        reduceMotion: "sometimes",
         useCursorPointers: 1,
         themes: {},
       }),
     ).toMatchObject({
-      disableAnimations: Appearance.DEFAULT.disableAnimations,
+      reduceMotion: Appearance.DEFAULT.reduceMotion,
       useCursorPointers: Appearance.DEFAULT.useCursorPointers,
     });
   });
 
-  it("writes app motion and cursor pointer toggles", async () => {
+  it("writes app motion mode and cursor pointer toggles", async () => {
     const previous = process.env["VEXED_HOME"];
     const testDir = await mkdtemp(join(tmpdir(), "vexed-appearance-"));
     process.env["VEXED_HOME"] = testDir;
@@ -190,15 +190,15 @@ describe("appearance settings", () => {
     try {
       Appearance.write({
         ...Appearance.DEFAULT,
-        disableAnimations: true,
+        reduceMotion: "off",
         useCursorPointers: true,
       });
 
       const source = await readFile(Appearance.path(), "utf8");
-      expect(source).toContain("disableAnimations: true");
+      expect(source).toContain("reduceMotion: off");
       expect(source).toContain("useCursorPointers: true");
       expect(Appearance.read()).toMatchObject({
-        disableAnimations: true,
+        reduceMotion: "off",
         useCursorPointers: true,
       });
     } finally {

--- a/app/src/main/settings/Appearance.ts
+++ b/app/src/main/settings/Appearance.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_THEME_PROFILE,
   THEME_TOKEN_NAMES,
   type Appearance,
+  type MotionMode,
   type ThemeMode,
   type ThemeProfile,
   type ThemeRgb,
@@ -15,6 +16,7 @@ import {
 export {
   THEME_TOKEN_NAMES,
   type Appearance,
+  type MotionMode,
   type ThemeMode,
   type ThemeProfile,
   type ThemeRgb,
@@ -28,6 +30,9 @@ const themeTokenNames = new Set<string>(THEME_TOKEN_NAMES);
 
 const isThemeMode = (value: unknown): value is ThemeMode =>
   value === "light" || value === "dark" || value === "system";
+
+const isMotionMode = (value: unknown): value is MotionMode =>
+  value === "system" || value === "on" || value === "off";
 
 const parseHexRgb = (value: string): ThemeRgb | undefined => {
   const match = /^#?([0-9a-f]{6})$/i.exec(value.trim());
@@ -160,10 +165,9 @@ export const normalize = (value: unknown): Appearance => {
     themeMode: isThemeMode(record["themeMode"])
       ? record["themeMode"]
       : DEFAULT.themeMode,
-    disableAnimations:
-      typeof record["disableAnimations"] === "boolean"
-        ? record["disableAnimations"]
-        : DEFAULT.disableAnimations,
+    reduceMotion: isMotionMode(record["reduceMotion"])
+      ? record["reduceMotion"]
+      : DEFAULT.reduceMotion,
     useCursorPointers:
       typeof record["useCursorPointers"] === "boolean"
         ? record["useCursorPointers"]
@@ -213,7 +217,7 @@ const serialize = (appearance: Appearance): PersistedAppearance => {
   const normalized = normalize(appearance);
   return {
     themeMode: normalized.themeMode,
-    disableAnimations: normalized.disableAnimations,
+    reduceMotion: normalized.reduceMotion,
     useCursorPointers: normalized.useCursorPointers,
     themes: {
       light: serializeThemeProfile(normalized.themes.light),

--- a/app/src/main/settings/Appearance.ts
+++ b/app/src/main/settings/Appearance.ts
@@ -4,8 +4,8 @@ import {
   DEFAULT_APPEARANCE,
   DEFAULT_THEME_PROFILE,
   THEME_TOKEN_NAMES,
+  isMotionMode,
   type Appearance,
-  type MotionMode,
   type ThemeMode,
   type ThemeProfile,
   type ThemeRgb,
@@ -30,9 +30,6 @@ const themeTokenNames = new Set<string>(THEME_TOKEN_NAMES);
 
 const isThemeMode = (value: unknown): value is ThemeMode =>
   value === "light" || value === "dark" || value === "system";
-
-const isMotionMode = (value: unknown): value is MotionMode =>
-  value === "system" || value === "on" || value === "off";
 
 const parseHexRgb = (value: string): ThemeRgb | undefined => {
   const match = /^#?([0-9a-f]{6})$/i.exec(value.trim());

--- a/app/src/renderer/windows/settings/App.tsx
+++ b/app/src/renderer/windows/settings/App.tsx
@@ -72,6 +72,7 @@ import {
   type AppSettings,
   type AppearancePatch,
   type HotkeysPatch,
+  type MotionMode,
   type PreferencesPatch,
   type ThemeMode,
   type ThemeRgb,
@@ -118,6 +119,15 @@ const themeModes: ReadonlyArray<{
   { label: "Light", value: "light" },
   { label: "Dark", value: "dark" },
   { label: "System", value: "system" },
+];
+
+const motionModes: ReadonlyArray<{
+  readonly label: string;
+  readonly value: MotionMode;
+}> = [
+  { label: "System", value: "system" },
+  { label: "On", value: "on" },
+  { label: "Off", value: "off" },
 ];
 
 const launchModes = [
@@ -981,20 +991,17 @@ function AppearanceSettings(props: {
       />
       <SettingsRow
         action={
-          <Switch
-            aria-label="Disable animations"
-            checked={props.settings.appearance.disableAnimations}
-            onChange={(event) =>
-              props.onAppearancePatch({
-                disableAnimations: event.currentTarget.checked,
-              })
+          <SegmentedControl
+            aria-label="Reduce motion"
+            onChange={(reduceMotion) =>
+              props.onAppearancePatch({ reduceMotion })
             }
-            size="default"
+            options={motionModes}
+            value={props.settings.appearance.reduceMotion}
           />
         }
-        class="settings-row--switch"
-        description="Turn off app animations regardless of system motion settings."
-        title="Disable animations"
+        description="Control animation and transition effects."
+        title="Reduce motion"
       />
       <SettingsRow
         action={

--- a/app/src/renderer/windows/settings/style.css
+++ b/app/src/renderer/windows/settings/style.css
@@ -92,17 +92,17 @@
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  :root:not([data-disable-animations="true"]) .settings-content-wrapper {
+  :root:not([data-reduce-motion="on"]) .settings-content-wrapper {
     scroll-behavior: smooth;
   }
 }
 
-:root[data-disable-animations="true"] .settings-content-wrapper {
+:root[data-reduce-motion="on"] .settings-content-wrapper {
   scroll-behavior: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .settings-content-wrapper {
+  :root:not([data-reduce-motion="off"]) .settings-content-wrapper {
     scroll-behavior: auto;
   }
 }

--- a/app/src/renderer/windows/settings/style.css
+++ b/app/src/renderer/windows/settings/style.css
@@ -105,6 +105,10 @@
   :root:not([data-reduce-motion="off"]) .settings-content-wrapper {
     scroll-behavior: auto;
   }
+
+  :root[data-reduce-motion="off"] .settings-content-wrapper {
+    scroll-behavior: smooth;
+  }
 }
 
 .settings-section {

--- a/app/src/shared/appearance-snapshot.test.ts
+++ b/app/src/shared/appearance-snapshot.test.ts
@@ -152,7 +152,7 @@ describe("appearance snapshot", () => {
     const snapshot = createAppearanceSnapshot(
       {
         ...DEFAULT_APPEARANCE,
-        disableAnimations: true,
+        reduceMotion: "on",
         useCursorPointers: true,
       },
       false,
@@ -162,9 +162,9 @@ describe("appearance snapshot", () => {
     applyAppearanceSnapshotToDocument(root as unknown as HTMLElement, snapshot);
 
     expect(root.dataset["theme"]).toBe("dark");
-    expect(root.dataset["disableAnimations"]).toBe("true");
+    expect(root.dataset["reduceMotion"]).toBe("on");
     expect(root.dataset["useCursorPointers"]).toBe("true");
-    expect(root.getAttribute("data-disable-animations")).toBe("true");
+    expect(root.getAttribute("data-reduce-motion")).toBe("on");
     expect(root.getAttribute("data-use-cursor-pointers")).toBe("true");
     expect(root.hasClass("dark")).toBe(true);
     expect(root.style.getPropertyValue("--background")).toBe("14, 14, 15");
@@ -175,15 +175,15 @@ describe("appearance snapshot", () => {
     expect(root.style.getPropertyValue("color-scheme")).toBe("dark");
   });
 
-  it("omits inactive app preference attributes", () => {
+  it("applies default app preference attributes", () => {
     const snapshot = createAppearanceSnapshot(DEFAULT_APPEARANCE, false);
     const root = createFakeRoot();
 
-    root.dataset["disableAnimations"] = "true";
+    root.dataset["reduceMotion"] = "on";
     root.dataset["useCursorPointers"] = "true";
     applyAppearanceSnapshotToDocument(root as unknown as HTMLElement, snapshot);
 
-    expect(root.hasAttribute("data-disable-animations")).toBe(false);
+    expect(root.getAttribute("data-reduce-motion")).toBe("system");
     expect(root.hasAttribute("data-use-cursor-pointers")).toBe(false);
     expect(root.style.getPropertyValue("--cursor-interactive")).toBe("default");
   });

--- a/app/src/shared/appearance-snapshot.ts
+++ b/app/src/shared/appearance-snapshot.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_THEME_TOKENS,
   THEME_TOKEN_NAMES,
   type Appearance,
+  type MotionMode,
   type ThemeRgb,
   type ThemeTokenName,
   type ThemeTokenValues,
@@ -51,7 +52,7 @@ export interface AppearanceSnapshot {
   readonly sansFontSize: number;
   readonly monoFontSize: number;
   readonly rounding: number;
-  readonly disableAnimations: boolean;
+  readonly reduceMotion: MotionMode;
   readonly useCursorPointers: boolean;
   readonly backgroundColor: string;
 }
@@ -115,7 +116,7 @@ export const createAppearanceSnapshot = (
     sansFontSize: profile.sansFontSize,
     monoFontSize: profile.monoFontSize,
     rounding: profile.rounding,
-    disableAnimations: appearance.disableAnimations,
+    reduceMotion: appearance.reduceMotion,
     useCursorPointers: appearance.useCursorPointers,
     backgroundColor: rgbToHex(tokens.background),
   };
@@ -163,7 +164,9 @@ export const isAppearanceSnapshot = (
     Number.isFinite(value["monoFontSize"]) &&
     typeof value["rounding"] === "number" &&
     Number.isFinite(value["rounding"]) &&
-    typeof value["disableAnimations"] === "boolean" &&
+    (value["reduceMotion"] === "system" ||
+      value["reduceMotion"] === "on" ||
+      value["reduceMotion"] === "off") &&
     typeof value["useCursorPointers"] === "boolean" &&
     typeof value["backgroundColor"] === "string"
   );
@@ -228,11 +231,7 @@ export const applyAppearanceSnapshotToDocument = (
   const style = root.style;
 
   root.dataset["theme"] = snapshot.variant;
-  if (snapshot.disableAnimations) {
-    root.dataset["disableAnimations"] = "true";
-  } else {
-    delete root.dataset["disableAnimations"];
-  }
+  root.dataset["reduceMotion"] = snapshot.reduceMotion;
   if (snapshot.useCursorPointers) {
     root.dataset["useCursorPointers"] = "true";
   } else {

--- a/app/src/shared/settings.ts
+++ b/app/src/shared/settings.ts
@@ -17,6 +17,9 @@ export type MotionMode = "system" | "on" | "off";
 export type ThemeVariant = "light" | "dark";
 export type ThemeRgb = readonly [number, number, number];
 
+export const isMotionMode = (value: unknown): value is MotionMode =>
+  value === "system" || value === "on" || value === "off";
+
 export const THEME_TOKEN_NAMES = [
   "background",
   "foreground",

--- a/app/src/shared/settings.ts
+++ b/app/src/shared/settings.ts
@@ -13,6 +13,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
 };
 
 export type ThemeMode = "light" | "dark" | "system";
+export type MotionMode = "system" | "on" | "off";
 export type ThemeVariant = "light" | "dark";
 export type ThemeRgb = readonly [number, number, number];
 
@@ -58,7 +59,7 @@ export interface ThemeProfile {
 
 export interface Appearance {
   readonly themeMode: ThemeMode;
-  readonly disableAnimations: boolean;
+  readonly reduceMotion: MotionMode;
   readonly useCursorPointers: boolean;
   readonly themes: {
     readonly light: ThemeProfile;
@@ -141,7 +142,7 @@ export const DEFAULT_THEME_PROFILE: ThemeProfile = {
 
 export const DEFAULT_APPEARANCE: Appearance = {
   themeMode: "dark",
-  disableAnimations: false,
+  reduceMotion: "system",
   useCursorPointers: false,
   themes: {
     light: DEFAULT_THEME_PROFILE,
@@ -171,7 +172,7 @@ export interface ThemeProfilePatch {
 
 export interface AppearancePatch {
   readonly themeMode?: ThemeMode;
-  readonly disableAnimations?: boolean;
+  readonly reduceMotion?: MotionMode;
   readonly useCursorPointers?: boolean;
   readonly themes?: Partial<Record<ThemeVariant, ThemeProfilePatch>>;
 }

--- a/packages/ui/src/styles/components.css
+++ b/packages/ui/src/styles/components.css
@@ -2892,9 +2892,9 @@ a.badge--destructive:hover {
 /* Reduced Motion */
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
+  :root:not([data-reduce-motion="off"]) *,
+  :root:not([data-reduce-motion="off"]) *::before,
+  :root:not([data-reduce-motion="off"]) *::after {
     animation-delay: 0s !important;
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
@@ -2903,9 +2903,9 @@ a.badge--destructive:hover {
   }
 }
 
-:root[data-disable-animations="true"] *,
-:root[data-disable-animations="true"] *::before,
-:root[data-disable-animations="true"] *::after {
+:root[data-reduce-motion="on"] *,
+:root[data-reduce-motion="on"] *::before,
+:root[data-reduce-motion="on"] *::after {
   animation-delay: 0s !important;
   animation-duration: 0.001ms !important;
   animation-iteration-count: 1 !important;
@@ -2913,14 +2913,14 @@ a.badge--destructive:hover {
   transition-duration: 0.001ms !important;
 }
 
-:root[data-disable-animations="true"] {
+:root[data-reduce-motion="on"] {
   scroll-behavior: auto !important;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
+  :root:not([data-reduce-motion="off"]) *,
+  :root:not([data-reduce-motion="off"]) *::before,
+  :root:not([data-reduce-motion="off"]) *::after {
     scroll-behavior: auto !important;
   }
 }

--- a/packages/ui/src/styles/styles.test.ts
+++ b/packages/ui/src/styles/styles.test.ts
@@ -149,7 +149,8 @@ describe("component color usage", () => {
     const components = readStyle("components.css");
 
     expect(components).toContain("cursor: var(--cursor-interactive);");
-    expect(components).toContain(':root[data-disable-animations="true"] *');
+    expect(components).toContain(':root[data-reduce-motion="on"] *');
+    expect(components).toContain(':root:not([data-reduce-motion="off"]) *');
     expect(components).toContain("animation-delay: 0s !important;");
     expect(components).toContain("transition-delay: 0s !important;");
   });


### PR DESCRIPTION
## Summary
- Rename the animation toggle to **Reduce motion** and switch it to a three-state control: `System`, `On`, and `Off`
- Update the underlying appearance setting to use a neutral `reduceMotion` mode instead of a boolean flag
- Wire the new mode through snapshot application and motion-related CSS so system preference, forced reduction, and opt-out behavior are explicit
- Refresh tests to cover the new setting shape and document the new motion behavior

## Testing
- `pnpm --dir app typecheck`
- `pnpm --dir app test src/main/settings/Appearance.test.ts src/shared/appearance-snapshot.test.ts`
- `pnpm --dir packages/ui test src/styles/styles.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the binary "Disable animations" setting with a three-option "Reduce motion" setting offering System (respects OS preference), On (reduce animations), and Off (enable animations) for more granular motion control across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->