### PR TITLE
fix: show autorelogin status during account launch

### DIFF
--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
@@ -15,7 +15,11 @@ import {
 } from "../../jobs/Services/Jobs";
 import { Player, type PlayerShape } from "../../flash/Services/Player";
 import { Settings, type SettingsShape } from "../../flash/Services/Settings";
-import { AutoRelogin, type AutoReloginShape } from "../Services/AutoRelogin";
+import {
+  AutoRelogin,
+  type AutoReloginShape,
+  type AutoReloginState,
+} from "../Services/AutoRelogin";
 import { AutoReloginLive } from "./AutoRelogin";
 
 const twigServer: ServerData = {
@@ -162,9 +166,7 @@ const withAutoRelogin = async <A>(
         }
 
         if (path === "flash.isConnMcBackButtonVisible") {
-          return (options.loginStalls === true) as ReturnType<
-            Window["swf"][K]
-          >;
+          return (options.loginStalls === true) as ReturnType<Window["swf"][K]>;
         }
 
         throw new Error(`unexpected bridge call: ${String(path)}`);
@@ -516,6 +518,34 @@ test("direct login without a server stops at server selection", async () => {
   ]);
 });
 
+test("direct login server selection prevents background relogin retry", async () => {
+  const result = await withAutoRelogin({}, (autoRelogin, harness) =>
+    Effect.gen(function* () {
+      yield* autoRelogin.enable();
+      yield* autoRelogin.setDelay(0);
+      harness.emitConnection("OnConnectionLost");
+      yield* Effect.sleep("10 millis");
+
+      const outcome = yield* autoRelogin.login({
+        username: "Hero",
+        password: "secret-password",
+      });
+      yield* harness.jobsState.task!;
+
+      return {
+        calls: harness.authCalls,
+        outcome,
+        state: yield* autoRelogin.getState(),
+      };
+    }),
+  );
+
+  expect(result.outcome).toEqual({ stage: "server-select" });
+  expect(result.calls).toEqual(["login:Hero:secret-password"]);
+  expect(result.state.attempting).toBe(false);
+  expect(result.state.waitingDelay).toBe(false);
+});
+
 test("direct login with a server waits for player readiness", async () => {
   const result = await withAutoRelogin({}, (autoRelogin, harness) =>
     Effect.gen(function* () {
@@ -536,6 +566,66 @@ test("direct login with a server waits for player readiness", async () => {
     "login:Hero:secret-password",
     "connectTo:Twig",
   ]);
+});
+
+test("direct login publishes busy and success state", async () => {
+  const states: AutoReloginState[] = [];
+  const result = await withAutoRelogin(
+    { playerReadyAfterConnectDelayMs: 10 },
+    (autoRelogin) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.onState((state) => {
+          states.push(state);
+        });
+
+        const outcome = yield* autoRelogin.login({
+          username: "Hero",
+          password: "secret-password",
+          server: "Twig",
+        });
+
+        return {
+          outcome,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(result.outcome).toEqual({ stage: "player-ready" });
+  expect(states.some((state) => state.attempting)).toBe(true);
+  expect(result.state.attempting).toBe(false);
+  expect(result.state.lastError).toBeUndefined();
+});
+
+test("direct login publishes failed state", async () => {
+  const states: AutoReloginState[] = [];
+  const result = await withAutoRelogin(
+    { invalidCredentials: true },
+    (autoRelogin) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.onState((state) => {
+          states.push(state);
+        });
+
+        const exit = yield* Effect.exit(
+          autoRelogin.login({
+            username: "Hero",
+            password: "wrong-password",
+            server: "Twig",
+          }),
+        );
+
+        return {
+          exit,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+  );
+
+  expect(Exit.isFailure(result.exit)).toBe(true);
+  expect(states.some((state) => state.attempting)).toBe(true);
+  expect(result.state.attempting).toBe(false);
+  expect(result.state.lastError).toBe("invalid username or password");
 });
 
 test("direct login fails explicitly when credentials are invalid", async () => {

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
@@ -439,6 +439,40 @@ const make = Effect.gen(function* () {
       state.ownedConnectionServerName = undefined;
     });
 
+  const markLoginStart = () =>
+    updateState((state) => {
+      state.attempting = true;
+      state.lastError = undefined;
+      state.attemptsRemaining = undefined;
+      state.ownedConnectionServerName = undefined;
+    });
+
+  const markLoginSuccess = () =>
+    updateState((state) => {
+      state.lastError = undefined;
+      state.attempting = false;
+      state.attemptsRemaining = undefined;
+      state.connected = true;
+      state.ownedConnectionServerName = undefined;
+      state.loggedOutSince = undefined;
+      state.lastAttemptAt = 0;
+    });
+
+  const markLoginFailure = (
+    error: unknown,
+    credentials: AutoLoginCredentials,
+  ) =>
+    updateState((state) => {
+      state.lastError = redacted(
+        formatReloginError(error),
+        credentials.password,
+      );
+      state.attempting = false;
+      state.attemptsRemaining = undefined;
+      state.connected = false;
+      state.ownedConnectionServerName = undefined;
+    });
+
   const markLoggedIn = () =>
     SynchronizedRef.update(stateRef, (state) => {
       // A ready player closes the disconnect window.
@@ -600,46 +634,47 @@ const make = Effect.gen(function* () {
     );
 
   const readConnDetailText = () =>
-    bridge.call("flash.getConnMcText").pipe(
-      Effect.catchCause(() =>
-        bridge
-          .call("flash.getGameObject", ["mcConnDetail.txtDetail.text"])
-          .pipe(Effect.catchCause(() => Effect.succeed(""))),
-      ),
-    );
+    bridge
+      .call("flash.getConnMcText")
+      .pipe(
+        Effect.catchCause(() =>
+          bridge
+            .call("flash.getGameObject", ["mcConnDetail.txtDetail.text"])
+            .pipe(Effect.catchCause(() => Effect.succeed(""))),
+        ),
+      );
 
-  const observeLoginScreenOutcome = (): Effect.Effect<
-    LoginScreenOutcome | null
-  > =>
-    Effect.gen(function* () {
-      const label = yield* bridge
-        .call("flash.getGameObject", ["mcLogin.currentLabel"])
-        .pipe(Effect.catchCause(() => Effect.succeed("")));
-      if (flashStringEquals(label, "Servers")) {
-        return { status: "server-select" } as const;
-      }
+  const observeLoginScreenOutcome =
+    (): Effect.Effect<LoginScreenOutcome | null> =>
+      Effect.gen(function* () {
+        const label = yield* bridge
+          .call("flash.getGameObject", ["mcLogin.currentLabel"])
+          .pipe(Effect.catchCause(() => Effect.succeed("")));
+        if (flashStringEquals(label, "Servers")) {
+          return { status: "server-select" } as const;
+        }
 
-      const [detail, backButtonVisible] = yield* Effect.all([
-        readConnDetailText(),
-        bridge
-          .call("flash.isConnMcBackButtonVisible")
-          .pipe(Effect.catchCause(() => Effect.succeed(false))),
-      ]);
-      if (flashStringEquals(detail, INVALID_CREDENTIALS_DETAIL)) {
-        return { status: "invalid-credentials" } as const;
-      }
+        const [detail, backButtonVisible] = yield* Effect.all([
+          readConnDetailText(),
+          bridge
+            .call("flash.isConnMcBackButtonVisible")
+            .pipe(Effect.catchCause(() => Effect.succeed(false))),
+        ]);
+        if (flashStringEquals(detail, INVALID_CREDENTIALS_DETAIL)) {
+          return { status: "invalid-credentials" } as const;
+        }
 
-      const decodedDetail = decodeFlashValue(detail);
-      const detailText =
-        typeof decodedDetail === "string" && decodedDetail !== "null"
-          ? decodedDetail.trim()
-          : "";
-      if (backButtonVisible && detailText !== "") {
-        return { status: "stalled", detail: detailText } as const;
-      }
+        const decodedDetail = decodeFlashValue(detail);
+        const detailText =
+          typeof decodedDetail === "string" && decodedDetail !== "null"
+            ? decodedDetail.trim()
+            : "";
+        if (backButtonVisible && detailText !== "") {
+          return { status: "stalled", detail: detailText } as const;
+        }
 
-      return null;
-    });
+        return null;
+      });
 
   const cancelStalledLogin = () =>
     auth.logout().pipe(
@@ -820,7 +855,7 @@ const make = Effect.gen(function* () {
       }
     });
 
-  const login = (
+  const performLogin = (
     credentials: AutoLoginCredentials,
   ): Effect.Effect<AutoLoginOutcome, unknown> =>
     withTemporaryLoginSettings(
@@ -884,6 +919,22 @@ const make = Effect.gen(function* () {
         return { stage: "player-ready" } as const;
       }),
     );
+
+  const login = (
+    credentials: AutoLoginCredentials,
+  ): Effect.Effect<AutoLoginOutcome, unknown> =>
+    Effect.gen(function* () {
+      yield* markLoginStart();
+      return yield* performLogin(credentials).pipe(
+        Effect.matchEffect({
+          onFailure: (error) =>
+            markLoginFailure(error, credentials).pipe(
+              Effect.andThen(Effect.fail(error)),
+            ),
+          onSuccess: (outcome) => markLoginSuccess().pipe(Effect.as(outcome)),
+        }),
+      );
+    });
 
   const loginAndWaitReady = (
     credentials: AutoLoginCredentials,


### PR DESCRIPTION
## Summary

- Publish direct account-manager AutoRelogin login attempts through the shared service state.
- Clear the transient status on success and keep login failures visible through lastError.
- Cover direct login success and failure state emissions in AutoRelogin tests.
