### PR TITLE
feat: add account manager groups

### DIFF
--- a/app/src/main/account-manager-ipc.ts
+++ b/app/src/main/account-manager-ipc.ts
@@ -13,14 +13,24 @@ import {
   type AccountScriptSession,
   type AccountScriptStatusUpdate,
   type ManagedAccount,
+  type ManagedAccountGroupDraft,
+  type ManagedAccountGroups,
+  type ManagedAccountGroupPatch,
   type ManagedAccountDraft,
   type ManagedAccountPatch,
   type ScriptExecutePayload,
 } from "../shared/ipc";
 import { WindowIds } from "../shared/windows";
+import {
+  type AccountManagerStorage,
+  getAccountsPath,
+  readAccountManagerStorage,
+  removeGroupMemberUsername,
+  renameGroupMemberUsername,
+  writeAccountManagerStorage,
+} from "./account-manager-store";
 import { getArtixLauncherRequestHeaders } from "./artix-launcher-headers";
 import { refreshCachedScriptPayload } from "./scripting";
-import * as Files from "./settings/Files";
 import { WindowService, type WindowEffectRunner } from "./windows";
 
 const SERVERS_API_URL = "https://game.aq.com/game/api/data/servers";
@@ -36,8 +46,6 @@ const sessions = new Map<number, AccountScriptSession>();
 const gameLaunchPayloads = new Map<number, AccountGameLaunchPayload>();
 
 const now = (): number => Date.now();
