### PR TITLE
fix: prevent quit from hiding windows

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -12,7 +12,7 @@ import {
 import { basename, join, sep } from "path";
 import process from "process";
 import { homedir } from "os";
-import { Effect } from "effect";
+import { Effect, Layer } from "effect";
 import appBranding from "../../appBranding.json";
 import { createAppearanceSnapshot } from "../shared/appearance-snapshot";
 import { ScriptingIpcChannels, type ScriptExecutePayload } from "../shared/ipc";
@@ -37,9 +37,12 @@ import { registerWindowIpcHandlers } from "./window-ipc";
 import {
   getRendererGameWindowPath,
   getRendererWindowPath,
+  makeElectronWindowRuntime,
+  makeWindowService,
   WindowManagerError,
   WindowService,
-  WindowServiceLive,
+  type WindowManagerConfig,
+  type WindowServiceShape,
   type WindowEffectRunner,
 } from "./windows";
 
@@ -282,6 +285,7 @@ const resolveDevRendererUrl = (): string | null => {
 };
 
 let runWindowEffect: WindowEffectRunner | null = null;
+let configuredWindowService: WindowServiceShape | null = null;
 
 const runConfiguredWindowEffect: WindowEffectRunner = (effect) => {
   if (!runWindowEffect) {
@@ -293,6 +297,16 @@ const runConfiguredWindowEffect: WindowEffectRunner = (effect) => {
   }
 
   return runWindowEffect(effect);
+};
+
+const markConfiguredWindowServiceQuitting = (): void => {
+  if (!configuredWindowService) {
+    throw new WindowManagerError({
+      message: "Window service has not been configured",
+    });
+  }
+
+  Effect.runSync(configuredWindowService.setQuitting(true));
 };
 
 const openStartupWindow = (launchMode: Preferences.AppLaunchMode): void => {
@@ -332,7 +346,7 @@ const revealStartupWindow = (): void => {
 
 app.whenReady().then(() => {
   const { preferences } = loadMainSettings();
-  const windowLayer = WindowServiceLive({
+  const windowServiceConfig: WindowManagerConfig = {
     gameWindowHtmlPath: getRendererGameWindowPath(rendererPath),
     isDev: isDevApp,
     preloadPath: join(__dirname, "../preload/index.js"),
@@ -344,7 +358,14 @@ app.whenReady().then(() => {
         nativeTheme.shouldUseDarkColors,
       ),
     onGameWindowCreated: configureGameWindow,
-  });
+  };
+  const windowService = makeWindowService(
+    windowServiceConfig,
+    makeElectronWindowRuntime(),
+  );
+  const windowLayer = Layer.succeed(WindowService, windowService);
+
+  configuredWindowService = windowService;
 
   runWindowEffect = <A>(
     effect: Effect.Effect<A, WindowManagerError, WindowService>,
@@ -365,14 +386,11 @@ app.whenReady().then(() => {
 });
 
 app.on("before-quit", () => {
-  void runConfiguredWindowEffect(
-    Effect.gen(function* () {
-      const windows = yield* WindowService;
-      yield* windows.setQuitting(true);
-    }),
-  ).catch((error) => {
+  try {
+    markConfiguredWindowServiceQuitting();
+  } catch (error) {
     console.error("Failed to mark window service as quitting:", error);
-  });
+  }
 });
 
 app.on("window-all-closed", () => {

--- a/app/src/main/windows.integration.test.ts
+++ b/app/src/main/windows.integration.test.ts
@@ -154,7 +154,10 @@ describe("app window wiring", () => {
     expect(windowSource).toContain("setQuitting: (quitting)");
     expect(windowSource).toContain("if (isQuitting)");
     expect(indexSource).toContain('app.on("before-quit"');
-    expect(indexSource).toContain("windows.setQuitting(true)");
+    expect(indexSource).toContain("markConfiguredWindowServiceQuitting()");
+    expect(indexSource).toContain(
+      "Effect.runSync(configuredWindowService.setQuitting(true))",
+    );
   });
 
   it("declares each SolidJS view as an individual renderer target", () => {

--- a/app/src/main/windows.test.ts
+++ b/app/src/main/windows.test.ts
@@ -415,6 +415,21 @@ describe("window service", () => {
     expect(child.destroyed).toBe(true);
   });
 
+  it("lets hidden-on-close app windows close while quitting", async () => {
+    const harness = createHarness();
+    const settings = (await run(
+      harness.service.openWindow(WindowIds.Settings),
+    )) as unknown as FakeWindow;
+
+    expect(settings.close()).toBe(true);
+    expect(settings.destroyed).toBe(false);
+
+    await run(harness.service.setQuitting(true));
+
+    expect(settings.close()).toBe(false);
+    expect(settings.destroyed).toBe(true);
+  });
+
   it("destroys and unregisters windows when renderer loading fails", async () => {
     const harness = createHarness();
     const gameWindow = (await run(


### PR DESCRIPTION
## Summary
- Set the window service quitting flag synchronously before Electron closes windows
- Keep hide-on-close windows from canceling app quit
- Add regression coverage for app windows closing during quit

## Root Cause
`before-quit` updated the window service through an async effect. Electron could begin closing windows before that effect ran, allowing hide-on-close windows to call `preventDefault()` and cancel quit.