### PR TITLE
fix: hide stacked topnav dividers

### DIFF
--- a/app/src/renderer/windows/game/style.css
+++ b/app/src/renderer/windows/game/style.css
@@ -616,7 +616,7 @@
   }
 
   .game-topnav__divider {
-    margin: 0 0.125rem;
+    display: none;
   }
 }
 
@@ -636,11 +636,5 @@
   .game-topnav__trigger.game-topnav__select-trigger {
     max-width: calc(50vw - 0.875rem);
     min-width: 5.75rem;
-  }
-}
-
-@media (max-width: 420px) {
-  .game-topnav__divider {
-    display: none;
   }
 }


### PR DESCRIPTION
## Summary
- Hide top nav dividers when the nav wraps into its stacked responsive layout
- Remove the narrower redundant divider hide rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated responsive design behavior for improved display on smaller screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->