### PR TITLE
fix: handle invalid map joins

### DIFF
--- a/app/src/renderer/windows/game/flash/Layers/Player.test.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Player.test.ts
@@ -1,0 +1,187 @@
+import { Effect, Layer, Option } from "effect";
+import { expect, test } from "vitest";
+import { Auth, type AuthShape } from "../Services/Auth";
+import { Bridge, type BridgeShape } from "../Services/Bridge";
+import { Inventory, type InventoryShape } from "../Services/Inventory";
+import {
+  Packet,
+  type ExtensionPacketHandler,
+  type PacketShape,
+} from "../Services/Packet";
+import { Player, type PlayerShape } from "../Services/Player";
+import { World, type WorldShape } from "../Services/World";
+import { PlayerLive } from "./Player";
+
+const auth = {
+  isLoggedIn: () => Effect.succeed(true),
+} as unknown as AuthShape;
+
+const inventory = {} as InventoryShape;
+
+const makeWorld = (state: {
+  readonly isLoaded: () => boolean;
+  readonly mapName: () => string;
+  readonly roomNumber: () => number;
+}): WorldShape =>
+  ({
+    map: {
+      isLoaded: () => Effect.succeed(state.isLoaded()),
+      getName: () => Effect.succeed(state.mapName()),
+      getRoomNumber: () => Effect.succeed(state.roomNumber()),
+      waitForGameAction: () => Effect.succeed(true),
+      getCells: () => Effect.succeed([]),
+    },
+    players: {
+      withSelf: () => Effect.succeed(Option.none()),
+    },
+  }) as unknown as WorldShape;
+
+const makePacket = (state: {
+  warningHandler: ExtensionPacketHandler | undefined;
+  disposed: boolean;
+}): PacketShape =>
+  ({
+    str(cmd: string, handler: ExtensionPacketHandler) {
+      expect(cmd).toBe("warning");
+      state.warningHandler = handler;
+      return Effect.succeed(() => {
+        state.warningHandler = undefined;
+        state.disposed = true;
+      });
+    },
+  }) as unknown as PacketShape;
+
+const withPlayer = async <A>(
+  services: {
+    readonly bridge: BridgeShape;
+    readonly packet: PacketShape;
+    readonly world: WorldShape;
+  },
+  body: (player: PlayerShape) => Effect.Effect<A, unknown>,
+): Promise<A> =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const player = yield* Player;
+        return yield* body(player);
+      }),
+    ).pipe(
+      Effect.provide(
+        PlayerLive.pipe(
+          Layer.provide(
+            Layer.mergeAll(
+              Layer.succeed(Auth)(auth),
+              Layer.succeed(Bridge)(services.bridge),
+              Layer.succeed(Inventory)(inventory),
+              Layer.succeed(Packet)(services.packet),
+              Layer.succeed(World)(services.world),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+test("joinMap returns promptly when the server warns that the target map is invalid", async () => {
+  const packetState = {
+    warningHandler: undefined as ExtensionPacketHandler | undefined,
+    disposed: false,
+  };
+  const bridgeCalls: unknown[][] = [];
+
+  const bridge = {
+    call(path, args) {
+      expect(path).toBe("player.joinMap");
+      bridgeCalls.push(args ?? []);
+
+      return Effect.gen(function* () {
+        const handler = packetState.warningHandler;
+        expect(handler).toBeDefined();
+
+        yield* handler!({
+          type: "extension",
+          raw: "",
+          packetType: "str",
+          cmd: "warning",
+          data: [
+            "warning",
+            "-1",
+            '"highcommand" is an Membership-Only Map.',
+          ],
+        });
+      }) as never;
+    },
+    callGameFunction: () => Effect.void,
+    onConnection: () => Effect.succeed(() => undefined),
+  } as BridgeShape;
+
+  await withPlayer(
+    {
+      bridge,
+      packet: makePacket(packetState),
+      world: makeWorld({
+        isLoaded: () => false,
+        mapName: () => "",
+        roomNumber: () => 0,
+      }),
+    },
+    (player) => player.joinMap("highcommand"),
+  );
+
+  expect(bridgeCalls).toEqual([["highcommand"]]);
+  expect(packetState.disposed).toBe(true);
+});
+
+test("joinMap ignores invalid-map warnings for other maps", async () => {
+  const packetState = {
+    warningHandler: undefined as ExtensionPacketHandler | undefined,
+    disposed: false,
+  };
+  let loaded = false;
+  const bridgeCalls: unknown[][] = [];
+
+  const bridge = {
+    call(path, args) {
+      expect(path).toBe("player.joinMap");
+      bridgeCalls.push(args ?? []);
+
+      return Effect.gen(function* () {
+        const handler = packetState.warningHandler;
+        expect(handler).toBeDefined();
+
+        yield* handler!({
+          type: "extension",
+          raw: "",
+          packetType: "str",
+          cmd: "warning",
+          data: [
+            "warning",
+            "-1",
+            '"highcommand" is an Membership-Only Map.',
+          ],
+        });
+
+        loaded = true;
+      }) as never;
+    },
+    callGameFunction: () => Effect.void,
+    onConnection: () => Effect.succeed(() => undefined),
+  } as BridgeShape;
+
+  await withPlayer(
+    {
+      bridge,
+      packet: makePacket(packetState),
+      world: makeWorld({
+        isLoaded: () => loaded,
+        mapName: () => "battleon",
+        roomNumber: () => 1,
+      }),
+    },
+    (player) => player.joinMap("battleon"),
+  );
+
+  expect(bridgeCalls).toEqual([["battleon"]]);
+  expect(loaded).toBe(true);
+  expect(packetState.disposed).toBe(true);
+});

--- a/app/src/renderer/windows/game/flash/Layers/Player.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Player.ts
@@ -1,11 +1,12 @@
 import { Collection } from "@vexed/collection";
 import { Faction, type Avatar, type FactionData } from "@vexed/game";
 import { equalsIgnoreCase } from "@vexed/shared/string";
-import { Effect, Layer, Option, Random, Ref } from "effect";
+import { Deferred, Effect, Layer, Option, Random, Ref } from "effect";
 import { isRecord } from "../PacketPayload";
 import { Auth } from "../Services/Auth";
 import { Bridge } from "../Services/Bridge";
 import type { BridgeEffect } from "../Services/Bridge";
+import { Packet } from "../Services/Packet";
 import { Player } from "../Services/Player";
 import type { PlayerShape } from "../Services/Player";
 import { World } from "../Services/World";
@@ -78,8 +79,30 @@ const parseMapTarget = (map: string): Effect.Effect<MapTarget> =>
     };
   });
 
+const getWarningMessage = (data: unknown): string | undefined =>
+  Array.isArray(data) && typeof data[2] === "string" ? data[2] : undefined;
+
+const getQuotedWarningMap = (message: string): string | undefined =>
+  message.match(/^"([^"]+)"/)?.[1];
+
+const isInvalidMapWarningForTarget = (
+  message: string,
+  targetMap: MapTarget,
+): boolean => {
+  const warningMap = getQuotedWarningMap(message);
+  if (warningMap === undefined) {
+    return false;
+  }
+
+  return (
+    equalsIgnoreCase(warningMap, targetMap.name) ||
+    equalsIgnoreCase(warningMap, targetMap.map)
+  );
+};
+
 const make = Effect.gen(function* () {
   const bridge = yield* Bridge;
+  const packet = yield* Packet;
   const world = yield* World;
   const auth = yield* Auth;
   const inventory = yield* Inventory;
@@ -304,21 +327,43 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      if (cell === undefined && pad === undefined) {
-        yield* bridge.call("player.joinMap", [targetMap.map]);
-      } else if (cell !== undefined && pad === undefined) {
-        yield* bridge.call("player.joinMap", [targetMap.map, cell]);
-      } else {
-        yield* bridge.call("player.joinMap", [
-          targetMap.map,
-          cell ?? "Enter",
-          pad,
-        ]);
-      }
+      const invalidMapWarning = yield* Deferred.make<void>();
+      const disposeWarningListener = yield* packet.str("warning", (response) =>
+        Effect.gen(function* () {
+          const message = getWarningMessage(response.data);
+          if (
+            message === undefined ||
+            !isInvalidMapWarningForTarget(message, targetMap)
+          ) {
+            return;
+          }
 
-      const loadedTargetMap = yield* waitFor(isTargetMapLoaded(targetMap), {
-        timeout: "5 seconds",
-      });
+          yield* Deferred.succeed(invalidMapWarning, undefined).pipe(
+            Effect.asVoid,
+          );
+        }),
+      );
+
+      const loadedTargetMap = yield* Effect.gen(function* () {
+        if (cell === undefined && pad === undefined) {
+          yield* bridge.call("player.joinMap", [targetMap.map]);
+        } else if (cell !== undefined && pad === undefined) {
+          yield* bridge.call("player.joinMap", [targetMap.map, cell]);
+        } else {
+          yield* bridge.call("player.joinMap", [
+            targetMap.map,
+            cell ?? "Enter",
+            pad,
+          ]);
+        }
+
+        return yield* Effect.raceFirst(
+          waitFor(isTargetMapLoaded(targetMap), {
+            timeout: "5 seconds",
+          }),
+          Deferred.await(invalidMapWarning).pipe(Effect.as(false)),
+        );
+      }).pipe(Effect.ensuring(Effect.sync(disposeWarningListener)));
 
       if (!loadedTargetMap) {
         return;


### PR DESCRIPTION
## Summary

- Return promptly when AQW sends a target-map warning during `api.player.joinMap`.

- Add regression coverage for matching invalid-map warnings and ignoring unrelated warnings.
