### PR TITLE
fix: handle autorelogin login failures

### DIFF
--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
@@ -43,11 +43,17 @@ const connectedOutcome = (serverName: string): AuthConnectOutcome => ({
   serverName,
 });
 
+const invalidCredentialsDetail =
+  "The username and password you entered did not match.\rPlease check the spelling and try again.";
+const authenticatingAccountDetail = "Authenticating Account Info...";
+
 type HarnessOptions = {
   readonly bridgeLoggedIn?: boolean;
   readonly connectOutcome?: AuthConnectOutcome;
   readonly emitConnectionOnConnect?: boolean;
   readonly iUpgDays?: number;
+  readonly invalidCredentials?: boolean;
+  readonly loginStalls?: boolean;
   readonly password?: string;
   readonly playerReadyAfterConnectDelayMs?: number;
   readonly playerReadyAfterReload?: boolean;
@@ -124,6 +130,16 @@ const withAutoRelogin = async <A>(
             ) as ReturnType<Window["swf"][K]>;
           }
 
+          if (key === "mcConnDetail.txtDetail.text") {
+            const detail =
+              options.invalidCredentials === true
+                ? invalidCredentialsDetail
+                : options.loginStalls === true
+                  ? authenticatingAccountDetail
+                  : "";
+            return detail as ReturnType<Window["swf"][K]>;
+          }
+
           if (key === "currentLabel") {
             return (phase === "game" ? "Game" : "Login") as ReturnType<
               Window["swf"][K]
@@ -136,11 +152,19 @@ const withAutoRelogin = async <A>(
         }
 
         if (path === "flash.getConnMcText") {
-          return "loading" as ReturnType<Window["swf"][K]>;
+          const detail =
+            options.invalidCredentials === true
+              ? invalidCredentialsDetail
+              : options.loginStalls === true
+                ? authenticatingAccountDetail
+                : "loading";
+          return detail as ReturnType<Window["swf"][K]>;
         }
 
         if (path === "flash.isConnMcBackButtonVisible") {
-          return false as ReturnType<Window["swf"][K]>;
+          return (options.loginStalls === true) as ReturnType<
+            Window["swf"][K]
+          >;
         }
 
         throw new Error(`unexpected bridge call: ${String(path)}`);
@@ -211,7 +235,10 @@ const withAutoRelogin = async <A>(
     },
     login(username: string, loginPassword: string) {
       authCalls.push(`login:${username}:${loginPassword}`);
-      phase = "servers";
+      phase =
+        options.invalidCredentials === true || options.loginStalls === true
+          ? "login"
+          : "servers";
       return Effect.void;
     },
     logout() {
@@ -511,6 +538,66 @@ test("direct login with a server waits for player readiness", async () => {
   ]);
 });
 
