### PR TITLE
refactor(settings): store hotkeys as binding array

### DIFF
--- a/app/src/main/settings-service.ts
+++ b/app/src/main/settings-service.ts
@@ -184,7 +184,7 @@ export const resetAppearance = (): AppSettings => {
 
 export const updateHotkeys = (patch: HotkeysPatch): AppSettings => {
   const current = HotkeysSettings.read();
-  const next = isRecord(patch.bindings)
+  const next = Array.isArray(patch.bindings)
     ? HotkeysSettings.applyPatch(current, patch.bindings)
     : current;
 

--- a/app/src/main/settings/Hotkeys.test.ts
+++ b/app/src/main/settings/Hotkeys.test.ts
@@ -7,8 +7,12 @@ import {
   normalize,
   normalizeHotkeyValue,
   path,
+  write,
 } from "./Hotkeys";
-import { normalizeHotkeyBinding } from "../../shared/hotkeys";
+import {
+  normalizeHotkeyBinding,
+  readHotkeyBinding,
+} from "../../shared/hotkeys";
 
 describe("hotkey settings", () => {
   afterEach(() => {
@@ -16,17 +20,13 @@ describe("hotkey settings", () => {
   });
 
   it("normalizes valid bindings", () => {
-    expect(
-      normalize({
-        bindings: {
-          "load-script": "mod+o",
-          "toggle-lag-killer": "alt+l",
-        },
-      }).bindings,
-    ).toMatchObject({
-      "load-script": "Mod+O",
-      "toggle-lag-killer": "Alt+L",
-    });
+    const bindings = normalize([
+      { id: "loadScript", value: "mod+o" },
+      { id: "toggleLagKiller", value: "alt+l" },
+    ]).bindings;
+
+    expect(readHotkeyBinding(bindings, "loadScript")).toBe("Mod+O");
+    expect(readHotkeyBinding(bindings, "toggleLagKiller")).toBe("Alt+L");
   });
 
   it("supports platform-explicit macOS Control bindings", () => {
@@ -36,49 +36,53 @@ describe("hotkey settings", () => {
 
   it("discards unknown command ids", () => {
     expect(
-      normalize({
-        bindings: {
-          "load-script": "Mod+O",
-          unknown: "Alt+U",
-        },
-      }).bindings,
-    ).not.toHaveProperty("unknown");
+      normalize([
+        { id: "loadScript", value: "Mod+O" },
+        { id: "unknown", value: "Alt+U" },
+      ]).bindings.some((binding) => (binding.id as string) === "unknown"),
+    ).toBe(false);
   });
 
   it("falls back to defaults for invalid values", () => {
-    expect(
-      normalize({
-        bindings: {
-          "load-script": "Control",
-        },
-      }).bindings["load-script"],
-    ).toBe(DEFAULT.bindings["load-script"]);
+    const bindings = normalize([
+      { id: "loadScript", value: "Control" },
+    ]).bindings;
+
+    expect(readHotkeyBinding(bindings, "loadScript")).toBe(
+      readHotkeyBinding(DEFAULT.bindings, "loadScript"),
+    );
 
     expect(normalizeHotkeyValue("Control")).toBeUndefined();
   });
 
   it("preserves empty strings as unbound", () => {
     expect(
-      normalize({
-        bindings: {
-          "load-script": "",
-        },
-      }).bindings["load-script"],
+      readHotkeyBinding(
+        normalize([{ id: "loadScript", value: "" }]).bindings,
+        "loadScript",
+      ),
     ).toBe("");
   });
 
   it("resets null patch values to defaults", () => {
-    const customized = normalize({
-      bindings: {
-        "load-script": "Alt+O",
-      },
-    });
+    const customized = normalize([{ id: "loadScript", value: "Alt+O" }]);
 
     expect(
-      applyPatch(customized, {
-        "load-script": null,
-      }).bindings["load-script"],
-    ).toBe(DEFAULT.bindings["load-script"]);
+      readHotkeyBinding(
+        applyPatch(customized, [{ id: "loadScript", value: null }]).bindings,
+        "loadScript",
+      ),
+    ).toBe(readHotkeyBinding(DEFAULT.bindings, "loadScript"));
+  });
+
+  it("writes keybindings as a top-level array", () => {
+    Files.configureAppDataHome("/tmp/vexed-test");
+
+    write(normalize([{ id: "loadScript", value: "Alt+O" }]));
+
+    expect(Files.readJson(path())).toEqual(
+      expect.arrayContaining([{ id: "loadScript", value: "Alt+O" }]),
+    );
   });
 
   it("resolves hotkeys under app data", () => {

--- a/app/src/main/settings/Hotkeys.ts
+++ b/app/src/main/settings/Hotkeys.ts
@@ -1,7 +1,8 @@
 import * as Files from "./Files";
-import { GAME_COMMANDS, isGameCommandId } from "../../shared/commands";
+import { isGameCommandId, type GameCommandId } from "../../shared/commands";
 import {
   DEFAULT_HOTKEYS,
+  createHotkeyBindings,
   createDefaultHotkeyBindings,
   normalizeHotkeyBinding,
   type HotkeyBindings,
@@ -23,29 +24,31 @@ const platform: HotkeyPlatform =
 export const normalizeHotkeyValue = (value: unknown): string | undefined =>
   normalizeHotkeyBinding(value, platform);
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const readBindingEntries = (
+  value: unknown,
+): readonly Record<string, unknown>[] =>
+  Array.isArray(value) ? value.filter(isRecord) : [];
+
 export const normalize = (value: unknown): HotkeysSettings => {
-  const defaults = createDefaultHotkeyBindings();
-  if (typeof value !== "object" || value === null) {
-    return {
-      bindings: defaults,
-    };
-  }
+  const values = new Map<GameCommandId, string>();
 
-  const record = value as Record<string, unknown>;
-  const rawBindings =
-    typeof record["bindings"] === "object" && record["bindings"] !== null
-      ? (record["bindings"] as Record<string, unknown>)
-      : {};
-  const bindings: HotkeyBindings = {};
+  for (const entry of readBindingEntries(value)) {
+    const id = entry["id"];
+    if (!isGameCommandId(id)) {
+      continue;
+    }
 
-  for (const command of GAME_COMMANDS) {
-    const rawValue = rawBindings[command.id];
+    const rawValue = entry["value"];
     const normalized = normalizeHotkeyValue(rawValue);
-    bindings[command.id] =
-      normalized === undefined ? (defaults[command.id] ?? "") : normalized;
+    if (normalized !== undefined) {
+      values.set(id, normalized);
+    }
   }
 
-  return { bindings };
+  return { bindings: createHotkeyBindings(values) };
 };
 
 export const path = (): string => Files.appDataJoin("keybindings.json");
@@ -53,36 +56,40 @@ export const path = (): string => Files.appDataJoin("keybindings.json");
 export const read = (): HotkeysSettings => normalize(Files.readJson(path()));
 
 export const write = (settings: HotkeysSettings): void => {
-  Files.writeJson(path(), normalize(settings));
+  Files.writeJson(path(), normalize(settings.bindings).bindings);
 };
 
 export const ensure = (): HotkeysSettings =>
-  Files.ensureJson(path(), DEFAULT, normalize);
+  Files.ensureJson(path(), DEFAULT, normalize, (settings) => settings.bindings);
 
 export const applyPatch = (
   current: HotkeysSettings,
-  patch: Record<string, unknown>,
+  patch: readonly unknown[],
 ): HotkeysSettings => {
-  const defaults = createDefaultHotkeyBindings();
-  const bindings: HotkeyBindings = {
-    ...current.bindings,
-  };
+  const defaults = new Map(
+    createDefaultHotkeyBindings().map((binding) => [binding.id, binding.value]),
+  );
+  const values = new Map(
+    current.bindings.map((binding) => [binding.id, binding.value]),
+  );
 
-  for (const [id, rawValue] of Object.entries(patch)) {
-    if (!isGameCommandId(id)) {
+  for (const entry of patch) {
+    if (!isRecord(entry) || !isGameCommandId(entry["id"])) {
       continue;
     }
 
+    const id = entry["id"];
+    const rawValue = entry["value"];
     if (rawValue === null) {
-      bindings[id] = defaults[id] ?? "";
+      values.set(id, defaults.get(id) ?? "");
       continue;
     }
 
     const normalized = normalizeHotkeyValue(rawValue);
     if (normalized !== undefined) {
-      bindings[id] = normalized;
+      values.set(id, normalized);
     }
   }
 
-  return normalize({ bindings });
+  return { bindings: createHotkeyBindings(values) };
 };

--- a/app/src/renderer/windows/environment/style.css
+++ b/app/src/renderer/windows/environment/style.css
@@ -76,7 +76,6 @@
   font-size: var(--text-sm);
   line-height: 1.35;
   padding: 0.625rem 0.75rem;
-  text-wrap: pretty;
 }
 
 .environment-grid {

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -1138,10 +1138,7 @@ export default function App(props: {
 
   return (
     <main class="game-shell">
-      <GameHotkeys
-        bindings={() => settings().hotkeys.bindings}
-        commands={() => gameCommands}
-      />
+      <GameHotkeys commands={() => gameCommands} />
       <Show when={topBarVisible()}>
         <TopNav
           openMenu={openTopNavMenu}

--- a/app/src/renderer/windows/game/TopNav.tsx
+++ b/app/src/renderer/windows/game/TopNav.tsx
@@ -35,11 +35,11 @@ import {
   MenuTrigger,
   cn,
 } from "@vexed/ui";
+import type { GameCommandId } from "../../../shared/commands";
 import {
-  getCommandDefinition,
-  type GameCommandId,
-} from "../../../shared/commands";
-import type { HotkeyBindings } from "../../../shared/hotkeys";
+  readHotkeyBinding,
+  type HotkeyBindings,
+} from "../../../shared/hotkeys";
 import type { AppPlatform } from "../../../shared/ipc";
 import {
   WindowIds,
@@ -119,7 +119,7 @@ export interface TopNavProps {
 }
 
 const commandHotkey = (bindings: HotkeyBindings, id: GameCommandId): string =>
-  bindings[id] ?? getCommandDefinition(id).defaultHotkey;
+  readHotkeyBinding(bindings, id);
 
 const optionHotkey = (bindings: HotkeyBindings, optionId: string): string => {
   const commandId = getTopNavOptionCommandId(optionId);
@@ -127,12 +127,12 @@ const optionHotkey = (bindings: HotkeyBindings, optionId: string): string => {
 };
 
 const windowCommandIds: Partial<Record<WindowId, GameCommandId>> = {
-  [WindowIds.Environment]: "open-environment",
-  [WindowIds.FastTravels]: "open-fast-travels",
-  [WindowIds.LoaderGrabber]: "open-loader-grabber",
-  [WindowIds.Follower]: "open-follower",
-  [WindowIds.PacketLogger]: "open-packet-logger",
-  [WindowIds.PacketSpammer]: "open-packet-spammer",
+  [WindowIds.Environment]: "openEnvironment",
+  [WindowIds.FastTravels]: "openFastTravels",
+  [WindowIds.LoaderGrabber]: "openLoaderGrabber",
+  [WindowIds.Follower]: "openFollower",
+  [WindowIds.PacketLogger]: "openPacketLogger",
+  [WindowIds.PacketSpammer]: "openPacketSpammer",
 };
 
 const windowHotkey = (bindings: HotkeyBindings, id: WindowId): string => {
@@ -462,12 +462,12 @@ export function TopNav(props: TopNavProps): JSX.Element {
                 <MenuItem
                   class="game-menu__item"
                   onSelect={() => void props.loadScript()}
-                  value="load-script"
+                  value="loadScript"
                 >
                   <span class="game-menu__item-label">Load Script</span>
                   <Show
                     when={formatOptionalHotkeyDisplay(
-                      commandHotkey(props.hotkeyBindings(), "load-script"),
+                      commandHotkey(props.hotkeyBindings(), "loadScript"),
                       props.hotkeyPlatform,
                     )}
                   >
@@ -486,13 +486,13 @@ export function TopNav(props: TopNavProps): JSX.Element {
                   class="game-menu__item"
                   disabled={!props.scriptRunning()}
                   onSelect={props.stopScript}
-                  value="stop-script"
+                  value="stopScript"
                   variant="destructive"
                 >
                   <span class="game-menu__item-label">Stop</span>
                   <Show
                     when={formatOptionalHotkeyDisplay(
-                      commandHotkey(props.hotkeyBindings(), "stop-script"),
+                      commandHotkey(props.hotkeyBindings(), "stopScript"),
                       props.hotkeyPlatform,
                     )}
                   >
@@ -689,7 +689,9 @@ export function TopNav(props: TopNavProps): JSX.Element {
               }
             >
               <span>Auto Relogin</span>
-              <Show when={props.autoReloginEnabled() && props.autoReloginServer()}>
+              <Show
+                when={props.autoReloginEnabled() && props.autoReloginServer()}
+              >
                 <span class="game-topnav__trigger-detail">
                   {props.autoReloginServer()}
                 </span>

--- a/app/src/renderer/windows/game/commands.test.ts
+++ b/app/src/renderer/windows/game/commands.test.ts
@@ -18,7 +18,7 @@ const createRuntime = (
   };
 
   return {
-    bindings: () => ({}) satisfies HotkeyBindings,
+    bindings: () => [] satisfies HotkeyBindings,
     loadScript: noop,
     startScript: noop,
     stopScript: noop,
@@ -54,7 +54,7 @@ describe("game commands", () => {
     const openTopNavMenu = vi.fn();
     const runtime = createRuntime({ openTopNavMenu });
 
-    findCommand(runtime, "open-options-menu").run();
+    findCommand(runtime, "openOptionsMenu").run();
 
     expect(openTopNavMenu).toHaveBeenCalledWith("options");
   });
@@ -63,7 +63,7 @@ describe("game commands", () => {
     const toggleTopBarVisible = vi.fn();
     const runtime = createRuntime({ toggleTopBarVisible });
 
-    findCommand(runtime, "toggle-top-bar").run();
+    findCommand(runtime, "toggleTopBar").run();
 
     expect(toggleTopBarVisible).toHaveBeenCalledOnce();
   });
@@ -80,7 +80,7 @@ describe("game commands", () => {
     ];
     const runtime = createRuntime({ optionItems });
 
-    const command = findCommand(runtime, "toggle-lag-killer");
+    const command = findCommand(runtime, "toggleLagKiller");
 
     expect(command.label()).toBe("Lag Killer");
 
@@ -88,5 +88,4 @@ describe("game commands", () => {
 
     expect(onSelect).toHaveBeenCalledOnce();
   });
-
 });

--- a/app/src/renderer/windows/game/commands.ts
+++ b/app/src/renderer/windows/game/commands.ts
@@ -5,7 +5,10 @@ import {
   type GameCommandId,
 } from "../../../shared/commands";
 import { WindowIds, type WindowId } from "../../../shared/windows";
-import type { HotkeyBindings } from "../../../shared/hotkeys";
+import {
+  readHotkeyBinding,
+  type HotkeyBindings,
+} from "../../../shared/hotkeys";
 import {
   findTopNavOption,
   topNavOptionCommandIds,
@@ -39,12 +42,12 @@ export interface GameCommand {
 }
 
 const windowCommandIds: Partial<Record<GameCommandId, WindowId>> = {
-  "open-environment": WindowIds.Environment,
-  "open-fast-travels": WindowIds.FastTravels,
-  "open-loader-grabber": WindowIds.LoaderGrabber,
-  "open-follower": WindowIds.Follower,
-  "open-packet-logger": WindowIds.PacketLogger,
-  "open-packet-spammer": WindowIds.PacketSpammer,
+  openEnvironment: WindowIds.Environment,
+  openFastTravels: WindowIds.FastTravels,
+  openLoaderGrabber: WindowIds.LoaderGrabber,
+  openFollower: WindowIds.Follower,
+  openPacketLogger: WindowIds.PacketLogger,
+  openPacketSpammer: WindowIds.PacketSpammer,
 };
 
 const findOption = (
@@ -59,11 +62,11 @@ const createCommandLabel = (
   id: GameCommandId,
   fallback: string,
 ): Accessor<string> => {
-  if (id === "toggle-script") {
+  if (id === "toggleScript") {
     return () => (runtime.scriptRunning() ? "Stop Script" : "Start Script");
   }
 
-  if (id === "toggle-autoattack") {
+  if (id === "toggleAutoattack") {
     return () =>
       runtime.autoAttackEnabled() ? "Disable Autoattack" : "Enable Autoattack";
   }
@@ -79,11 +82,11 @@ const createCommandEnabled = (
   runtime: GameCommandRuntime,
   id: GameCommandId,
 ): Accessor<boolean> => {
-  if (id === "toggle-script") {
+  if (id === "toggleScript") {
     return () => runtime.scriptLoaded();
   }
 
-  if (id === "stop-script") {
+  if (id === "stopScript") {
     return () => runtime.scriptRunning();
   }
 
@@ -101,13 +104,13 @@ const createCommandRunner = (
   runtime: GameCommandRuntime,
   id: GameCommandId,
 ): (() => void) => {
-  if (id === "load-script") {
+  if (id === "loadScript") {
     return () => {
       void runtime.loadScript();
     };
   }
 
-  if (id === "toggle-script") {
+  if (id === "toggleScript") {
     return () => {
       if (!runtime.scriptLoaded()) {
         return;
@@ -121,7 +124,7 @@ const createCommandRunner = (
     };
   }
 
-  if (id === "stop-script") {
+  if (id === "stopScript") {
     return () => {
       if (runtime.scriptRunning()) {
         runtime.stopScript();
@@ -129,17 +132,17 @@ const createCommandRunner = (
     };
   }
 
-  if (id === "toggle-autoattack") {
+  if (id === "toggleAutoattack") {
     return () => {
       runtime.setAutoAttackEnabled((enabled) => !enabled);
     };
   }
 
-  if (id === "open-options-menu") {
+  if (id === "openOptionsMenu") {
     return () => runtime.openTopNavMenu("options");
   }
 
-  if (id === "toggle-top-bar") {
+  if (id === "toggleTopBar") {
     return runtime.toggleTopBarVisible;
   }
 
@@ -173,8 +176,7 @@ export const createGameCommands = (
       category: definition.category,
       label: createCommandLabel(runtime, definition.id, definition.label),
       keywords: definition.keywords,
-      hotkey: () =>
-        runtime.bindings()[definition.id] ?? definition.defaultHotkey,
+      hotkey: () => readHotkeyBinding(runtime.bindings(), definition.id),
       enabled,
       run: () => {
         if (enabled()) {

--- a/app/src/renderer/windows/game/hotkeys.tsx
+++ b/app/src/renderer/windows/game/hotkeys.tsx
@@ -1,7 +1,6 @@
 import { createHotkey } from "@tanstack/solid-hotkeys";
 import type { RegisterableHotkey } from "@tanstack/solid-hotkeys";
 import { For, Show, type Accessor, type JSX } from "solid-js";
-import type { HotkeyBindings } from "../../../shared/hotkeys";
 import type { GameCommand } from "./commands";
 
 function GameHotkeyRegistration(props: {
@@ -30,12 +29,11 @@ function GameHotkeyRegistration(props: {
 
 export function GameHotkeys(props: {
   readonly commands: Accessor<readonly GameCommand[]>;
-  readonly bindings: Accessor<HotkeyBindings>;
 }): JSX.Element {
   return (
     <For each={props.commands()}>
       {(command) => (
-        <Show when={props.bindings()[command.id] ?? command.hotkey()}>
+        <Show when={command.hotkey()}>
           <GameHotkeyRegistration command={command} />
         </Show>
       )}

--- a/app/src/renderer/windows/game/topNavOptions.ts
+++ b/app/src/renderer/windows/game/topNavOptions.ts
@@ -18,15 +18,15 @@ export interface TopNavOptionItem {
 }
 
 export const topNavOptionCommandIds: Partial<Record<GameCommandId, string>> = {
-  "toggle-infinite-range": "infinite-range",
-  "toggle-provoke-cell": "provoke-cell",
-  "toggle-enemy-magnet": "enemy-magnet",
-  "toggle-lag-killer": "lag-killer",
-  "toggle-hide-players": "hide-players",
-  "toggle-skip-cutscenes": "skip-cutscenes",
-  "toggle-disable-fx": "disable-fx",
-  "toggle-collisions": "collisions",
-  "toggle-death-ads": "death-ads",
+  toggleInfiniteRange: "infinite-range",
+  toggleProvokeCell: "provoke-cell",
+  toggleEnemyMagnet: "enemy-magnet",
+  toggleLagKiller: "lag-killer",
+  toggleHidePlayers: "hide-players",
+  toggleSkipCutscenes: "skip-cutscenes",
+  toggleDisableFx: "disable-fx",
+  toggleCollisions: "collisions",
+  toggleDeathAds: "death-ads",
 };
 
 const commandIdsByOptionId = new Map<string, GameCommandId>(

--- a/app/src/renderer/windows/settings/App.tsx
+++ b/app/src/renderer/windows/settings/App.tsx
@@ -6,10 +6,12 @@ import {
   formatHotkeyDisplayParts as displayHotkeyParts,
 } from "@vexed/shared/hotkeyDisplay";
 import {
+  Alert,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
+  AlertDescription,
   AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
@@ -38,7 +40,7 @@ import {
   TooltipTrigger,
   type ButtonProps,
 } from "@vexed/ui";
-import { RotateCcw, X } from "lucide-solid";
+import { CircleAlert, RotateCcw, X } from "lucide-solid";
 import {
   For,
   Show,
@@ -58,6 +60,7 @@ import {
   type GameCommandId,
 } from "../../../shared/commands";
 import {
+  readHotkeyBinding,
   normalizeHotkeyBinding,
   type HotkeyBindings,
 } from "../../../shared/hotkeys";
@@ -219,6 +222,28 @@ function SettingsRow(props: {
       </div>
       <div class="settings-row__action">{props.action}</div>
     </div>
+  );
+}
+
+function SettingsErrorNotice(props: {
+  readonly id: number;
+  readonly message: string;
+  readonly scope?: "global" | "hotkeys";
+}): JSX.Element {
+  return (
+    <Alert
+      aria-live="polite"
+      class="settings-error"
+      data-error-id={props.id}
+      data-scope={props.scope}
+      role="alert"
+      variant="error"
+    >
+      <AlertDescription class="settings-error__message">
+        <CircleAlert aria-hidden="true" class="settings-error__icon" />
+        {props.message}
+      </AlertDescription>
+    </Alert>
   );
 }
 
@@ -529,8 +554,7 @@ function GeneralSettings(props: {
 }
 
 const readHotkey = (bindings: HotkeyBindings, id: GameCommandId): string => {
-  const definition = GAME_COMMANDS.find((command) => command.id === id);
-  return bindings[id] ?? definition?.defaultHotkey ?? "";
+  return readHotkeyBinding(bindings, id);
 };
 
 const getConflictingLabels = (
@@ -557,19 +581,26 @@ function HotkeySettingsSection(props: {
   const [recordingId, setRecordingId] = createSignal<GameCommandId | null>(
     null,
   );
-  const [localError, setLocalError] = createSignal<string | null>(null);
+  const [localError, setLocalError] = createSignal<{
+    readonly id: number;
+    readonly message: string;
+  } | null>(null);
+  let nextLocalErrorId = 0;
+
+  const showLocalError = (message: string): void => {
+    setLocalError({ id: ++nextLocalErrorId, message });
+  };
 
   const commitBinding = async (
     id: GameCommandId,
     value: string | null,
   ): Promise<void> => {
-    setLocalError(null);
     const definition = GAME_COMMANDS.find((command) => command.id === id);
 
     if (value !== null) {
       const normalized = normalizeHotkeyBinding(value, props.platform);
       if (normalized === undefined) {
-        setLocalError("That shortcut is not valid.");
+        showLocalError("That shortcut is not valid.");
         return;
       }
 
@@ -579,15 +610,14 @@ function HotkeySettingsSection(props: {
         normalized,
       );
       if (conflicts.length > 0) {
-        setLocalError(`Shortcut already used by ${conflicts.join(", ")}.`);
+        showLocalError(`Shortcut already used by ${conflicts.join(", ")}.`);
         return;
       }
 
       await props.onHotkeysPatch({
-        bindings: {
-          [id]: normalized,
-        },
+        bindings: [{ id, value: normalized }],
       });
+      setLocalError(null);
       return;
     }
 
@@ -598,17 +628,16 @@ function HotkeySettingsSection(props: {
       defaultValue,
     );
     if (conflicts.length > 0) {
-      setLocalError(
+      showLocalError(
         `Default shortcut already used by ${conflicts.join(", ")}.`,
       );
       return;
     }
 
     await props.onHotkeysPatch({
-      bindings: {
-        [id]: null,
-      },
+      bindings: [{ id, value: null }],
     });
+    setLocalError(null);
   };
 
   createEffect(() => {
@@ -622,6 +651,7 @@ function HotkeySettingsSection(props: {
       event.stopPropagation();
 
       if (event.key === "Escape") {
+        setLocalError(null);
         setRecordingId(null);
         return;
       }
@@ -637,7 +667,7 @@ function HotkeySettingsSection(props: {
         props.platform,
       );
       if (normalized === undefined) {
-        setLocalError("Press a complete shortcut.");
+        showLocalError("Press a complete shortcut.");
         return;
       }
 
@@ -769,7 +799,13 @@ function HotkeySettingsSection(props: {
       }
     >
       <Show when={localError()}>
-        {(message) => <div class="settings-error">{message()}</div>}
+        {(notice) => (
+          <SettingsErrorNotice
+            id={notice().id}
+            message={notice().message}
+            scope="hotkeys"
+          />
+        )}
       </Show>
 
       <div class="hotkey-layouts--continuous">
@@ -1035,18 +1071,26 @@ function SettingsApp(props: {
   const [settings, setSettings] = createSignal<AppSettings>(
     props.initialSettings ?? defaultSettings,
   );
-  const [error, setError] = createSignal<string | null>(null);
+  const [error, setError] = createSignal<{
+    readonly id: number;
+    readonly message: string;
+  } | null>(null);
   const [activeTab, setActiveTab] = createSignal<SettingsTabId>("general");
+  let nextErrorId = 0;
+
+  const showError = (message: string): void => {
+    setError({ id: ++nextErrorId, message });
+  };
 
   const runSettingsUpdate = async (
     update: Promise<AppSettings>,
   ): Promise<void> => {
     try {
-      setError(null);
       setSettings(await update);
+      setError(null);
     } catch (cause) {
       console.error("Failed to update settings:", cause);
-      setError(
+      showError(
         cause instanceof Error ? cause.message : "Settings update failed",
       );
     }
@@ -1059,7 +1103,7 @@ function SettingsApp(props: {
         .then(setSettings)
         .catch((cause: unknown) => {
           console.error("Failed to load settings:", cause);
-          setError(
+          showError(
             cause instanceof Error ? cause.message : "Settings unavailable",
           );
         });
@@ -1092,7 +1136,13 @@ function SettingsApp(props: {
             </div>
             <div class="settings-content-wrapper">
               <Show when={error()}>
-                {(message) => <div class="settings-error">{message()}</div>}
+                {(notice) => (
+                  <SettingsErrorNotice
+                    id={notice().id}
+                    message={notice().message}
+                    scope="global"
+                  />
+                )}
               </Show>
               <TabsContent value="general">
                 <GeneralSettings

--- a/app/src/renderer/windows/settings/style.css
+++ b/app/src/renderer/windows/settings/style.css
@@ -472,15 +472,27 @@
   min-width: 0;
 }
 
-.settings-error {
-  background: rgba(var(--destructive), 0.12);
-  border: 1px solid rgba(var(--destructive), 0.45);
+.settings-error.alert {
   border-radius: var(--radius-md);
   color: rgb(var(--destructive));
-  font-size: var(--text-base);
   margin: 0;
   max-width: 100%;
-  padding: 0.75rem 1rem;
+  min-height: 2.75rem;
+}
+
+.settings-error__message.alert__description {
+  align-items: flex-start;
+  color: inherit;
+  display: flex;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.settings-error__icon {
+  flex: 0 0 auto;
+  height: 0.875rem;
+  margin-top: 0.125rem;
+  width: 0.875rem;
 }
 
 .hotkey-settings-header-actions {

--- a/app/src/shared/commands.test.ts
+++ b/app/src/shared/commands.test.ts
@@ -38,17 +38,19 @@ describe("game command registry", () => {
   it("creates defaults for every command", () => {
     const defaults = getDefaultHotkeys();
 
-    expect(Object.keys(defaults).sort()).toEqual([...GAME_COMMAND_IDS].sort());
+    expect(defaults.map((binding) => binding.id).sort()).toEqual(
+      [...GAME_COMMAND_IDS].sort(),
+    );
   });
 
   it("groups environment with tool commands", () => {
     expect(
-      GAME_COMMANDS.find((command) => command.id === "open-environment"),
+      GAME_COMMANDS.find((command) => command.id === "openEnvironment"),
     ).toEqual(expect.objectContaining({ category: "Tools" }));
   });
 
   it("validates command ids", () => {
-    expect(isGameCommandId("load-script")).toBe(true);
+    expect(isGameCommandId("loadScript")).toBe(true);
     expect(isGameCommandId("missing-command")).toBe(false);
     expect(isGameCommandId(null)).toBe(false);
   });

--- a/app/src/shared/commands.ts
+++ b/app/src/shared/commands.ts
@@ -8,27 +8,27 @@ export type CommandCategory =
   | "Packets";
 
 export type GameCommandId =
-  | "toggle-top-bar"
-  | "load-script"
-  | "toggle-script"
-  | "stop-script"
-  | "open-options-menu"
-  | "open-environment"
-  | "open-fast-travels"
-  | "open-loader-grabber"
-  | "open-follower"
-  | "open-packet-logger"
-  | "open-packet-spammer"
-  | "toggle-autoattack"
-  | "toggle-infinite-range"
-  | "toggle-provoke-cell"
-  | "toggle-enemy-magnet"
-  | "toggle-lag-killer"
-  | "toggle-hide-players"
-  | "toggle-skip-cutscenes"
-  | "toggle-disable-fx"
-  | "toggle-collisions"
-  | "toggle-death-ads";
+  | "toggleTopBar"
+  | "loadScript"
+  | "toggleScript"
+  | "stopScript"
+  | "openOptionsMenu"
+  | "openEnvironment"
+  | "openFastTravels"
+  | "openLoaderGrabber"
+  | "openFollower"
+  | "openPacketLogger"
+  | "openPacketSpammer"
+  | "toggleAutoattack"
+  | "toggleInfiniteRange"
+  | "toggleProvokeCell"
+  | "toggleEnemyMagnet"
+  | "toggleLagKiller"
+  | "toggleHidePlayers"
+  | "toggleSkipCutscenes"
+  | "toggleDisableFx"
+  | "toggleCollisions"
+  | "toggleDeathAds";
 
 export interface CommandDefinition {
   readonly id: GameCommandId;
@@ -39,19 +39,22 @@ export interface CommandDefinition {
   readonly defaultHotkey: string;
 }
 
-export type DefaultHotkeyBindings = Partial<Record<GameCommandId, string>>;
+export type DefaultHotkeyBindings = readonly {
+  readonly id: GameCommandId;
+  readonly value: string;
+}[];
 
 export const GAME_COMMANDS: readonly CommandDefinition[] = [
   {
-    id: "toggle-top-bar",
+    id: "toggleTopBar",
     scope: "game",
     category: "Application",
     label: "Toggle Top Bar",
     keywords: ["top", "bar", "navigation", "chrome"],
-    defaultHotkey: "Meta+Shift+T",
+    defaultHotkey: "Mod+Shift+T",
   },
   {
-    id: "load-script",
+    id: "loadScript",
     scope: "game",
     category: "Scripts",
     label: "Load Script",
@@ -59,7 +62,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Mod+O",
   },
   {
-    id: "toggle-script",
+    id: "toggleScript",
     scope: "game",
     category: "Scripts",
     label: "Start or Stop Script",
@@ -67,7 +70,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "stop-script",
+    id: "stopScript",
     scope: "game",
     category: "Scripts",
     label: "Stop Script",
@@ -75,7 +78,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Mod+Shift+X",
   },
   {
-    id: "open-options-menu",
+    id: "openOptionsMenu",
     scope: "game",
     category: "Options",
     label: "Open Options Menu",
@@ -83,7 +86,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Mod+Shift+,",
   },
   {
-    id: "open-environment",
+    id: "openEnvironment",
     scope: "game",
     category: "Tools",
     label: "Open Environment",
@@ -91,7 +94,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Mod+E",
   },
   {
-    id: "open-fast-travels",
+    id: "openFastTravels",
     scope: "game",
     category: "Tools",
     label: "Open Fast Travels",
@@ -99,7 +102,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "open-loader-grabber",
+    id: "openLoaderGrabber",
     scope: "game",
     category: "Tools",
     label: "Open Loader/Grabber",
@@ -107,7 +110,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "open-follower",
+    id: "openFollower",
     scope: "game",
     category: "Tools",
     label: "Open Follower",
@@ -115,7 +118,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "open-packet-logger",
+    id: "openPacketLogger",
     scope: "game",
     category: "Packets",
     label: "Open Packet Logger",
@@ -123,7 +126,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "open-packet-spammer",
+    id: "openPacketSpammer",
     scope: "game",
     category: "Packets",
     label: "Open Packet Spammer",
@@ -131,7 +134,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-autoattack",
+    id: "toggleAutoattack",
     scope: "game",
     category: "Options",
     label: "Toggle Autoattack",
@@ -139,7 +142,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-infinite-range",
+    id: "toggleInfiniteRange",
     scope: "game",
     category: "Options",
     label: "Toggle Infinite Range",
@@ -147,7 +150,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Alt+I",
   },
   {
-    id: "toggle-provoke-cell",
+    id: "toggleProvokeCell",
     scope: "game",
     category: "Options",
     label: "Toggle Provoke Cell",
@@ -155,7 +158,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-enemy-magnet",
+    id: "toggleEnemyMagnet",
     scope: "game",
     category: "Options",
     label: "Toggle Enemy Magnet",
@@ -163,7 +166,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-lag-killer",
+    id: "toggleLagKiller",
     scope: "game",
     category: "Options",
     label: "Toggle Lag Killer",
@@ -171,7 +174,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Alt+L",
   },
   {
-    id: "toggle-hide-players",
+    id: "toggleHidePlayers",
     scope: "game",
     category: "Options",
     label: "Toggle Hide Players",
@@ -179,7 +182,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-skip-cutscenes",
+    id: "toggleSkipCutscenes",
     scope: "game",
     category: "Options",
     label: "Toggle Skip Cutscenes",
@@ -187,7 +190,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-disable-fx",
+    id: "toggleDisableFx",
     scope: "game",
     category: "Options",
     label: "Toggle Disable FX",
@@ -195,7 +198,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-collisions",
+    id: "toggleCollisions",
     scope: "game",
     category: "Options",
     label: "Toggle Collisions",
@@ -203,7 +206,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "",
   },
   {
-    id: "toggle-death-ads",
+    id: "toggleDeathAds",
     scope: "game",
     category: "Options",
     label: "Toggle Death Ads",
@@ -234,6 +237,7 @@ export const getCommandDefinition = (id: GameCommandId): CommandDefinition => {
 };
 
 export const getDefaultHotkeys = (): DefaultHotkeyBindings =>
-  Object.fromEntries(
-    GAME_COMMANDS.map((command) => [command.id, command.defaultHotkey]),
-  ) as DefaultHotkeyBindings;
+  GAME_COMMANDS.map((command) => ({
+    id: command.id,
+    value: command.defaultHotkey,
+  }));

--- a/app/src/shared/hotkeys.ts
+++ b/app/src/shared/hotkeys.ts
@@ -5,12 +5,23 @@ import {
   type RegisterableHotkey,
 } from "@tanstack/solid-hotkeys";
 import {
+  GAME_COMMANDS,
+  getCommandDefinition,
   getDefaultHotkeys,
   type GameCommandId,
-  type DefaultHotkeyBindings,
 } from "./commands";
 
-export type HotkeyBindings = Partial<Record<GameCommandId, string>>;
+export interface HotkeyBinding {
+  readonly id: GameCommandId;
+  readonly value: string;
+}
+
+export interface HotkeyBindingPatch {
+  readonly id: GameCommandId;
+  readonly value: string | null;
+}
+
+export type HotkeyBindings = readonly HotkeyBinding[];
 export type HotkeyPlatform = "mac" | "windows" | "linux";
 
 export interface HotkeysSettings {
@@ -18,12 +29,8 @@ export interface HotkeysSettings {
 }
 
 export interface HotkeysPatch {
-  readonly bindings?: Partial<Record<GameCommandId, string | null>>;
+  readonly bindings?: readonly HotkeyBindingPatch[];
 }
-
-export const DEFAULT_HOTKEYS: HotkeysSettings = {
-  bindings: getDefaultHotkeys(),
-};
 
 export const normalizeHotkeyBinding = (
   value: unknown,
@@ -52,6 +59,24 @@ export const normalizeHotkeyBinding = (
   }
 };
 
-export const createDefaultHotkeyBindings = (): HotkeyBindings => ({
-  ...(getDefaultHotkeys() satisfies DefaultHotkeyBindings),
-});
+export const createDefaultHotkeyBindings = (): HotkeyBindings =>
+  getDefaultHotkeys().map((binding) => ({ ...binding }));
+
+export const readHotkeyBinding = (
+  bindings: HotkeyBindings,
+  id: GameCommandId,
+): string =>
+  bindings.find((binding) => binding.id === id)?.value ??
+  getCommandDefinition(id).defaultHotkey;
+
+export const createHotkeyBindings = (
+  values: ReadonlyMap<GameCommandId, string>,
+): HotkeyBindings =>
+  GAME_COMMANDS.map((command) => ({
+    id: command.id,
+    value: values.get(command.id) ?? command.defaultHotkey,
+  }));
+
+export const DEFAULT_HOTKEYS: HotkeysSettings = {
+  bindings: createDefaultHotkeyBindings(),
+};


### PR DESCRIPTION
## Summary

- Store hotkey bindings as a top-level JSON array of `{ id, value }` entries.
- Rename game command binding ids to camelCase across settings and game-window consumers.
- Harden the settings error notice so global and hotkey errors render through a stable accessible surface.
