### PR TITLE
feat: add game top bar toggle hotkey

### DIFF
--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -6,10 +6,12 @@ import { Spinner } from "@vexed/ui";
 import { mountWindow } from "../mount";
 import { Data, Effect, Fiber } from "effect";
 import {
+  createEffect,
   createMemo,
   createSignal,
   onCleanup,
   onMount,
+  Show,
   type JSX,
 } from "solid-js";
 import {
@@ -174,6 +176,7 @@ export default function App(props: {
     createSignal<number | null>(null);
   const [openTopNavMenu, setOpenTopNavMenu] =
     createSignal<GameTopNavMenu | null>(null);
+  const [topBarVisible, setTopBarVisible] = createSignal(true);
   const [cells, setCells] = createSignal<readonly string[]>([DEFAULT_CELL]);
   const [pads] = createSignal<readonly string[]>(DEFAULT_PADS);
   const [validPads, setValidPads] = createSignal<readonly string[]>([]);
@@ -995,6 +998,21 @@ export default function App(props: {
     optionItems,
     openWindow,
     openTopNavMenu: (menu) => setOpenTopNavMenu(menu),
+    toggleTopBarVisible: () => {
+      setOpenTopNavMenu(null);
+      setTopBarVisible((visible) => !visible);
+    },
+  });
+
+  createEffect(() => {
+    document.documentElement.toggleAttribute(
+      "data-top-bar-hidden",
+      !topBarVisible(),
+    );
+  });
+
+  onCleanup(() => {
+    document.documentElement.removeAttribute("data-top-bar-hidden");
   });
 
   onMount(() => {
@@ -1124,65 +1142,67 @@ export default function App(props: {
         bindings={() => settings().hotkeys.bindings}
         commands={() => gameCommands}
       />
-      <TopNav
-        openMenu={openTopNavMenu}
-        setOpenMenu={setOpenTopNavMenu}
-        hotkeyBindings={() => settings().hotkeys.bindings}
-        hotkeyPlatform={window.ipc.platform.os}
-        autoAttackEnabled={autoAttackEnabled}
-        setAutoAttackEnabled={setAutoAttackEnabled}
-        gameLoaded={gameLoaded}
-        playerReady={playerReady}
-        scriptLoaded={scriptLoaded}
-        scriptRunning={scriptRunning}
-        scriptStatus={scriptStatus}
-        scriptDiagnosticsCount={scriptDiagnosticsCount}
-        loadScript={loadScript}
-        startScript={startScript}
-        stopScript={stopScript}
-        optionItems={optionItems}
-        walkSpeed={walkSpeed}
-        setWalkSpeed={setWalkSpeed}
-        handleSetWalkSpeed={handleSetWalkSpeed}
-        frameRate={frameRate}
-        setFrameRate={setFrameRate}
-        handleSetFrameRate={handleSetFrameRate}
-        customName={customName}
-        setCustomName={setCustomName}
-        handleSetCustomName={handleSetCustomName}
-        customGuild={customGuild}
-        setCustomGuild={setCustomGuild}
-        handleSetCustomGuild={handleSetCustomGuild}
-        autoZoneEnabled={autoZoneEnabled}
-        autoZoneMap={autoZoneMap}
-        handleToggleAutoZone={handleToggleAutoZone}
-        handleSelectAutoZoneMap={handleSelectAutoZoneMap}
-        autoReloginEnabled={autoReloginEnabled}
-        autoReloginCaptured={autoReloginCaptured}
-        autoReloginAttempting={autoReloginAttempting}
-        autoReloginWaitingDelay={autoReloginWaitingDelay}
-        autoReloginToggling={autoReloginToggling}
-        autoReloginDelaySeconds={autoReloginDelaySeconds}
-        setAutoReloginDelaySeconds={setAutoReloginDelaySeconds}
-        autoReloginServer={autoReloginServer}
-        autoReloginServers={autoReloginServers}
-        autoReloginLastError={autoReloginLastError}
-        autoReloginAttemptsRemaining={autoReloginAttemptsRemaining}
-        handleToggleAutoRelogin={handleToggleAutoRelogin}
-        handleRefreshAutoReloginServers={refreshAutoReloginServers}
-        handleSelectAutoReloginServer={handleSelectAutoReloginServer}
-        handleSetAutoReloginDelay={handleSetAutoReloginDelay}
-        cells={cells}
-        pads={pads}
-        validPads={validPads}
-        selectedCell={selectedCell}
-        selectedPad={selectedPad}
-        travelBusy={travelBusy}
-        handleRefreshTravelOptions={refreshTravelOptions}
-        handleSelectCell={handleSelectCell}
-        handleSelectPad={handleSelectPad}
-        handleOpenBank={handleOpenBank}
-      />
+      <Show when={topBarVisible()}>
+        <TopNav
+          openMenu={openTopNavMenu}
+          setOpenMenu={setOpenTopNavMenu}
+          hotkeyBindings={() => settings().hotkeys.bindings}
+          hotkeyPlatform={window.ipc.platform.os}
+          autoAttackEnabled={autoAttackEnabled}
+          setAutoAttackEnabled={setAutoAttackEnabled}
+          gameLoaded={gameLoaded}
+          playerReady={playerReady}
+          scriptLoaded={scriptLoaded}
+          scriptRunning={scriptRunning}
+          scriptStatus={scriptStatus}
+          scriptDiagnosticsCount={scriptDiagnosticsCount}
+          loadScript={loadScript}
+          startScript={startScript}
+          stopScript={stopScript}
+          optionItems={optionItems}
+          walkSpeed={walkSpeed}
+          setWalkSpeed={setWalkSpeed}
+          handleSetWalkSpeed={handleSetWalkSpeed}
+          frameRate={frameRate}
+          setFrameRate={setFrameRate}
+          handleSetFrameRate={handleSetFrameRate}
+          customName={customName}
+          setCustomName={setCustomName}
+          handleSetCustomName={handleSetCustomName}
+          customGuild={customGuild}
+          setCustomGuild={setCustomGuild}
+          handleSetCustomGuild={handleSetCustomGuild}
+          autoZoneEnabled={autoZoneEnabled}
+          autoZoneMap={autoZoneMap}
+          handleToggleAutoZone={handleToggleAutoZone}
+          handleSelectAutoZoneMap={handleSelectAutoZoneMap}
+          autoReloginEnabled={autoReloginEnabled}
+          autoReloginCaptured={autoReloginCaptured}
+          autoReloginAttempting={autoReloginAttempting}
+          autoReloginWaitingDelay={autoReloginWaitingDelay}
+          autoReloginToggling={autoReloginToggling}
+          autoReloginDelaySeconds={autoReloginDelaySeconds}
+          setAutoReloginDelaySeconds={setAutoReloginDelaySeconds}
+          autoReloginServer={autoReloginServer}
+          autoReloginServers={autoReloginServers}
+          autoReloginLastError={autoReloginLastError}
+          autoReloginAttemptsRemaining={autoReloginAttemptsRemaining}
+          handleToggleAutoRelogin={handleToggleAutoRelogin}
+          handleRefreshAutoReloginServers={refreshAutoReloginServers}
+          handleSelectAutoReloginServer={handleSelectAutoReloginServer}
+          handleSetAutoReloginDelay={handleSetAutoReloginDelay}
+          cells={cells}
+          pads={pads}
+          validPads={validPads}
+          selectedCell={selectedCell}
+          selectedPad={selectedPad}
+          travelBusy={travelBusy}
+          handleRefreshTravelOptions={refreshTravelOptions}
+          handleSelectCell={handleSelectCell}
+          handleSelectPad={handleSelectPad}
+          handleOpenBank={handleOpenBank}
+        />
+      </Show>
 
       <section
         id="loader-container"

--- a/app/src/renderer/windows/game/commands.test.ts
+++ b/app/src/renderer/windows/game/commands.test.ts
@@ -29,6 +29,7 @@ const createRuntime = (
     optionItems: () => [],
     openWindow: noop,
     openTopNavMenu: noop,
+    toggleTopBarVisible: noop,
     ...overrides,
   };
 };
@@ -56,6 +57,15 @@ describe("game commands", () => {
     findCommand(runtime, "open-options-menu").run();
 
     expect(openTopNavMenu).toHaveBeenCalledWith("options");
+  });
+
+  it("toggles top bar visibility", () => {
+    const toggleTopBarVisible = vi.fn();
+    const runtime = createRuntime({ toggleTopBarVisible });
+
+    findCommand(runtime, "toggle-top-bar").run();
+
+    expect(toggleTopBarVisible).toHaveBeenCalledOnce();
   });
 
   it("dispatches option commands through top nav option items", () => {

--- a/app/src/renderer/windows/game/commands.ts
+++ b/app/src/renderer/windows/game/commands.ts
@@ -25,6 +25,7 @@ export interface GameCommandRuntime {
   readonly optionItems: Accessor<readonly TopNavOptionItem[]>;
   readonly openWindow: (id: WindowId) => void;
   readonly openTopNavMenu: (menu: GameTopNavMenu) => void;
+  readonly toggleTopBarVisible: () => void;
 }
 
 export interface GameCommand {
@@ -136,6 +137,10 @@ const createCommandRunner = (
 
   if (id === "open-options-menu") {
     return () => runtime.openTopNavMenu("options");
+  }
+
+  if (id === "toggle-top-bar") {
+    return runtime.toggleTopBarVisible;
   }
 
   const windowId = windowCommandIds[id];

--- a/app/src/renderer/windows/game/index.html
+++ b/app/src/renderer/windows/game/index.html
@@ -28,6 +28,10 @@
         height: calc(100% - var(--topnav-offset, var(--topnav-height, 28px)));
         z-index: 1;
       }
+      html[data-top-bar-hidden] #swf {
+        top: 0;
+        height: 100%;
+      }
     </style>
   </head>
   <body>

--- a/app/src/renderer/windows/settings/App.tsx
+++ b/app/src/renderer/windows/settings/App.tsx
@@ -136,6 +136,7 @@ const launchModes = [
 ] as const;
 
 const commandCategories: readonly CommandCategory[] = [
+  "Application",
   "Scripts",
   "Options",
   "Tools",

--- a/app/src/renderer/windows/settings/style.css
+++ b/app/src/renderer/windows/settings/style.css
@@ -493,6 +493,7 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
+  padding-bottom: 1.5rem;
 }
 
 .hotkey-category-title {

--- a/app/src/shared/commands.ts
+++ b/app/src/shared/commands.ts
@@ -8,6 +8,7 @@ export type CommandCategory =
   | "Packets";
 
 export type GameCommandId =
+  | "toggle-top-bar"
   | "load-script"
   | "toggle-script"
   | "stop-script"
@@ -41,6 +42,14 @@ export interface CommandDefinition {
 export type DefaultHotkeyBindings = Partial<Record<GameCommandId, string>>;
 
 export const GAME_COMMANDS: readonly CommandDefinition[] = [
+  {
+    id: "toggle-top-bar",
+    scope: "game",
+    category: "Application",
+    label: "Toggle Top Bar",
+    keywords: ["top", "bar", "navigation", "chrome"],
+    defaultHotkey: "Meta+Shift+T",
+  },
   {
     id: "load-script",
     scope: "game",


### PR DESCRIPTION
## Summary
- add a configurable game hotkey for toggling the top bar
- make the SWF fill the full game window while the top bar is hidden
- add spacing below the hotkeys settings cards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to toggle the top navigation bar visibility with the keyboard shortcut Meta+Shift+T, enabling a full-screen gameplay experience when needed.

* **Improvements**
  * Enhanced the settings hotkeys menu layout with improved spacing and expanded category organization for better usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->