+test("direct login fails explicitly when credentials are invalid", async () => {
+  const result = await withAutoRelogin(
+    { invalidCredentials: true },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          autoRelogin.login({
+            username: "Hero",
+            password: "wrong-password",
+            server: "Twig",
+          }),
+        );
+        return {
+          calls: harness.authCalls,
+          exit,
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:wrong-password"]);
+  expect(Exit.isFailure(result.exit)).toBe(true);
+  expect(
+    Exit.match(result.exit, {
+      onFailure: (cause) => String(cause),
+      onSuccess: () => "",
+    }),
+  ).toContain("invalid username or password");
+});
+
+test("direct login cancels and fails explicitly when authentication stalls", async () => {
+  const result = await withAutoRelogin(
+    { loginStalls: true },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          autoRelogin.login({
+            username: "Hero",
+            password: "secret-password",
+            server: "Twig",
+          }),
+        );
+        return {
+          calls: harness.authCalls,
+          exit,
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password", "logout"]);
+  expect(Exit.isFailure(result.exit)).toBe(true);
+  expect(
+    Exit.match(result.exit, {
+      onFailure: (cause) => String(cause),
+      onSuccess: () => "",
+    }),
+  ).toContain(
+    "login did not reach server select: Authenticating Account Info...",
+  );
+});
+
 test("direct login reloads avatar art when connected player stays unready", async () => {
   const result = await withAutoRelogin(
     {
@@ -690,6 +777,30 @@ test("non-retryable connect outcome stops relogin after one attempt", async () =
     "connectTo:Twig",
   ]);
   expect(result.state.lastError).toContain("member-only");
+});
+
+test("invalid captured credentials stop relogin without retrying", async () => {
+  const result = await withAutoRelogin(
+    { invalidCredentials: true },
+    (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelay(0);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state).toMatchObject({
+    enabled: false,
+    attempting: false,
+    lastError: "invalid username or password",
+  });
+  expect(result.state.attemptsRemaining).toBeUndefined();
 });
 
 test("server selection during attempt is ignored", async () => {

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
@@ -43,6 +43,10 @@ const AVATAR_RELOAD_READY_TIMEOUT = "20 seconds";
 const MIN_FAILURE_COOLDOWN_MS = 5_000;
 const MAX_FAILURE_COOLDOWN_MS = 60_000;
 const MAX_RELOGIN_RETRIES = 3;
+const INVALID_CREDENTIALS_DETAIL =
+  "The username and password you entered did not match.\rPlease check the spelling and try again.";
+const INVALID_CREDENTIALS_ERROR = "invalid username or password";
+const LOGIN_STALLED_ERROR = "login did not reach server select";
 
 class AutoReloginAttemptError extends Data.TaggedError(
   "AutoReloginAttemptError",
@@ -96,6 +100,18 @@ type LogoutObservation = {
 type CaptureCurrentSessionOptions = {
   readonly preserveTargetServer?: boolean;
 };
+
+type LoginScreenOutcome =
+  | {
+      readonly status: "server-select";
+    }
+  | {
+      readonly status: "invalid-credentials";
+    }
+  | {
+      readonly status: "stalled";
+      readonly detail: string;
+    };
 
 const initialState = (): RuntimeState => ({
   enabled: false,
@@ -583,16 +599,96 @@ const make = Effect.gen(function* () {
       ),
     );
 
-  const waitForServerSelect = waitFor(
-    bridge.call("flash.getGameObject", ["mcLogin.currentLabel"]).pipe(
-      Effect.map((label) => flashStringEquals(label, "Servers")),
-      Effect.catchTag("SwfCallError", () => Effect.succeed(false)),
-    ),
-    {
-      timeout: SERVER_SELECT_TIMEOUT,
-      schedule: Schedule.spaced("100 millis"),
-    },
-  );
+  const readConnDetailText = () =>
+    bridge.call("flash.getConnMcText").pipe(
+      Effect.catchCause(() =>
+        bridge
+          .call("flash.getGameObject", ["mcConnDetail.txtDetail.text"])
+          .pipe(Effect.catchCause(() => Effect.succeed(""))),
+      ),
+    );
+
+  const observeLoginScreenOutcome = (): Effect.Effect<
+    LoginScreenOutcome | null
+  > =>
+    Effect.gen(function* () {
+      const label = yield* bridge
+        .call("flash.getGameObject", ["mcLogin.currentLabel"])
+        .pipe(Effect.catchCause(() => Effect.succeed("")));
+      if (flashStringEquals(label, "Servers")) {
+        return { status: "server-select" } as const;
+      }
+
+      const [detail, backButtonVisible] = yield* Effect.all([
+        readConnDetailText(),
+        bridge
+          .call("flash.isConnMcBackButtonVisible")
+          .pipe(Effect.catchCause(() => Effect.succeed(false))),
+      ]);
+      if (flashStringEquals(detail, INVALID_CREDENTIALS_DETAIL)) {
+        return { status: "invalid-credentials" } as const;
+      }
+
+      const decodedDetail = decodeFlashValue(detail);
+      const detailText =
+        typeof decodedDetail === "string" && decodedDetail !== "null"
+          ? decodedDetail.trim()
+          : "";
+      if (backButtonVisible && detailText !== "") {
+        return { status: "stalled", detail: detailText } as const;
+      }
+
+      return null;
+    });
+
+  const cancelStalledLogin = () =>
+    auth.logout().pipe(
+      Effect.catchCause(() => Effect.void),
+      Effect.andThen(
+        bridge
+          .call("flash.hideConnMc")
+          .pipe(Effect.catchCause(() => Effect.void)),
+      ),
+    );
+
+  const loginStalledMessage = (detail: string): string =>
+    detail === "" ? LOGIN_STALLED_ERROR : `${LOGIN_STALLED_ERROR}: ${detail}`;
+
+  const failStalledLogin = (detail: string) =>
+    cancelStalledLogin().pipe(
+      Effect.andThen(failAttempt(loginStalledMessage(detail), true)),
+    );
+
+  const waitForLoginScreenOutcome = () =>
+    observeLoginScreenOutcome().pipe(
+      Effect.repeat({
+        until: (outcome) => outcome !== null,
+        schedule: Schedule.passthrough<
+          number,
+          LoginScreenOutcome | null,
+          never,
+          never
+        >(Schedule.spaced("100 millis")),
+      }),
+      Effect.timeoutOption(SERVER_SELECT_TIMEOUT),
+      Effect.map((completed) =>
+        Option.isSome(completed) ? completed.value : null,
+      ),
+    );
+
+  const waitForServerSelect = () =>
+    Effect.gen(function* () {
+      const outcome = yield* waitForLoginScreenOutcome();
+      if (outcome?.status === "invalid-credentials") {
+        return yield* failAttempt(INVALID_CREDENTIALS_ERROR, false);
+      }
+
+      if (outcome?.status === "stalled") {
+        return yield* failStalledLogin(outcome.detail);
+      }
+
+      return outcome?.status === "server-select";
+    });
 
   const waitForServers = waitFor(
     auth.getServers().pipe(
@@ -738,7 +834,7 @@ const make = Effect.gen(function* () {
         }
 
         yield* logStage("waiting for server select");
-        if (!(yield* waitForServerSelect)) {
+        if (!(yield* waitForServerSelect())) {
           return yield* failAttempt("server select did not load", true);
         }
 
@@ -832,7 +928,7 @@ const make = Effect.gen(function* () {
           }
 
           yield* logStage("waiting for server select");
-          if (!(yield* waitForServerSelect)) {
+          if (!(yield* waitForServerSelect())) {
             return yield* failAttempt("server select did not load", true);
           }
 


### PR DESCRIPTION
Summary:
- Detect invalid AQW credentials during Auto Relogin login waits and fail without retrying.
- Treat visible conn-detail cancel/back state during login as a retryable stalled-login failure.
- Add coverage for invalid credentials and stalled authentication states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error detection to better identify and report invalid credentials.
  * Enhanced handling for stalled authentication scenarios with automatic connection recovery.
  * Refined auto-relogin logic to prevent unnecessary retry attempts on authentication failures.

* **Tests**
  * Added test coverage for invalid credential and authentication timeout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->