-
-const getAccountsPath = (): string => Files.appDataJoin("accounts.json");
 
 class AccountServersFetchError extends Data.TaggedError(
   "AccountServersFetchError",
@@ -74,45 +82,6 @@ const normalizeOptionalString = (value: unknown): string => {
   return value.trim();
 };
 
-const isManagedAccount = (value: unknown): value is ManagedAccount => {
-  if (typeof value !== "object" || value === null) {
-    return false;
-  }
-
-  const account = value as Partial<ManagedAccount>;
-  return (
-    typeof account.label === "string" &&
-    typeof account.username === "string" &&
-    typeof account.password === "string"
-  );
-};
-
-const normalizeStoredAccount = (account: ManagedAccount): ManagedAccount => ({
-  label: account.label,
-  username: account.username,
-  password: account.password,
-});
-
-const dedupeAccountsByUsername = (
-  accounts: readonly ManagedAccount[],
-): readonly ManagedAccount[] => {
-  const seen = new Set<string>();
-  const nextAccounts: ManagedAccount[] = [];
-
-  for (const account of accounts) {
-    const key = account.username.toLowerCase();
-    if (seen.has(key)) {
-      console.error("Ignoring duplicate account username", account.username);
-      continue;
-    }
-
-    seen.add(key);
-    nextAccounts.push(account);
-  }
-
-  return nextAccounts;
-};
-
 const hasAccountUsername = (
   accounts: readonly ManagedAccount[],
   username: string,
@@ -128,26 +97,106 @@ const hasAccountUsername = (
   );
 };
 
-const normalizeAccounts = (value: unknown): readonly ManagedAccount[] => {
-  if (!Array.isArray(value)) {
-    return [];
-  }
+const readStorage = async (): Promise<AccountManagerStorage> =>
+  readAccountManagerStorage();
 
-  return dedupeAccountsByUsername(
-    value.filter(isManagedAccount).map(normalizeStoredAccount),
-  );
+const writeStorage = async (storage: AccountManagerStorage): Promise<void> => {
+  writeAccountManagerStorage(storage);
 };
 
 const readAccounts = async (): Promise<readonly ManagedAccount[]> =>
-  Files.ensureJson(getAccountsPath(), [], normalizeAccounts);
+  (await readStorage()).accounts;
 
-const writeAccounts = async (
-  accounts: readonly ManagedAccount[],
-): Promise<void> => {
-  Files.writeJson(
-    getAccountsPath(),
-    dedupeAccountsByUsername(accounts).map(normalizeStoredAccount),
+const groupNameKey = (name: string): string => name.toLowerCase();
+
+const findGroupName = (
+  groups: ManagedAccountGroups,
+  name: string,
+): string | undefined => {
+  const key = groupNameKey(name);
+  return Object.keys(groups).find(
+    (groupName) => groupNameKey(groupName) === key,
   );
+};
+
+const hasGroupName = (
+  groups: ManagedAccountGroups,
+  name: string,
+  options?: { readonly exceptName?: string },
+): boolean => {
+  const existingName = findGroupName(groups, name);
+  return (
+    existingName !== undefined &&
+    groupNameKey(existingName) !== groupNameKey(options?.exceptName ?? "")
+  );
+};
+
+const normalizeGroupMembersInput = (
+  value: unknown,
+  accounts: readonly ManagedAccount[],
+): readonly string[] => {
+  if (!Array.isArray(value)) {
+    throw new Error("Group usernames must be an array");
+  }
+
+  const usernames = new Set(accounts.map((account) => account.username));
+  const seen = new Set<string>();
+  const members: string[] = [];
+
+  for (const username of value) {
+    if (typeof username !== "string") {
+      throw new Error("Group username must be a string");
+    }
+
+    const normalized = normalizeRequiredString(username, "group username");
+    if (!usernames.has(normalized)) {
+      throw new Error(`Account not found: ${normalized}`);
+    }
+
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) {
+      throw new Error(`Duplicate group member: ${normalized}`);
+    }
+
+    seen.add(key);
+    members.push(normalized);
+  }
+
+  return members;
+};
+
+const normalizeGroupDraft = (
+  draft: unknown,
+  accounts: readonly ManagedAccount[],
+): ManagedAccountGroupDraft => {
+  if (typeof draft !== "object" || draft === null) {
+    throw new Error("Group draft must be an object");
+  }
+
+  const input = draft as Partial<ManagedAccountGroupDraft>;
+  return {
+    name: normalizeRequiredString(input.name, "group name"),
+    usernames: normalizeGroupMembersInput(input.usernames, accounts),
+  };
+};
+
+const normalizeGroupPatch = (
+  patch: unknown,
+  accounts: readonly ManagedAccount[],
+): ManagedAccountGroupPatch => {
+  if (typeof patch !== "object" || patch === null) {
+    throw new Error("Group patch must be an object");
+  }
+
+  const input = patch as Partial<ManagedAccountGroupPatch>;
+  return {
+    ...(input.name === undefined
+      ? {}
+      : { name: normalizeRequiredString(input.name, "group name") }),
+    ...(input.usernames === undefined
+      ? {}
+      : { usernames: normalizeGroupMembersInput(input.usernames, accounts) }),
+  };
 };
 
 const visibleSessions = (): readonly AccountScriptSession[] => {
@@ -163,11 +212,15 @@ const visibleSessions = (): readonly AccountScriptSession[] => {
   return [...latestByUsername.values()];
 };
 
-const toState = async (): Promise<AccountManagerState> => ({
-  accounts: await readAccounts(),
-  sessions: visibleSessions(),
-  storagePath: getAccountsPath(),
-});
+const toState = async (): Promise<AccountManagerState> => {
+  const storage = await readStorage();
+  return {
+    accounts: storage.accounts,
+    groups: storage.groups,
+    sessions: visibleSessions(),
+    storagePath: getAccountsPath(),
+  };
+};
 
 const toAccountGameServer = (server: {
   readonly bOnline: number;
@@ -597,12 +650,15 @@ export const registerAccountManagerIpcHandlers = (
     async (event, draft: unknown) => {
       await requireAccountManagerSender(event, runWindowEffect);
       const accountDraft = normalizeDraft(draft);
-      const accounts = await readAccounts();
-      if (hasAccountUsername(accounts, accountDraft.username)) {
+      const storage = await readStorage();
+      if (hasAccountUsername(storage.accounts, accountDraft.username)) {
         throw new Error("An account with this username already exists");
       }
 
-      await writeAccounts([...accounts, accountDraft]);
+      await writeStorage({
+        ...storage,
+        accounts: [...storage.accounts, accountDraft],
+      });
 
       return await publishStateToAccountManager(runWindowEffect);
     },
@@ -614,10 +670,10 @@ export const registerAccountManagerIpcHandlers = (
       await requireAccountManagerSender(event, runWindowEffect);
       const currentUsername = normalizeRequiredString(username, "username");
       const accountPatch = normalizePatch(patch);
-      const accounts = await readAccounts();
+      const storage = await readStorage();
       const nextUsername = accountPatch.username ?? currentUsername;
       if (
-        hasAccountUsername(accounts, nextUsername, {
+        hasAccountUsername(storage.accounts, nextUsername, {
           exceptUsername: currentUsername,
         })
       ) {
@@ -625,7 +681,7 @@ export const registerAccountManagerIpcHandlers = (
       }
 
       let found = false;
-      const nextAccounts = accounts.map((account) => {
+      const nextAccounts = storage.accounts.map((account) => {
         if (account.username !== currentUsername) {
           return account;
         }
@@ -654,7 +710,14 @@ export const registerAccountManagerIpcHandlers = (
         }
       }
 
-      await writeAccounts(nextAccounts);
+      await writeStorage({
+        accounts: nextAccounts,
+        groups: renameGroupMemberUsername(
+          storage.groups,
+          currentUsername,
+          nextUsername,
+        ),
+      });
       return await publishStateToAccountManager(runWindowEffect);
     },
   );
@@ -664,12 +727,12 @@ export const registerAccountManagerIpcHandlers = (
     async (event, username: unknown) => {
       await requireAccountManagerSender(event, runWindowEffect);
       const accountUsername = normalizeRequiredString(username, "username");
-      const accounts = await readAccounts();
-      const nextAccounts = accounts.filter(
+      const storage = await readStorage();
+      const nextAccounts = storage.accounts.filter(
         (account) => account.username !== accountUsername,
       );
 
-      if (nextAccounts.length === accounts.length) {
+      if (nextAccounts.length === storage.accounts.length) {
         throw new Error("Account not found");
       }
 
@@ -678,7 +741,98 @@ export const registerAccountManagerIpcHandlers = (
           sessions.delete(gameWindowId);
         }
       }
-      await writeAccounts(nextAccounts);
+      await writeStorage({
+        accounts: nextAccounts,
+        groups: removeGroupMemberUsername(storage.groups, accountUsername),
+      });
+      return await publishStateToAccountManager(runWindowEffect);
+    },
+  );
+
+  ipcMain.handle(
+    AccountManagerIpcChannels.createGroup,
+    async (event, draft: unknown) => {
+      await requireAccountManagerSender(event, runWindowEffect);
+      const storage = await readStorage();
+      const groupDraft = normalizeGroupDraft(draft, storage.accounts);
+      if (hasGroupName(storage.groups, groupDraft.name)) {
+        throw new Error("A group with this name already exists");
+      }
+
+      await writeStorage({
+        ...storage,
+        groups: {
+          ...storage.groups,
+          [groupDraft.name]: groupDraft.usernames,
+        },
+      });
+
+      return await publishStateToAccountManager(runWindowEffect);
+    },
+  );
+
+  ipcMain.handle(
+    AccountManagerIpcChannels.updateGroup,
+    async (event, name: unknown, patch: unknown) => {
+      await requireAccountManagerSender(event, runWindowEffect);
+      const currentName = normalizeRequiredString(name, "group name");
+      const storage = await readStorage();
+      const existingName = findGroupName(storage.groups, currentName);
+      if (existingName === undefined) {
+        throw new Error("Group not found");
+      }
+
+      const groupPatch = normalizeGroupPatch(patch, storage.accounts);
+      const nextName = groupPatch.name ?? existingName;
+      if (
+        hasGroupName(storage.groups, nextName, {
+          exceptName: existingName,
+        })
+      ) {
+        throw new Error("A group with this name already exists");
+      }
+
+      const groups: Record<string, readonly string[]> = {};
+      for (const [groupName, usernames] of Object.entries(storage.groups)) {
+        if (groupName === existingName) {
+          groups[nextName] = groupPatch.usernames ?? usernames;
+        } else {
+          groups[groupName] = usernames;
+        }
+      }
+
+      await writeStorage({
+        ...storage,
+        groups,
+      });
+
+      return await publishStateToAccountManager(runWindowEffect);
+    },
+  );
+
+  ipcMain.handle(
+    AccountManagerIpcChannels.deleteGroup,
+    async (event, name: unknown) => {
+      await requireAccountManagerSender(event, runWindowEffect);
+      const groupName = normalizeRequiredString(name, "group name");
+      const storage = await readStorage();
+      const existingName = findGroupName(storage.groups, groupName);
+      if (existingName === undefined) {
+        throw new Error("Group not found");
+      }
+
+      const groups: Record<string, readonly string[]> = {};
+      for (const [name, usernames] of Object.entries(storage.groups)) {
+        if (name !== existingName) {
+          groups[name] = usernames;
+        }
+      }
+
+      await writeStorage({
+        ...storage,
+        groups,
+      });
+
       return await publishStateToAccountManager(runWindowEffect);
     },
   );

--- a/app/src/main/account-manager-store.test.ts
+++ b/app/src/main/account-manager-store.test.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getAccountsPath,
+  normalizeAccountManagerStorage,
+  readAccountManagerStorage,
+  removeGroupMemberUsername,
+  renameGroupMemberUsername,
+  writeAccountManagerStorage,
+} from "./account-manager-store";
+import * as Files from "./settings/Files";
+
+describe("account manager storage", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "vexed-account-manager-"));
+    Files.configureAppDataHome(testDir);
+  });
+
+  afterEach(async () => {
+    Files.resetPathConfigurationForTests();
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("reads object-shaped account storage", async () => {
+    await writeFile(
+      getAccountsPath(),
+      JSON.stringify({
+        accounts: [
+          {
+            label: "Main",
+            username: "main",
+            password: "secret",
+          },
+        ],
+        groups: {
+          Farm: ["main"],
+        },
+      }),
+      "utf8",
+    );
+
+    expect(readAccountManagerStorage()).toEqual({
+      accounts: [
+        {
+          label: "Main",
+          username: "main",
+          password: "secret",
+        },
+      ],
+      groups: {
+        Farm: ["main"],
+      },
+    });
+  });
+
+  it("does not migrate old array-shaped storage", () => {
+    expect(
+      normalizeAccountManagerStorage([
+        {
+          label: "Main",
+          username: "main",
+          password: "secret",
+        },
+      ]),
+    ).toEqual({
+      accounts: [],
+      groups: {},
+    });
+  });
+
+  it("dedupes accounts and group members while dropping unknown members", () => {
+    expect(
+      normalizeAccountManagerStorage({
+        accounts: [
+          { label: "Main", username: "main", password: "secret" },
+          { label: "Duplicate", username: "MAIN", password: "secret" },
+          { label: "Alt", username: "alt", password: "secret" },
+        ],
+        groups: {
+          Farm: ["main", "main", "missing", "alt"],
+          "": ["main"],
+        },
+      }),
+    ).toEqual({
+      accounts: [
+        { label: "Main", username: "main", password: "secret" },
+        { label: "Alt", username: "alt", password: "secret" },
+      ],
+      groups: {
+        Farm: ["main", "alt"],
+      },
+    });
+  });
+
+  it("writes object-shaped account storage", async () => {
+    writeAccountManagerStorage({
+      accounts: [{ label: "Main", username: "main", password: "secret" }],
+      groups: {
+        Farm: ["main", "missing"],
+      },
+    });
+
+    expect(JSON.parse(await readFile(getAccountsPath(), "utf8"))).toEqual({
+      accounts: [{ label: "Main", username: "main", password: "secret" }],
+      groups: {
+        Farm: ["main"],
+      },
+    });
+  });
+
+  it("renames account usernames inside group membership", () => {
+    expect(
+      renameGroupMemberUsername(
+        {
+          Farm: ["main", "alt"],
+          Boss: ["alt"],
+        },
+        "alt",
+        "main",
+      ),
+    ).toEqual({
+      Farm: ["main"],
+      Boss: ["main"],
+    });
+  });
+
+  it("removes deleted account usernames from group membership", () => {
+    expect(
+      removeGroupMemberUsername(
+        {
+          Farm: ["main", "alt"],
+          Boss: ["alt"],
+        },
+        "alt",
+      ),
+    ).toEqual({
+      Farm: ["main"],
+      Boss: [],
+    });
+  });
+});

--- a/app/src/main/account-manager-store.ts
+++ b/app/src/main/account-manager-store.ts
@@ -1,0 +1,198 @@
+import type { ManagedAccount, ManagedAccountGroups } from "../shared/ipc";
+import * as Files from "./settings/Files";
+
+export interface AccountManagerStorage {
+  readonly accounts: readonly ManagedAccount[];
+  readonly groups: ManagedAccountGroups;
+}
+
+const emptyStorage: AccountManagerStorage = {
+  accounts: [],
+  groups: {},
+};
+
+export const getAccountsPath = (): string => Files.appDataJoin("accounts.json");
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isManagedAccount = (value: unknown): value is ManagedAccount => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value["label"] === "string" &&
+    typeof value["username"] === "string" &&
+    typeof value["password"] === "string"
+  );
+};
+
+export const normalizeStoredAccount = (
+  account: ManagedAccount,
+): ManagedAccount => ({
+  label: account.label,
+  username: account.username,
+  password: account.password,
+});
+
+export const dedupeAccountsByUsername = (
+  accounts: readonly ManagedAccount[],
+): readonly ManagedAccount[] => {
+  const seen = new Set<string>();
+  const nextAccounts: ManagedAccount[] = [];
+
+  for (const account of accounts) {
+    const key = account.username.toLowerCase();
+    if (seen.has(key)) {
+      console.error("Ignoring duplicate account username");
+      continue;
+    }
+
+    seen.add(key);
+    nextAccounts.push(account);
+  }
+
+  return nextAccounts;
+};
+
+const normalizeAccounts = (value: unknown): readonly ManagedAccount[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return dedupeAccountsByUsername(
+    value.filter(isManagedAccount).map(normalizeStoredAccount),
+  );
+};
+
+const normalizeStoredGroupMembers = (
+  value: unknown,
+  accounts: readonly ManagedAccount[],
+): readonly string[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const accountUsernames = new Set(accounts.map((account) => account.username));
+  const seen = new Set<string>();
+  const usernames: string[] = [];
+
+  for (const member of value) {
+    if (typeof member !== "string" || !accountUsernames.has(member)) {
+      continue;
+    }
+
+    const key = member.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    usernames.push(member);
+  }
+
+  return usernames;
+};
+
+const normalizeGroups = (
+  value: unknown,
+  accounts: readonly ManagedAccount[],
+): ManagedAccountGroups => {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  const groups: Record<string, readonly string[]> = {};
+  const seen = new Set<string>();
+
+  for (const [rawName, rawMembers] of Object.entries(value)) {
+    const name = rawName.trim();
+    const key = name.toLowerCase();
+    if (name === "" || seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    groups[name] = normalizeStoredGroupMembers(rawMembers, accounts);
+  }
+
+  return groups;
+};
+
+export const normalizeAccountManagerStorage = (
+  value: unknown,
+): AccountManagerStorage => {
+  if (!isRecord(value)) {
+    return emptyStorage;
+  }
+
+  const accounts = normalizeAccounts(value["accounts"]);
+
+  return {
+    accounts,
+    groups: normalizeGroups(value["groups"], accounts),
+  };
+};
+
+export const renameGroupMemberUsername = (
+  groups: ManagedAccountGroups,
+  currentUsername: string,
+  nextUsername: string,
+): ManagedAccountGroups => {
+  if (currentUsername === nextUsername) {
+    return groups;
+  }
+
+  const nextGroups: Record<string, readonly string[]> = {};
+  for (const [name, usernames] of Object.entries(groups)) {
+    const seen = new Set<string>();
+    const nextUsernames: string[] = [];
+    for (const username of usernames) {
+      const next = username === currentUsername ? nextUsername : username;
+      const key = next.toLowerCase();
+      if (seen.has(key)) {
+        continue;
+      }
+
+      seen.add(key);
+      nextUsernames.push(next);
+    }
+    nextGroups[name] = nextUsernames;
+  }
+
+  return nextGroups;
+};
+
+export const removeGroupMemberUsername = (
+  groups: ManagedAccountGroups,
+  accountUsername: string,
+): ManagedAccountGroups => {
+  const nextGroups: Record<string, readonly string[]> = {};
+  for (const [name, usernames] of Object.entries(groups)) {
+    nextGroups[name] = usernames.filter(
+      (username) => username !== accountUsername,
+    );
+  }
+
+  return nextGroups;
+};
+
+export const readAccountManagerStorage = (): AccountManagerStorage =>
+  Files.ensureJson(
+    getAccountsPath(),
+    emptyStorage,
+    normalizeAccountManagerStorage,
+  );
+
+export const writeAccountManagerStorage = (
+  storage: AccountManagerStorage,
+): void => {
+  const accounts = dedupeAccountsByUsername(
+    storage.accounts.map(normalizeStoredAccount),
+  );
+  Files.writeJson(getAccountsPath(), {
+    accounts,
+    groups: normalizeGroups(storage.groups, accounts),
+  });
+};

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -31,6 +31,8 @@ import {
   type EnvironmentQuestAutoRegisterOptions,
   type EnvironmentState,
   type HotkeysPatch,
+  type ManagedAccountGroupDraft,
+  type ManagedAccountGroupPatch,
   type ManagedAccountDraft,
   type ManagedAccountPatch,
   type PreferencesPatch,
@@ -176,6 +178,25 @@ const bridge: AppBridge = {
       return (await ipcRenderer.invoke(
         AccountManagerIpcChannels.deleteAccount,
         username,
+      )) as AccountManagerState;
+    },
+    createGroup: async (draft: ManagedAccountGroupDraft) => {
+      return (await ipcRenderer.invoke(
+        AccountManagerIpcChannels.createGroup,
+        draft,
+      )) as AccountManagerState;
+    },
+    updateGroup: async (name: string, patch: ManagedAccountGroupPatch) => {
+      return (await ipcRenderer.invoke(
+        AccountManagerIpcChannels.updateGroup,
+        name,
+        patch,
+      )) as AccountManagerState;
+    },
+    deleteGroup: async (name: string) => {
+      return (await ipcRenderer.invoke(
+        AccountManagerIpcChannels.deleteGroup,
+        name,
       )) as AccountManagerState;
     },
     launch: async (request: AccountLaunchRequest) => {

--- a/app/src/renderer/windows/account-manager/App.tsx
+++ b/app/src/renderer/windows/account-manager/App.tsx
@@ -1,6 +1,7 @@
 /* @refresh reload */
 import "../../polyfills";
 import "./style.css";
+import { createHotkey } from "@tanstack/solid-hotkeys";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -43,12 +44,14 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
+  Kbd,
   Spinner,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@vexed/ui";
 import {
+  CircleQuestionMark,
   Eye,
   EyeOff,
   FolderOpen,
@@ -78,6 +81,7 @@ import {
   type AccountManagerState,
   type AccountScriptSession,
   type ManagedAccount,
+  type ManagedAccountGroups,
   type ManagedAccountDraft,
   type ScriptExecutePayload,
 } from "../../../shared/ipc";
@@ -98,12 +102,19 @@ interface LaunchScriptSelection {
   readonly payload: ScriptExecutePayload | null;
 }
 
+interface GroupFormState {
+  readonly name: string;
+  readonly usernames: ReadonlySet<string>;
+}
+
 const NO_SERVER_VALUE = "__no_server__";
+const MANUAL_GROUP_VALUE = "__manual_selection__";
 const LAUNCH_WITH_SCRIPT_CHECKBOX_ID = "account-manager-launch-with-script";
 const ACCOUNT_PASSWORD_INPUT_ID = "account-manager-account-password";
 
 const emptyState: AccountManagerState = {
   accounts: [],
+  groups: {},
   sessions: [],
   storagePath: "",
 };
@@ -117,6 +128,11 @@ const emptyForm = (): AccountFormState => ({
 const emptyLaunchScriptSelection = (): LaunchScriptSelection => ({
   enabled: false,
   payload: null,
+});
+
+const emptyGroupForm = (): GroupFormState => ({
+  name: "",
+  usernames: new Set(),
 });
 
 const toDraft = (form: AccountFormState): ManagedAccountDraft => ({
@@ -176,6 +192,28 @@ const sameVisibleSession = (
   previous.scriptName === next.scriptName &&
   previous.message === next.message;
 
+const sameGroups = (
+  previous: ManagedAccountGroups,
+  next: ManagedAccountGroups,
+): boolean => {
+  const previousEntries = Object.entries(previous);
+  const nextEntries = Object.entries(next);
+  if (previousEntries.length !== nextEntries.length) {
+    return false;
+  }
+
+  return previousEntries.every(([name, previousUsernames]) => {
+    const nextUsernames = next[name];
+    return (
+      nextUsernames !== undefined &&
+      previousUsernames.length === nextUsernames.length &&
+      previousUsernames.every(
+        (username, index) => username === nextUsernames[index],
+      )
+    );
+  });
+};
+
 const reconcileAccounts = (
   previousAccounts: readonly ManagedAccount[],
   nextAccounts: readonly ManagedAccount[],
@@ -232,10 +270,14 @@ const reconcileAccountManagerState = (
     previousState.sessions,
     nextState.sessions,
   );
+  const groups = sameGroups(previousState.groups, nextState.groups)
+    ? previousState.groups
+    : nextState.groups;
 
   if (
     previousState.storagePath === nextState.storagePath &&
     previousState.accounts === accounts &&
+    previousState.groups === groups &&
     previousState.sessions === sessions
   ) {
     return previousState;
@@ -243,6 +285,7 @@ const reconcileAccountManagerState = (
 
   return {
     accounts,
+    groups,
     sessions,
     storagePath: nextState.storagePath,
   };
@@ -311,6 +354,9 @@ function AccountDeleteTrigger(props: {
 }
 
 function App(): JSX.Element {
+  let accountSearchInput: HTMLInputElement | undefined;
+  let groupFieldElement: HTMLDivElement | undefined;
+  let groupComboboxInput: HTMLInputElement | undefined;
   let usernameInput: HTMLInputElement | undefined;
   let scriptPathInputElement: HTMLInputElement | undefined;
   let serverSelectionSettlingTimeout: number | undefined;
@@ -320,6 +366,19 @@ function App(): JSX.Element {
   const [selectedAccountUsernames, setSelectedAccountUsernames] = createSignal<
     ReadonlySet<string>
   >(new Set());
+  const [selectedGroupName, setSelectedGroupName] = createSignal("");
+  const [groupDialogOpen, setGroupDialogOpen] = createSignal(false);
+  const [groupDialogMode, setGroupDialogMode] = createSignal<"create" | "edit">(
+    "create",
+  );
+  const [editingGroupName, setEditingGroupName] = createSignal<string | null>(
+    null,
+  );
+  const [groupForm, setGroupForm] = createSignal<GroupFormState>(
+    emptyGroupForm(),
+  );
+  const [groupDialogError, setGroupDialogError] = createSignal("");
+  const [groupSearchQuery, setGroupSearchQuery] = createSignal("");
   const [form, setForm] = createSignal<AccountFormState>(emptyForm());
   const [passwordVisible, setPasswordVisible] = createSignal(false);
   const [dialogOpen, setDialogOpen] = createSignal(false);
@@ -352,6 +411,15 @@ function App(): JSX.Element {
   const [busy, setBusy] = createSignal(false);
 
   const accounts = createMemo(() => state().accounts);
+  const accountUsernames = createMemo(
+    () => new Set(accounts().map((account) => account.username)),
+  );
+  const groups = createMemo(() => state().groups);
+  const groupEntries = createMemo(() =>
+    Object.entries(groups()).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  );
   const filteredAccounts = createMemo(() => {
     const query = searchQuery().trim().toLowerCase();
     if (query === "") {
@@ -375,15 +443,25 @@ function App(): JSX.Element {
   const selectedLaunchUsernames = createMemo(() => {
     return [...selectedAccountUsernames()];
   });
-  const selectedVisibleCount = createMemo(() => {
-    const selected = selectedAccountUsernames();
-    return filteredAccounts().filter((account) =>
-      selected.has(account.username),
-    ).length;
+  const selectedAccountCount = createMemo(
+    () => selectedAccountUsernames().size,
+  );
+  const filteredGroupAccounts = createMemo(() => {
+    const query = groupSearchQuery().trim().toLowerCase();
+    if (query === "") {
+      return accounts();
+    }
+
+    return accounts().filter(
+      (account) =>
+        account.label.toLowerCase().includes(query) ||
+        account.username.toLowerCase().includes(query),
+    );
   });
   const formSubmittable = createMemo(
     () => form().username.trim() !== "" && form().password.trim() !== "",
   );
+  const groupFormSubmittable = createMemo(() => groupForm().name.trim() !== "");
   const serverOptions = createMemo(() => servers());
   const filteredServerOptions = createMemo(() => {
     const query = serverSearchQuery().trim().toLowerCase();
@@ -411,10 +489,49 @@ function App(): JSX.Element {
     const payload = selectedScript();
     return payload?.name ?? payload?.path ?? "";
   });
+  const selectedGroupLabel = createMemo(
+    () => selectedGroupName() || "Manual selection",
+  );
   const launchScriptPayload = createMemo(() => {
     const selection = launchScript();
     return selection.enabled ? selection.payload : null;
   });
+
+  createHotkey(
+    "/",
+    (event) => {
+      if (event.repeat) {
+        return;
+      }
+
+      accountSearchInput?.focus();
+      accountSearchInput?.select();
+    },
+    {
+      eventType: "keydown",
+      conflictBehavior: "replace",
+      ignoreInputs: true,
+    },
+  );
+
+  createHotkey(
+    "G",
+    (event) => {
+      if (event.repeat) {
+        return;
+      }
+
+      groupComboboxInput?.focus();
+      groupFieldElement
+        ?.querySelector<HTMLButtonElement>(".combobox__trigger")
+        ?.click();
+    },
+    {
+      eventType: "keydown",
+      conflictBehavior: "replace",
+      ignoreInputs: true,
+    },
+  );
 
   createEffect(() => {
     if (dialogOpen()) {
@@ -438,7 +555,17 @@ function App(): JSX.Element {
     const usernames = new Set(
       nextState.accounts.map((account) => account.username),
     );
+    const currentGroupName = selectedGroupName();
     setSelectedAccountUsernames((previous) => {
+      if (currentGroupName !== "") {
+        const groupUsernames = nextState.groups[currentGroupName];
+        if (groupUsernames !== undefined) {
+          return new Set(
+            groupUsernames.filter((username) => usernames.has(username)),
+          );
+        }
+      }
+
       let removed = false;
       const next = new Set<string>();
       for (const username of previous) {
@@ -451,6 +578,13 @@ function App(): JSX.Element {
 
       return removed ? next : previous;
     });
+
+    if (
+      currentGroupName !== "" &&
+      nextState.groups[currentGroupName] === undefined
+    ) {
+      setSelectedGroupName("");
+    }
 
     const currentEditingUsername = editingUsername();
     if (currentEditingUsername && !usernames.has(currentEditingUsername)) {
@@ -589,6 +723,136 @@ function App(): JSX.Element {
     setDialogError("");
     setPasswordVisible(false);
     setDialogOpen(true);
+  };
+
+  const selectGroup = (
+    groupName: string,
+    nextGroups: ManagedAccountGroups = groups(),
+  ) => {
+    if (groupName === "") {
+      setSelectedGroupName("");
+      return;
+    }
+
+    const members = nextGroups[groupName];
+    if (members === undefined) {
+      setSelectedGroupName("");
+      return;
+    }
+
+    const usernames = accountUsernames();
+    setSelectedGroupName(groupName);
+    setSelectedAccountUsernames(
+      new Set(members.filter((username) => usernames.has(username))),
+    );
+  };
+
+  const openCreateGroupDialog = () => {
+    setEditingGroupName(null);
+    setGroupDialogMode("create");
+    setGroupForm({
+      name: "",
+      usernames: new Set(selectedAccountUsernames()),
+    });
+    setGroupSearchQuery("");
+    setGroupDialogError("");
+    setGroupDialogOpen(true);
+  };
+
+  const openEditGroupDialog = () => {
+    const groupName = selectedGroupName();
+    const usernames = groupName === "" ? undefined : groups()[groupName];
+    if (groupName === "" || usernames === undefined) {
+      return;
+    }
+
+    setEditingGroupName(groupName);
+    setGroupDialogMode("edit");
+    setGroupForm({
+      name: groupName,
+      usernames: new Set(usernames),
+    });
+    setGroupSearchQuery("");
+    setGroupDialogError("");
+    setGroupDialogOpen(true);
+  };
+
+  const setGroupFormName = (name: string) => {
+    setGroupForm((previous) => ({
+      ...previous,
+      name,
+    }));
+    setGroupDialogError("");
+  };
+
+  const toggleGroupMember = (username: string, checked: boolean) => {
+    setGroupForm((previous) => {
+      const usernames = new Set(previous.usernames);
+      if (checked) {
+        usernames.add(username);
+      } else {
+        usernames.delete(username);
+      }
+
+      return {
+        ...previous,
+        usernames,
+      };
+    });
+  };
+
+  const handleSaveGroup = async () => {
+    if (busy() || !groupFormSubmittable()) {
+      return;
+    }
+
+    const payload = {
+      name: groupForm().name.trim(),
+      usernames: [...groupForm().usernames],
+    };
+    const currentGroupName = editingGroupName();
+    setBusy(true);
+    setGroupDialogError("");
+    try {
+      const nextState =
+        currentGroupName === null
+          ? await window.ipc.accounts.createGroup(payload)
+          : await window.ipc.accounts.updateGroup(currentGroupName, payload);
+
+      applyState(nextState);
+      setGroupDialogOpen(false);
+      selectGroup(payload.name, nextState.groups);
+    } catch (error) {
+      console.error("Failed to save group:", error);
+      setGroupDialogError(
+        error instanceof Error ? error.message : "Save failed",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDeleteGroup = async () => {
+    const groupName = editingGroupName() ?? selectedGroupName();
+    if (busy() || groupName === "") {
+      return;
+    }
+
+    setBusy(true);
+    setGroupDialogError("");
+    try {
+      const nextState = await window.ipc.accounts.deleteGroup(groupName);
+      applyState(nextState);
+      setSelectedGroupName("");
+      setGroupDialogOpen(false);
+    } catch (error) {
+      console.error("Failed to delete group:", error);
+      setGroupDialogError(
+        error instanceof Error ? error.message : "Delete failed",
+      );
+    } finally {
+      setBusy(false);
+    }
   };
 
   const handleSave = async (options: SaveOptions) => {
@@ -771,6 +1035,7 @@ function App(): JSX.Element {
   };
 
   const toggleSelected = (username: string, checked: boolean) => {
+    setSelectedGroupName("");
     setSelectedAccountUsernames((previous) => {
       const next = new Set(previous);
       if (checked) {
@@ -783,6 +1048,7 @@ function App(): JSX.Element {
   };
 
   const selectVisibleAccounts = () => {
+    setSelectedGroupName("");
     setSelectedAccountUsernames((previous) => {
       const next = new Set(previous);
       for (const account of filteredAccounts()) {
@@ -793,6 +1059,7 @@ function App(): JSX.Element {
   };
 
   const invertVisibleSelection = () => {
+    setSelectedGroupName("");
     setSelectedAccountUsernames((previous) => {
       const next = new Set(previous);
       for (const account of filteredAccounts()) {
@@ -854,10 +1121,19 @@ function App(): JSX.Element {
                 <Search aria-hidden="true" />
               </InputGroupAddon>
               <InputGroupInput
+                ref={(element) => {
+                  accountSearchInput = element;
+                }}
                 value={searchQuery()}
                 placeholder="Search accounts..."
                 onInput={(event) => setSearchQuery(event.currentTarget.value)}
               />
+              <InputGroupAddon
+                align="inline-end"
+                class="account-search__shortcut"
+              >
+                <Kbd>/</Kbd>
+              </InputGroupAddon>
             </InputGroup>
             <div class="account-manager__launch-row">
               <div class="account-manager__field-container">
@@ -885,90 +1161,90 @@ function App(): JSX.Element {
                 </div>
                 <Combobox
                   class="account-manager__server-field account-manager__field account-manager__server-combobox"
-                    value={[launchServer() || NO_SERVER_VALUE]}
-                    disabled={serversLoading() || serverError() !== ""}
-                    inputBehavior="autohighlight"
-                    openOnClick
-                    positioning={{ fitViewport: true, sameWidth: false }}
-                    onOpenChange={(details) => {
-                      if (!details.open) {
-                        setServerInputValue(launchServer());
-                        setServerSearchQuery("");
-                      }
-                    }}
-                    onValueChange={(details) => {
-                      const value = details.value[0] ?? NO_SERVER_VALUE;
-                      const nextLaunchServer =
-                        value === NO_SERVER_VALUE ? "" : value;
-                      setServerInputValue(nextLaunchServer);
+                  value={[launchServer() || NO_SERVER_VALUE]}
+                  disabled={serversLoading() || serverError() !== ""}
+                  inputBehavior="autohighlight"
+                  openOnClick
+                  positioning={{ fitViewport: true, sameWidth: false }}
+                  onOpenChange={(details) => {
+                    if (!details.open) {
+                      setServerInputValue(launchServer());
                       setServerSearchQuery("");
-                      setLaunchServer(nextLaunchServer);
-                      setServerSelectionInitialized(true);
+                    }
+                  }}
+                  onValueChange={(details) => {
+                    const value = details.value[0] ?? NO_SERVER_VALUE;
+                    const nextLaunchServer =
+                      value === NO_SERVER_VALUE ? "" : value;
+                    setServerInputValue(nextLaunchServer);
+                    setServerSearchQuery("");
+                    setLaunchServer(nextLaunchServer);
+                    setServerSelectionInitialized(true);
+                  }}
+                >
+                  <ComboboxInput
+                    classList={{
+                      "account-manager__server-input--settling":
+                        serversLoading() || serverSelectionSettling(),
                     }}
-                  >
-                    <ComboboxInput
-                      classList={{
-                        "account-manager__server-input--settling":
-                          serversLoading() || serverSelectionSettling(),
-                      }}
-                      placeholder="Choose server..."
-                      showClear={false}
-                      size="lg"
-                      value={serverInputValue()}
-                      onInput={(event) => {
-                        const value = event.currentTarget.value;
-                        setServerInputValue(value);
-                        setServerSearchQuery(value);
-                      }}
-                      onKeyDown={(event) => {
-                        if (event.key !== "Escape") {
-                          return;
-                        }
+                    placeholder="Choose server..."
+                    showClear={false}
+                    size="lg"
+                    value={serverInputValue()}
+                    onInput={(event) => {
+                      const value = event.currentTarget.value;
+                      setServerInputValue(value);
+                      setServerSearchQuery(value);
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key !== "Escape") {
+                        return;
+                      }
 
-                        setServerInputValue(launchServer());
-                        setServerSearchQuery("");
-                      }}
-                    />
-                    <ComboboxContent class="account-manager__server-content">
-                      <Show
-                        when={
-                          !showNoServerOption() &&
-                          filteredServerOptions().length === 0
-                        }
-                      >
-                        <ComboboxEmpty>No matching servers</ComboboxEmpty>
+                      setServerInputValue(launchServer());
+                      setServerSearchQuery("");
+                    }}
+                  />
+                  <ComboboxContent class="account-manager__server-content">
+                    <Show
+                      when={
+                        !showNoServerOption() &&
+                        filteredServerOptions().length === 0
+                      }
+                    >
+                      <ComboboxEmpty>No matching servers</ComboboxEmpty>
+                    </Show>
+                    <ComboboxList>
+                      <Show when={showNoServerOption()}>
+                        <ComboboxItem value={NO_SERVER_VALUE} label="None">
+                          None
+                        </ComboboxItem>
                       </Show>
-                      <ComboboxList>
-                        <Show when={showNoServerOption()}>
-                          <ComboboxItem value={NO_SERVER_VALUE} label="None">
-                            None
-                          </ComboboxItem>
-                        </Show>
-                        <For each={filteredServerOptions()}>
-                          {(server) => (
-                            <ComboboxItem
-                              value={server.name}
-                              label={server.name}
-                              disabled={!server.online}
+                      <For each={filteredServerOptions()}>
+                        {(server) => (
+                          <ComboboxItem
+                            value={server.name}
+                            label={server.name}
+                            disabled={!server.online}
+                          >
+                            <span
+                              class={`account-server-option account-server-option--${serverAvailability(
+                                server,
+                              )}`}
                             >
-                              <span
-                                class={`account-server-option account-server-option--${serverAvailability(
-                                  server,
-                                )}`}
-                              >
-                                <span class="account-server-option__name">
-                                  {server.name}
-                                </span>
-                                <span class="account-server-option__meta">
-                                  {serverMeta(server)}
-                                </span>
+                              <span class="account-server-option__name">
+                                {server.name}
                               </span>
-                            </ComboboxItem>
-                          )}
-                        </For>
-                      </ComboboxList>
-                    </ComboboxContent>
-                  </Combobox>
+                              <span class="account-server-option__meta">
+                                {serverMeta(server)}
+                              </span>
+                            </span>
+                          </ComboboxItem>
+                        )}
+                      </For>
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
               </div>
 
               <div class="account-manager__field-container">
@@ -1131,9 +1407,147 @@ function App(): JSX.Element {
           </div>
 
           <div class="account-manager__selection-bar">
-            <span>
-              {selectedVisibleCount()} of {filteredAccounts().length} selected
-            </span>
+            <div class="account-manager__selection-context">
+              <div class="account-manager__group-row">
+                <div class="account-manager__group-label">
+                  <span>Groups</span>
+                  <Tooltip closeDelay={0} openDelay={250}>
+                    <TooltipTrigger
+                      asChild={(triggerProps) => (
+                        <Button
+                          {...(triggerProps({
+                            "aria-label": "What are groups?",
+                            size: "icon-sm",
+                            type: "button",
+                            variant: "ghost",
+                          } as ButtonProps) as ButtonProps)}
+                        >
+                          <CircleQuestionMark class="button__icon" />
+                        </Button>
+                      )}
+                    />
+                    <TooltipContent>
+                      Groups are saved account selections.
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <div
+                  ref={(element) => {
+                    groupFieldElement = element;
+                  }}
+                  class="account-manager__group-field"
+                >
+                  <Combobox
+                    class="account-manager__group-combobox"
+                    value={[selectedGroupName() || MANUAL_GROUP_VALUE]}
+                    inputBehavior="autohighlight"
+                    openOnClick
+                    positioning={{ fitViewport: true, sameWidth: false }}
+                    onValueChange={(details) => {
+                      const value = details.value[0] ?? MANUAL_GROUP_VALUE;
+                      selectGroup(
+                        value === MANUAL_GROUP_VALUE ? "" : value,
+                        groups(),
+                      );
+                    }}
+                  >
+                    <ComboboxInput
+                      ref={(element) => {
+                        groupComboboxInput = element;
+                      }}
+                      value={selectedGroupLabel()}
+                      readOnly
+                      showClear={false}
+                      size="lg"
+                      placeholder="Choose group..."
+                    />
+                    <ComboboxContent class="account-manager__group-content">
+                      <ComboboxList>
+                        <ComboboxItem
+                          value={MANUAL_GROUP_VALUE}
+                          label="Manual selection"
+                        >
+                          Manual selection
+                        </ComboboxItem>
+                        <For each={groupEntries()}>
+                          {([name, usernames]) => (
+                            <ComboboxItem value={name} label={name}>
+                              <span class="account-group-option">
+                                <span class="account-group-option__name">
+                                  {name}
+                                </span>
+                                <span class="account-group-option__meta">
+                                  {usernames.length}
+                                </span>
+                              </span>
+                            </ComboboxItem>
+                          )}
+                        </For>
+                      </ComboboxList>
+                    </ComboboxContent>
+                  </Combobox>
+                  <Kbd class="account-manager__group-shortcut">G</Kbd>
+                </div>
+                <div class="account-manager__group-actions">
+                  <Button
+                    variant="secondary"
+                    onClick={openCreateGroupDialog}
+                    disabled={busy()}
+                  >
+                    <Plus class="button__icon" />
+                    New Group
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    onClick={openEditGroupDialog}
+                    disabled={busy() || selectedGroupName() === ""}
+                  >
+                    <Pencil class="button__icon" />
+                    Edit
+                  </Button>
+                  <AlertDialog>
+                    <AlertDialogTrigger
+                      asChild={(triggerProps) => (
+                        <Button
+                          {...(triggerProps({
+                            variant: "destructive-outline",
+                            disabled: busy() || selectedGroupName() === "",
+                          } as ButtonProps) as ButtonProps)}
+                        >
+                          <Trash2 class="button__icon" />
+                          Delete
+                        </Button>
+                      )}
+                    />
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Group</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Delete {selectedGroupName()}? Accounts in this group
+                          will stay saved.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => void handleDeleteGroup()}
+                          variant="destructive"
+                        >
+                          Delete group
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </div>
+              <span class="account-manager__selection-count">
+                {selectedAccountCount()} selected
+                <Show when={filteredAccounts().length !== accounts().length}>
+                  {" "}
+                  ({filteredAccounts().length} visible)
+                </Show>
+              </span>
+            </div>
             <div class="account-manager__selection-actions">
               <Button variant="secondary" onClick={selectVisibleAccounts}>
                 All
@@ -1336,6 +1750,143 @@ function App(): JSX.Element {
             </Show>
           </div>
         </section>
+
+        <Dialog
+          open={groupDialogOpen()}
+          onOpenChange={(details) => {
+            setGroupDialogOpen(details.open);
+            if (!details.open) {
+              setEditingGroupName(null);
+            }
+          }}
+        >
+          <DialogContent class="account-dialog account-group-dialog">
+            <DialogHeader>
+              <DialogTitle>
+                {groupDialogMode() === "edit" ? "Edit Group" : "New Group"}
+              </DialogTitle>
+            </DialogHeader>
+
+            <form
+              class="account-dialog__form"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void handleSaveGroup();
+              }}
+            >
+              <div class="account-dialog__fields">
+                <Show when={groupDialogError()}>
+                  <div class="account-dialog__error">{groupDialogError()}</div>
+                </Show>
+                <label class="account-dialog__field">
+                  <span>Name</span>
+                  <Input
+                    fullWidth
+                    size="lg"
+                    value={groupForm().name}
+                    placeholder="Group name"
+                    onInput={(event) =>
+                      setGroupFormName(event.currentTarget.value)
+                    }
+                  />
+                </label>
+                <div class="account-dialog__field">
+                  <span>Accounts</span>
+                  <InputGroup class="account-group-dialog__search">
+                    <InputGroupAddon>
+                      <Search aria-hidden="true" />
+                    </InputGroupAddon>
+                    <InputGroupInput
+                      value={groupSearchQuery()}
+                      placeholder="Search accounts..."
+                      onInput={(event) =>
+                        setGroupSearchQuery(event.currentTarget.value)
+                      }
+                    />
+                  </InputGroup>
+                  <div class="account-group-dialog__members">
+                    <Show
+                      when={filteredGroupAccounts().length > 0}
+                      fallback={
+                        <div class="account-group-dialog__empty">
+                          No matching accounts
+                        </div>
+                      }
+                    >
+                      <For each={filteredGroupAccounts()}>
+                        {(account) => (
+                          <label class="account-group-dialog__member">
+                            <Checkbox
+                              checked={groupForm().usernames.has(
+                                account.username,
+                              )}
+                              onChange={(event) =>
+                                toggleGroupMember(
+                                  account.username,
+                                  event.currentTarget.checked,
+                                )
+                              }
+                            />
+                            <span class="account-group-dialog__member-text">
+                              <span class="account-group-dialog__member-name">
+                                {account.label}
+                              </span>
+                              <span class="account-group-dialog__member-meta">
+                                {account.username}
+                              </span>
+                            </span>
+                          </label>
+                        )}
+                      </For>
+                    </Show>
+                  </div>
+                </div>
+              </div>
+
+              <DialogFooter>
+                <Show when={groupDialogMode() === "edit"}>
+                  <AlertDialog>
+                    <AlertDialogTrigger
+                      class="button button--destructive-outline button--size-default"
+                      disabled={busy()}
+                      type="button"
+                    >
+                      <Trash2 class="button__icon" />
+                      Delete
+                    </AlertDialogTrigger>
+                    <AlertDialogContent class="account-dialog">
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete Group</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Delete {editingGroupName()}? Accounts in this group
+                          will stay saved.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={() => void handleDeleteGroup()}
+                          variant="destructive"
+                        >
+                          Delete group
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </Show>
+                <DialogClose type="button">Cancel</DialogClose>
+                <Button
+                  size="lg"
+                  type="submit"
+                  loading={busy()}
+                  disabled={!groupFormSubmittable()}
+                >
+                  {groupDialogMode() === "edit" ? "Update" : "Create Group"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </DialogContent>
+        </Dialog>
 
         <Dialog
           open={dialogOpen()}

--- a/app/src/renderer/windows/account-manager/style.css
+++ b/app/src/renderer/windows/account-manager/style.css
@@ -32,6 +32,129 @@
   font-size: var(--text-base);
 }
 
+.account-search__shortcut {
+  padding-left: 0.25rem !important;
+  padding-right: 0.5rem !important;
+}
+
+.account-manager__group-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.account-manager__group-label {
+  align-items: center;
+  color: rgb(var(--foreground));
+  display: flex;
+  font-size: var(--text-base);
+  font-weight: 600;
+  gap: 0.125rem;
+  line-height: 1;
+  min-width: 0;
+}
+
+.account-manager__group-label .button {
+  color: rgb(var(--muted-foreground));
+}
+
+.account-manager__group-label .button__icon {
+  height: 1rem;
+  width: 1rem;
+}
+
+.account-manager__group-field {
+  flex: 1 1 100%;
+  max-width: 100%;
+  min-width: 0;
+  position: relative;
+}
+
+@media (min-width: 1024px) {
+  .account-manager__group-field {
+    flex: 1 1 12rem;
+    max-width: 18rem;
+  }
+}
+
+.account-manager__group-combobox {
+  display: flex;
+  height: var(--control-height-lg);
+  min-width: 0;
+  width: 100%;
+}
+
+.account-manager__group-combobox .combobox__control {
+  min-width: 0;
+  width: 100%;
+}
+
+.account-manager__group-combobox .combobox__control:focus-within {
+  border-color: rgba(var(--ring), 0.58);
+  box-shadow:
+    var(--shadow-xs),
+    inset 0 0 0 1px rgba(var(--ring), 0.12);
+}
+
+.account-manager__group-combobox .combobox__input {
+  cursor: var(--cursor-interactive);
+  font-size: var(--text-base);
+  font-weight: 500;
+  padding-right: 3.25rem;
+  user-select: none;
+}
+
+.account-manager__group-combobox .combobox__input:focus,
+.account-manager__group-combobox .combobox__input:focus-visible {
+  box-shadow: none;
+  outline: none;
+}
+
+.account-manager__group-content {
+  min-width: min(20rem, var(--available-width));
+  width: max-content;
+}
+
+.account-manager__group-shortcut {
+  pointer-events: none;
+  position: absolute;
+  right: 2.625rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.account-manager__group-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.account-group-option {
+  align-items: baseline;
+  display: flex;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.account-group-option__name {
+  flex: 1 1 auto;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-group-option__meta {
+  color: rgb(var(--muted-foreground));
+  flex: 0 0 auto;
+  font-size: var(--text-sm);
+}
+
 .account-manager__launch-row {
   display: grid;
   gap: 0.875rem;
@@ -171,6 +294,7 @@
 .account-manager__selection-actions {
   align-items: center;
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 
@@ -238,14 +362,31 @@
 }
 
 .account-manager__selection-bar {
-  align-items: center;
+  align-items: flex-end;
   color: rgb(var(--muted-foreground));
   display: flex;
+  flex-wrap: wrap;
   font-size: var(--text-base);
   gap: 1rem;
   justify-content: space-between;
-  min-height: 3.25rem;
+  margin-top: 0.75rem;
+  min-height: 4rem;
   min-width: 0;
+}
+
+.account-manager__selection-context {
+  display: grid;
+  flex: 1 1 auto;
+  gap: 0.375rem;
+  justify-items: start;
+  min-width: 0;
+}
+
+.account-manager__selection-count {
+  color: rgb(var(--muted-foreground));
+  font-size: var(--text-base);
+  line-height: 1.25;
+  white-space: nowrap;
 }
 
 .account-list {
@@ -436,6 +577,10 @@
   max-width: 34rem;
 }
 
+.account-group-dialog.dialog__content {
+  max-width: 38rem;
+}
+
 .account-dialog .dialog__header {
   padding: 1.5rem 1.75rem 1.25rem;
 }
@@ -547,6 +692,72 @@
   width: 0.9375rem;
 }
 
+.account-group-dialog__search {
+  height: var(--control-height-lg);
+}
+
+.account-group-dialog__members {
+  border: 1px solid rgba(var(--border), 0.8);
+  border-radius: var(--radius-lg);
+  display: grid;
+  max-height: min(34vh, 18rem);
+  min-height: 8rem;
+  overflow-y: auto;
+}
+
+.account-group-dialog__member {
+  align-items: center;
+  cursor: var(--cursor-interactive);
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 3.25rem;
+  padding: 0.625rem 0.875rem;
+}
+
+.account-group-dialog__member + .account-group-dialog__member {
+  border-top: 1px solid rgba(var(--border), 0.62);
+}
+
+.account-group-dialog__member:hover {
+  background: rgba(var(--accent), 0.42);
+}
+
+.account-group-dialog__member-text {
+  display: grid;
+  gap: 0.1875rem;
+  min-width: 0;
+}
+
+.account-group-dialog__member-name {
+  color: rgb(var(--foreground));
+  font-size: var(--text-base);
+  font-weight: 600;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-group-dialog__member-meta {
+  color: rgb(var(--muted-foreground));
+  font-size: var(--text-sm);
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-group-dialog__empty {
+  align-items: center;
+  color: rgb(var(--muted-foreground));
+  display: flex;
+  font-size: var(--text-base);
+  justify-content: center;
+  min-height: 8rem;
+  padding: 1rem;
+}
+
 .account-dialog .dialog__footer {
   justify-content: flex-end;
   padding: 1rem 1.75rem;
@@ -572,12 +783,6 @@
 
   .account-manager__launch-row {
     grid-template-columns: 1fr;
-  }
-
-  .account-manager__selection-actions,
-  .account-manager__selection-bar {
-    flex-wrap: wrap;
-    justify-content: flex-start;
   }
 
   .account-list {

--- a/app/src/shared/ipc.ts
+++ b/app/src/shared/ipc.ts
@@ -73,6 +73,9 @@ export const AccountManagerIpcChannels = {
   createAccount: "account-manager:create-account",
   updateAccount: "account-manager:update-account",
   deleteAccount: "account-manager:delete-account",
+  createGroup: "account-manager:create-group",
+  updateGroup: "account-manager:update-group",
+  deleteGroup: "account-manager:delete-group",
   launch: "account-manager:launch",
   updateScriptStatus: "account-manager:update-script-status",
   changed: "account-manager:changed",
@@ -153,6 +156,18 @@ export interface ManagedAccountPatch {
   readonly password?: string;
 }
 
+export type ManagedAccountGroups = Readonly<Record<string, readonly string[]>>;
+
+export interface ManagedAccountGroupDraft {
+  readonly name: string;
+  readonly usernames: readonly string[];
+}
+
+export interface ManagedAccountGroupPatch {
+  readonly name?: string;
+  readonly usernames?: readonly string[];
+}
+
 export interface AccountGameServer {
   readonly name: string;
   readonly language: string;
@@ -178,6 +193,7 @@ export interface AccountScriptSession {
 
 export interface AccountManagerState {
   readonly accounts: readonly ManagedAccount[];
+  readonly groups: ManagedAccountGroups;
   readonly sessions: readonly AccountScriptSession[];
   readonly storagePath: string;
 }
@@ -276,6 +292,18 @@ export interface AccountManagerInvokeChannels {
     [username: string],
     AccountManagerState
   >;
+  readonly [AccountManagerIpcChannels.createGroup]: IpcInvokeDefinition<
+    [draft: ManagedAccountGroupDraft],
+    AccountManagerState
+  >;
+  readonly [AccountManagerIpcChannels.updateGroup]: IpcInvokeDefinition<
+    [name: string, patch: ManagedAccountGroupPatch],
+    AccountManagerState
+  >;
+  readonly [AccountManagerIpcChannels.deleteGroup]: IpcInvokeDefinition<
+    [name: string],
+    AccountManagerState
+  >;
   readonly [AccountManagerIpcChannels.launch]: IpcInvokeDefinition<
     [request: AccountLaunchRequest],
     AccountLaunchResult
@@ -304,6 +332,12 @@ export interface AccountManagerBridge {
     patch: ManagedAccountPatch,
   ): Promise<AccountManagerState>;
   deleteAccount(username: string): Promise<AccountManagerState>;
+  createGroup(draft: ManagedAccountGroupDraft): Promise<AccountManagerState>;
+  updateGroup(
+    name: string,
+    patch: ManagedAccountGroupPatch,
+  ): Promise<AccountManagerState>;
+  deleteGroup(name: string): Promise<AccountManagerState>;
   launch(request: AccountLaunchRequest): Promise<AccountLaunchResult>;
   updateScriptStatus(update: AccountScriptStatusUpdate): Promise<void>;
   onChanged(listener: (state: AccountManagerState) => void): () => void;

--- a/packages/ui/src/components/Combobox.tsx
+++ b/packages/ui/src/components/Combobox.tsx
@@ -42,6 +42,12 @@ type ComboboxScrollToIndexDetails = Parameters<
   NonNullable<ComboboxProps["scrollToIndexFn"]>
 >[0];
 
+const defaultComboboxPositioning: NonNullable<ComboboxProps["positioning"]> = {
+  fitViewport: true,
+  placement: "bottom-start",
+  sameWidth: true,
+};
+
 function scrollComboboxItemIntoView(
   details: ComboboxScrollToIndexDetails,
 ): void {
@@ -108,9 +114,7 @@ export function Combobox(props: ComboboxProps): JSX.Element {
         class={cn("combobox", local.class)}
         collection={collection()}
         data-slot="combobox"
-        positioning={
-          local.positioning ?? { fitViewport: true, sameWidth: true }
-        }
+        positioning={{ ...defaultComboboxPositioning, ...local.positioning }}
         scrollToIndexFn={local.scrollToIndexFn ?? scrollComboboxItemIntoView}
       >
         {local.children}

--- a/packages/ui/src/styles/components.css
+++ b/packages/ui/src/styles/components.css
@@ -2162,6 +2162,9 @@ a.badge--destructive:hover {
 
 .select__positioner,
 .combobox__positioner {
+  --x: 0px;
+  --y: -100vh;
+
   outline: none;
   z-index: 60;
 }


### PR DESCRIPTION
Summary:
- add persistent account-manager storage for accounts and groups
- add group create/edit/delete and grouped launch selection UI
- expose group IPC contracts and preload APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added group management to the Account Manager, allowing users to create, edit, and delete groups
  * Added group selection interface with ability to quickly populate account selections from saved groups
  * Added keyboard shortcuts for faster group workflow
  * Enhanced UI with group selection controls and dedicated group management dialog

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->