### PR TITLE
fix: constrain cells menu viewport

### DIFF
--- a/app/src/renderer/windows/game/style.css
+++ b/app/src/renderer/windows/game/style.css
@@ -326,6 +326,13 @@
   min-width: 10rem;
 }
 
+.game-menu--cells .menu__viewport {
+  max-height: min(
+    18rem,
+    calc(100vh - var(--topnav-offset, var(--topnav-height, 32px)) - 1rem)
+  );
+}
+
 .game-menu__autofocus-anchor {
   height: 1px;
   opacity: 0;


### PR DESCRIPTION
## Summary
- cap the cells menu scroll viewport instead of the menu content wrapper
- keep long cell lists scrollable without clipping hidden items