### PR TITLE
fix: refresh cached scripts on game reload

### DIFF
--- a/app/src/main/account-manager-ipc.ts
+++ b/app/src/main/account-manager-ipc.ts
@@ -19,6 +19,7 @@ import {
 } from "../shared/ipc";
 import { WindowIds } from "../shared/windows";
 import { getArtixLauncherRequestHeaders } from "./artix-launcher-headers";
+import { refreshCachedScriptPayload } from "./scripting";
 import * as Files from "./settings/Files";
 import { WindowService, type WindowEffectRunner } from "./windows";
 
@@ -387,6 +388,17 @@ const normalizePatch = (patch: unknown): ManagedAccountPatch => {
 const scriptName = (script: ScriptExecutePayload | null | undefined): string =>
   script?.name || script?.path || "script";
 
+const scriptRefreshErrorMessage = (
+  script: ScriptExecutePayload,
+  error: unknown,
+): string => {
+  const message = error instanceof Error ? error.message : "";
+  const name = scriptName(script);
+  return message
+    ? `Failed to refresh ${name}: ${message}`
+    : `Failed to refresh ${name}`;
+};
+
 const isScriptPayload = (value: unknown): value is ScriptExecutePayload => {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -468,6 +480,23 @@ const sendGameLaunchPayload = (
   window.webContents.send(AccountManagerIpcChannels.gameLaunch, payload);
 };
 
+const refreshGameLaunchScript = async (
+  payload: AccountGameLaunchPayload,
+): Promise<AccountGameLaunchPayload> => {
+  if (payload.script === undefined) {
+    return payload;
+  }
+
+  const script = await refreshCachedScriptPayload(payload.script);
+  const nextPayload: AccountGameLaunchPayload = {
+    ...payload,
+    script,
+  };
+
+  gameLaunchPayloads.set(payload.gameWindowId, nextPayload);
+  return nextPayload;
+};
+
 const serverLoadErrorMessage = (error: unknown): string => {
   const message = error instanceof Error ? error.message : "";
   const statusCode = /Failed to fetch servers: (\d{3})/.exec(message)?.[1];
@@ -531,7 +560,28 @@ export const registerAccountManagerIpcHandlers = (
       return null;
     }
 
-    return gameLaunchPayloads.get(gameWindowId) ?? null;
+    const payload = gameLaunchPayloads.get(gameWindowId);
+    if (!payload) {
+      return null;
+    }
+
+    try {
+      return await refreshGameLaunchScript(payload);
+    } catch (error) {
+      if (payload.script !== undefined) {
+        await setSession(
+          {
+            username: payload.account.username,
+            gameWindowId,
+            status: "failed",
+            scriptName: scriptName(payload.script),
+            message: scriptRefreshErrorMessage(payload.script, error),
+          },
+          runWindowEffect,
+        );
+      }
+      throw error;
+    }
   });
 
   ipcMain.handle(
@@ -639,6 +689,12 @@ export const registerAccountManagerIpcHandlers = (
         throw new Error("Account not found");
       }
 
+      const requestedScript = launchRequest.script ?? null;
+      const launchScript =
+        requestedScript === null
+          ? null
+          : await refreshCachedScriptPayload(requestedScript);
+
       const gameWindow = await runWindowEffect(
         Effect.gen(function* () {
           const windows = yield* WindowService;
@@ -648,9 +704,7 @@ export const registerAccountManagerIpcHandlers = (
       const gameWindowId = gameWindow.id;
       const gameLaunchPayload: AccountGameLaunchPayload = {
         account,
-        ...(launchRequest.script === null
-          ? {}
-          : { script: launchRequest.script }),
+        ...(launchScript === null ? {} : { script: launchScript }),
         ...(launchRequest.server === undefined
           ? {}
           : { server: launchRequest.server }),
@@ -666,12 +720,12 @@ export const registerAccountManagerIpcHandlers = (
           gameWindowId,
           status: "starting",
           message:
-            launchRequest.script === null
+            launchScript === null
               ? "Signing in"
-              : `Queued ${scriptName(launchRequest.script)}`,
-          ...(launchRequest.script === null
+              : `Queued ${scriptName(launchScript)}`,
+          ...(launchScript === null
             ? {}
-            : { scriptName: scriptName(launchRequest.script) }),
+            : { scriptName: scriptName(launchScript) }),
         },
         runWindowEffect,
       );
@@ -684,9 +738,9 @@ export const registerAccountManagerIpcHandlers = (
             gameWindowId,
             status: "stopped",
             message: "Game window closed",
-            ...(launchRequest.script === null
+            ...(launchScript === null
               ? {}
-              : { scriptName: scriptName(launchRequest.script) }),
+              : { scriptName: scriptName(launchScript) }),
           },
           runWindowEffect,
         ).catch((error) => {

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,5 +1,5 @@
 import "abort-controller/polyfill";
-import { promises, unwatchFile, watchFile, type Stats } from "fs";
+import { unwatchFile, watchFile, type Stats } from "fs";
 import {
   app,
   BrowserWindow,
@@ -9,7 +9,7 @@ import {
   session,
   type OpenDialogOptions,
 } from "electron";
-import { basename, join, sep } from "path";
+import { join } from "path";
 import process from "process";
 import { homedir } from "os";
 import { Effect, Layer } from "effect";
@@ -28,6 +28,7 @@ import { registerEnvironmentIpcHandlers } from "./environment-ipc";
 import * as Appearance from "./settings/Appearance";
 import * as Files from "./settings/Files";
 import * as Preferences from "./settings/Preferences";
+import { getScriptsPath, updateCachedScriptPayload } from "./scripting";
 import { registerSettingsIpcHandlers } from "./settings-ipc";
 import {
   installNativeThemeChangeBroadcast,
@@ -45,8 +46,6 @@ import {
   type WindowServiceShape,
   type WindowEffectRunner,
 } from "./windows";
-
-const { mkdir, readFile, realpath } = promises;
 
 const flash = require("nw-flash-trust");
 
@@ -83,7 +82,6 @@ const workspacePath = Files.resolveWorkspaceHome({
   documentsPath: app.getPath("documents"),
 });
 Files.configureWorkspaceHome(workspacePath);
-const scriptsPath = Files.workspaceJoin("scripts");
 const devRendererReloadPath = process.env["VEXED_DEV_RENDERER_RELOAD"];
 const devRendererUrl = process.env["VEXED_DEV_RENDERER_URL"];
 
@@ -129,40 +127,12 @@ const getEventWindow = (senderId?: number): BrowserWindow | null => {
   return first ?? null;
 };
 
-const resolveScriptPath = async (path: string): Promise<string> => {
-  await mkdir(scriptsPath, { recursive: true });
-
-  const [scriptsRoot, scriptPath] = await Promise.all([
-    realpath(scriptsPath),
-    realpath(path),
-  ]);
-
-  if (
-    scriptPath !== scriptsRoot &&
-    !scriptPath.startsWith(`${scriptsRoot}${sep}`)
-  ) {
-    throw new Error("Script path must be inside the scripts directory");
-  }
-
-  return scriptPath;
-};
-
-const toScriptPayload = async (path: string): Promise<ScriptExecutePayload> => {
-  const scriptPath = await resolveScriptPath(path);
-
-  return {
-    source: await readFile(scriptPath, "utf8"),
-    path: scriptPath,
-    name: basename(scriptPath),
-  };
-};
-
 const openScriptDialog = async (
   win: BrowserWindow | null,
 ): Promise<ScriptExecutePayload | null> => {
   const options: OpenDialogOptions = {
     title: "Open script",
-    defaultPath: scriptsPath,
+    defaultPath: getScriptsPath(),
     filters: [
       { name: "JavaScript", extensions: ["js", "cjs"] },
       { name: "All Files", extensions: ["*"] },
@@ -184,7 +154,7 @@ const openScriptDialog = async (
     return null;
   }
 
-  return await toScriptPayload(path);
+  return await updateCachedScriptPayload(path);
 };
 
 let scriptingIpcRegistered = false;
@@ -206,7 +176,7 @@ const registerScriptingIpcHandlers = () => {
         throw new Error("Invalid script path");
       }
 
-      return await toScriptPayload(path.trim());
+      return await updateCachedScriptPayload(path.trim());
     },
   );
 

--- a/app/src/main/scripting.test.ts
+++ b/app/src/main/scripting.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as Files from "./settings/Files";
+import {
+  refreshCachedScriptPayload,
+  updateCachedScriptPayload,
+} from "./scripting";
+
+let tempDir: string | undefined;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "vexed-scripting-"));
+  Files.configureWorkspaceHome(tempDir);
+});
+
+afterEach(async () => {
+  Files.resetPathConfigurationForTests();
+  if (tempDir !== undefined) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("main scripting cache", () => {
+  it("refreshes cached path-backed scripts from disk", async () => {
+    const scriptsDir = Files.workspaceJoin("scripts");
+    const scriptPath = join(scriptsDir, "farm.js");
+    await mkdir(scriptsDir, { recursive: true });
+    await writeFile(scriptPath, "module.exports = 'first';\n", "utf8");
+    const resolvedScriptPath = await realpath(scriptPath);
+
+    const payload = await updateCachedScriptPayload(scriptPath);
+    expect(payload).toMatchObject({
+      source: "module.exports = 'first';\n",
+      path: resolvedScriptPath,
+      name: "farm.js",
+    });
+
+    await writeFile(scriptPath, "module.exports = 'second';\n", "utf8");
+
+    const refreshed = await refreshCachedScriptPayload(payload);
+    expect(refreshed).toMatchObject({
+      source: "module.exports = 'second';\n",
+      path: resolvedScriptPath,
+      name: "farm.js",
+    });
+  });
+
+  it("keeps inline scripts as-is because they have no file cache key", async () => {
+    const payload = { source: "module.exports = 1;", name: "inline.js" };
+
+    await expect(refreshCachedScriptPayload(payload)).resolves.toBe(payload);
+  });
+
+  it("rejects scripts outside the workspace scripts directory", async () => {
+    if (tempDir === undefined) {
+      throw new Error("Missing temp directory");
+    }
+
+    const scriptsDir = Files.workspaceJoin("scripts");
+    const outsidePath = join(tempDir, "outside.js");
+    await mkdir(scriptsDir, { recursive: true });
+    await writeFile(outsidePath, "module.exports = 1;\n", "utf8");
+
+    await expect(updateCachedScriptPayload(outsidePath)).rejects.toThrow(
+      "Script path must be inside the scripts directory",
+    );
+  });
+});

--- a/app/src/main/scripting.ts
+++ b/app/src/main/scripting.ts
@@ -5,8 +5,6 @@ import * as Files from "./settings/Files";
 
 const { mkdir, readFile, realpath } = promises;
 
-const cachedScripts = new Map<string, ScriptExecutePayload>();
-
 export const getScriptsPath = (): string => Files.workspaceJoin("scripts");
 
 export const resolveScriptPath = async (path: string): Promise<string> => {

--- a/app/src/main/scripting.ts
+++ b/app/src/main/scripting.ts
@@ -38,7 +38,6 @@ export const updateCachedScriptPayload = async (
     name: basename(scriptPath),
   };
 
-  cachedScripts.set(scriptPath, payload);
   return payload;
 };
 

--- a/app/src/main/scripting.ts
+++ b/app/src/main/scripting.ts
@@ -1,0 +1,54 @@
+import { promises } from "fs";
+import { basename, sep } from "path";
+import type { ScriptExecutePayload } from "../shared/ipc";
+import * as Files from "./settings/Files";
+
+const { mkdir, readFile, realpath } = promises;
+
+const cachedScripts = new Map<string, ScriptExecutePayload>();
+
+export const getScriptsPath = (): string => Files.workspaceJoin("scripts");
+
+export const resolveScriptPath = async (path: string): Promise<string> => {
+  const scriptsPath = getScriptsPath();
+  await mkdir(scriptsPath, { recursive: true });
+
+  const [scriptsRoot, scriptPath] = await Promise.all([
+    realpath(scriptsPath),
+    realpath(path),
+  ]);
+
+  if (
+    scriptPath !== scriptsRoot &&
+    !scriptPath.startsWith(`${scriptsRoot}${sep}`)
+  ) {
+    throw new Error("Script path must be inside the scripts directory");
+  }
+
+  return scriptPath;
+};
+
+export const updateCachedScriptPayload = async (
+  path: string,
+): Promise<ScriptExecutePayload> => {
+  const scriptPath = await resolveScriptPath(path);
+  const payload: ScriptExecutePayload = {
+    source: await readFile(scriptPath, "utf8"),
+    path: scriptPath,
+    name: basename(scriptPath),
+  };
+
+  cachedScripts.set(scriptPath, payload);
+  return payload;
+};
+
+export const refreshCachedScriptPayload = async (
+  payload: ScriptExecutePayload,
+): Promise<ScriptExecutePayload> => {
+  const path = payload.path?.trim();
+  if (!path) {
+    return payload;
+  }
+
+  return await updateCachedScriptPayload(path);
+};


### PR DESCRIPTION
## Summary

Move script file payload ownership into the main process so selected scripts are cached by canonical path and refreshed from disk before account launches are delivered or replayed.

This prevents a reloaded game window from receiving the original stale script source after the script file has changed, while keeping inline scripts unchanged and preserving the existing scripts-directory guard.