### PR TITLE
feat: add combat profiles and auto attack

### DIFF
--- a/app/esbuild.config.js
+++ b/app/esbuild.config.js
@@ -40,6 +40,11 @@ const solidRendererTargets = [
     html: "src/renderer/windows/index.html",
   },
   {
+    name: "skills",
+    entryPoint: "./src/renderer/windows/skills/App.tsx",
+    html: "src/renderer/windows/index.html",
+  },
+  {
     name: "fast-travels",
     entryPoint: "./src/renderer/windows/fast-travels/App.tsx",
     html: "src/renderer/windows/index.html",

--- a/app/src/main/combat-profiles-ipc.test.ts
+++ b/app/src/main/combat-profiles-ipc.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CombatProfilesIpcChannels } from "../shared/ipc";
+
+const readSource = (path: string) =>
+  readFileSync(resolve(import.meta.dirname, path), "utf8");
+
+describe("combat profile IPC wiring", () => {
+  it("declares typed combat profile IPC channels", () => {
+    expect(CombatProfilesIpcChannels.getState).toBe(
+      "combat-profiles:get-state",
+    );
+    expect(CombatProfilesIpcChannels.saveProfile).toBe(
+      "combat-profiles:save-profile",
+    );
+    expect(CombatProfilesIpcChannels.deleteProfile).toBe(
+      "combat-profiles:delete-profile",
+    );
+    expect(CombatProfilesIpcChannels.setAutoAttack).toBe(
+      "combat-profiles:set-auto-attack",
+    );
+    expect(CombatProfilesIpcChannels.changed).toBe("combat-profiles:changed");
+  });
+
+  it("exposes the combat profile bridge to renderers", () => {
+    const source = readSource("preload.ts");
+
+    expect(source).toContain("CombatProfilesIpcChannels.getState");
+    expect(source).toContain("combatProfiles: {");
+    expect(source).toContain("saveProfile: async");
+    expect(source).toContain("deleteProfile: async");
+    expect(source).toContain("setAutoAttack: async");
+    expect(source).toContain(
+      "ipcRenderer.on(CombatProfilesIpcChannels.changed",
+    );
+  });
+
+  it("registers combat profile IPC handlers through the main entrypoint", () => {
+    const indexSource = readSource("index.ts");
+    const ipcSource = readSource("combat-profiles-ipc.ts");
+
+    expect(indexSource).toContain("registerCombatProfilesIpcHandlers()");
+    expect(ipcSource).toContain(
+      "ipcMain.handle(CombatProfilesIpcChannels.getState",
+    );
+    expect(ipcSource).toContain(
+      "ipcMain.handle(CombatProfilesIpcChannels.saveProfile",
+    );
+    expect(ipcSource).toContain(
+      "ipcMain.handle(CombatProfilesIpcChannels.deleteProfile",
+    );
+    expect(ipcSource).toContain(
+      "ipcMain.handle(CombatProfilesIpcChannels.setAutoAttack",
+    );
+  });
+});

--- a/app/src/main/combat-profiles-ipc.ts
+++ b/app/src/main/combat-profiles-ipc.ts
@@ -1,0 +1,124 @@
+import { BrowserWindow, ipcMain } from "electron";
+import {
+  DEFAULT_COMBAT_PROFILE_ID,
+  DEFAULT_COMBAT_PROFILE_LIBRARY,
+  normalizeCombatProfileLibrary,
+  type CombatProfile,
+  type CombatProfileAutoAttackState,
+  type CombatProfileLibrary,
+} from "../shared/combat-profiles";
+import { CombatProfilesIpcChannels } from "../shared/ipc";
+import * as Files from "./settings/Files";
+
+let combatProfilesIpcRegistered = false;
+
+const path = (): string => Files.appDataJoin("combat-profiles.json");
+
+const readState = (): CombatProfileLibrary =>
+  Files.ensureJson(
+    path(),
+    DEFAULT_COMBAT_PROFILE_LIBRARY,
+    normalizeCombatProfileLibrary,
+  );
+
+const writeState = (state: CombatProfileLibrary): CombatProfileLibrary => {
+  const normalized = normalizeCombatProfileLibrary(state);
+  Files.writeJson(path(), normalized);
+  return normalized;
+};
+
+const broadcastChanged = (state: CombatProfileLibrary): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) {
+      continue;
+    }
+
+    win.webContents.send(CombatProfilesIpcChannels.changed, state);
+  }
+};
+
+const publishState = (state: CombatProfileLibrary): CombatProfileLibrary => {
+  const normalized = writeState(state);
+  broadcastChanged(normalized);
+  return normalized;
+};
+
+const normalizeProfilePayload = (profile: unknown): CombatProfile => {
+  const normalized = normalizeCombatProfileLibrary({ profiles: [profile] });
+  const explicitId =
+    typeof profile === "object" && profile !== null && "id" in profile
+      ? (profile as { readonly id?: unknown }).id
+      : undefined;
+
+  if (explicitId === DEFAULT_COMBAT_PROFILE_ID) {
+    return (
+      normalized.profiles.find(
+        (candidate) => candidate.id === DEFAULT_COMBAT_PROFILE_ID,
+      ) ?? DEFAULT_COMBAT_PROFILE_LIBRARY.profiles[0]!
+    );
+  }
+
+  return (
+    normalized.profiles.find(
+      (candidate) => candidate.id !== DEFAULT_COMBAT_PROFILE_ID,
+    ) ??
+    normalized.profiles[0] ??
+    DEFAULT_COMBAT_PROFILE_LIBRARY.profiles[0]!
+  );
+};
+
+const saveProfile = (profile: unknown): CombatProfileLibrary => {
+  const current = readState();
+  const normalizedProfile = normalizeProfilePayload(profile);
+  return publishState({
+    ...current,
+    profiles: [
+      ...current.profiles.filter(
+        (candidate) => candidate.id !== normalizedProfile.id,
+      ),
+      normalizedProfile,
+    ],
+  });
+};
+
+const deleteProfile = (profileId: unknown): CombatProfileLibrary => {
+  if (typeof profileId !== "string" || profileId === DEFAULT_COMBAT_PROFILE_ID) {
+    return readState();
+  }
+
+  const current = readState();
+  return publishState({
+    ...current,
+    profiles: current.profiles.filter((profile) => profile.id !== profileId),
+  });
+};
+
+const setAutoAttack = (state: unknown): CombatProfileLibrary => {
+  const current = readState();
+  return publishState({
+    ...current,
+    autoAttack: state as CombatProfileAutoAttackState,
+  });
+};
+
+export const registerCombatProfilesIpcHandlers = (): void => {
+  if (combatProfilesIpcRegistered) {
+    return;
+  }
+
+  ipcMain.handle(CombatProfilesIpcChannels.getState, () => readState());
+
+  ipcMain.handle(CombatProfilesIpcChannels.saveProfile, (_event, profile) =>
+    saveProfile(profile),
+  );
+
+  ipcMain.handle(CombatProfilesIpcChannels.deleteProfile, (_event, profileId) =>
+    deleteProfile(profileId),
+  );
+
+  ipcMain.handle(CombatProfilesIpcChannels.setAutoAttack, (_event, state) =>
+    setAutoAttack(state),
+  );
+
+  combatProfilesIpcRegistered = true;
+};

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   getArtixLauncherRequestHeaders,
   getArtixLauncherUserAgent,
 } from "./artix-launcher-headers";
+import { registerCombatProfilesIpcHandlers } from "./combat-profiles-ipc";
 import { createApplicationMenu } from "./menu";
 import { registerEnvironmentIpcHandlers } from "./environment-ipc";
 import * as Appearance from "./settings/Appearance";
@@ -344,6 +345,7 @@ app.whenReady().then(() => {
   registerScriptingIpcHandlers();
   registerArmyIpcHandlers();
   registerAccountManagerIpcHandlers(runConfiguredWindowEffect);
+  registerCombatProfilesIpcHandlers();
   registerEnvironmentIpcHandlers(runConfiguredWindowEffect);
   registerSettingsIpcHandlers();
   registerWindowIpcHandlers(runConfiguredWindowEffect);

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -6,6 +6,7 @@ import {
 import {
   AccountManagerIpcChannels,
   ArmyIpcChannels,
+  CombatProfilesIpcChannels,
   EnvironmentIpcChannels,
   SettingsIpcChannels,
   ScriptingIpcChannels,
@@ -27,6 +28,9 @@ import {
   type AppSettings,
   type AppPlatform,
   type AppearancePatch,
+  type CombatProfile,
+  type CombatProfileAutoAttackState,
+  type CombatProfileLibrary,
   type EnvironmentItemRules,
   type EnvironmentQuestAutoRegisterOptions,
   type EnvironmentState,
@@ -277,6 +281,45 @@ const bridge: AppBridge = {
         ArmyIpcChannels.status,
         payload,
       )) as ArmyStatusResult;
+    },
+  },
+  combatProfiles: {
+    getState: async () => {
+      return (await ipcRenderer.invoke(
+        CombatProfilesIpcChannels.getState,
+      )) as CombatProfileLibrary;
+    },
+    saveProfile: async (profile: CombatProfile) => {
+      return (await ipcRenderer.invoke(
+        CombatProfilesIpcChannels.saveProfile,
+        profile,
+      )) as CombatProfileLibrary;
+    },
+    deleteProfile: async (profileId: string) => {
+      return (await ipcRenderer.invoke(
+        CombatProfilesIpcChannels.deleteProfile,
+        profileId,
+      )) as CombatProfileLibrary;
+    },
+    setAutoAttack: async (state: CombatProfileAutoAttackState) => {
+      return (await ipcRenderer.invoke(
+        CombatProfilesIpcChannels.setAutoAttack,
+        state,
+      )) as CombatProfileLibrary;
+    },
+    onChanged: (listener) => {
+      const subscription = (_event: unknown, state: CombatProfileLibrary) => {
+        listener(state);
+      };
+
+      ipcRenderer.on(CombatProfilesIpcChannels.changed, subscription);
+
+      return () => {
+        ipcRenderer.removeListener(
+          CombatProfilesIpcChannels.changed,
+          subscription,
+        );
+      };
     },
   },
   environment: {

--- a/app/src/renderer/windows/environment/style.css
+++ b/app/src/renderer/windows/environment/style.css
@@ -39,10 +39,9 @@
 
 .environment-sync-spinner.spinner {
   border-width: 1.5px;
+  box-sizing: border-box;
   flex: 0 0 auto;
   height: 0.875rem;
-  margin-left: -0.125rem;
-  margin-right: -0.125rem;
   opacity: 0.9;
   width: 0.875rem;
 }

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -206,6 +206,7 @@ export default function App(props: {
   let autoAttackStateDisposer: (() => void) | undefined;
   let autoZoneStateDisposer: (() => void) | undefined;
   let autoReloginStateDisposer: (() => void) | undefined;
+  let autoAttackToggleInFlight = false;
   let cleanedUp = false;
   const accountLaunchFibers = new Set<Fiber.Fiber<void, unknown>>();
   const assignDisposer =
@@ -839,6 +840,11 @@ export default function App(props: {
   };
 
   const handleToggleAutoAttack = () => {
+    if (autoAttackToggleInFlight) {
+      return;
+    }
+
+    autoAttackToggleInFlight = true;
     const nextEnabled = !autoAttackEnabled();
     setAutoAttackEnabled(nextEnabled);
 
@@ -860,6 +866,9 @@ export default function App(props: {
       .catch((error) => {
         console.error("Toggle auto attack error:", error);
         refreshAutoAttackState();
+      })
+      .finally(() => {
+        autoAttackToggleInFlight = false;
       });
   };
 
@@ -1141,7 +1150,11 @@ export default function App(props: {
     scriptRunning,
     autoAttackEnabled,
     toggleAutoAttack: handleToggleAutoAttack,
-    toggleBank: handleOpenBank,
+    toggleBank: () => {
+      if (canApplyGameSettings()) {
+        handleOpenBank();
+      }
+    },
     optionItems,
     openWindow,
     openTopNavMenu: (menu) => setOpenTopNavMenu(menu),

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -20,6 +20,14 @@ import {
   DEFAULT_PREFERENCES,
   type AppSettings,
 } from "../../../shared/settings";
+import {
+  DEFAULT_COMBAT_PROFILE_ID,
+  DEFAULT_COMBAT_PROFILE_LIBRARY,
+  autoAttackStateToProfileRef,
+  findCombatProfileByRef,
+  type CombatProfileAutoAttackMode,
+  type CombatProfileLibrary,
+} from "../../../shared/combat-profiles";
 import type {
   AccountGameLaunchPayload,
   ScriptExecutePayload,
@@ -32,6 +40,10 @@ import { SwfMethodNotFoundError, SwfUnavailableError } from "./flash/Errors";
 import { Bank } from "./flash/Services/Bank";
 import { Player } from "./flash/Services/Player";
 import { World } from "./flash/Services/World";
+import {
+  AutoAttack,
+  type AutoAttackState,
+} from "./features/Services/AutoAttack";
 import {
   AutoRelogin,
   type AutoReloginState,
@@ -133,6 +145,11 @@ export default function App(props: {
   const [gameLoaded, setGameLoaded] = createSignal(getGameLoadState().loaded);
   const [playerReady, setPlayerReady] = createSignal(false);
   const [autoAttackEnabled, setAutoAttackEnabled] = createSignal(false);
+  const [autoAttackProfileLabel, setAutoAttackProfileLabel] =
+    createSignal("Generic");
+  const [autoAttackLastError, setAutoAttackLastError] = createSignal("");
+  const [combatProfileLibrary, setCombatProfileLibrary] =
+    createSignal<CombatProfileLibrary>(DEFAULT_COMBAT_PROFILE_LIBRARY);
   const [scriptName, setScriptName] = createSignal("");
   const [scriptSource, setScriptSource] = createSignal("");
   const [scriptLoaded, setScriptLoaded] = createSignal(false);
@@ -186,12 +203,13 @@ export default function App(props: {
   const [travelBusy, setTravelBusy] = createSignal(false);
 
   let settingsStateDisposer: (() => void) | undefined;
+  let autoAttackStateDisposer: (() => void) | undefined;
   let autoZoneStateDisposer: (() => void) | undefined;
   let autoReloginStateDisposer: (() => void) | undefined;
   let cleanedUp = false;
   const accountLaunchFibers = new Set<Fiber.Fiber<void, unknown>>();
   const assignDisposer =
-    (slot: "settings" | "autoZone" | "autoRelogin") =>
+    (slot: "settings" | "autoAttack" | "autoZone" | "autoRelogin") =>
     (dispose: () => void) => {
       if (cleanedUp) {
         dispose();
@@ -200,6 +218,8 @@ export default function App(props: {
 
       if (slot === "settings") {
         settingsStateDisposer = dispose;
+      } else if (slot === "autoAttack") {
+        autoAttackStateDisposer = dispose;
       } else if (slot === "autoZone") {
         autoZoneStateDisposer = dispose;
       } else {
@@ -749,6 +769,116 @@ export default function App(props: {
     );
   };
 
+  const autoAttackConfiguredProfileLabel = createMemo(() => {
+    const library = combatProfileLibrary();
+    const state = library.autoAttack;
+
+    if (state.mode === "generic") {
+      return "Generic";
+    }
+
+    if (state.mode === "selected" && state.selectedProfileId) {
+      const profile = findCombatProfileByRef(library, {
+        mode: "selected",
+        profileId: state.selectedProfileId,
+      });
+      return `Profile: ${profile.label}`;
+    }
+
+    return "Match class";
+  });
+
+  const applyAutoAttackState = (state: AutoAttackState) => {
+    setAutoAttackEnabled(state.enabled);
+    setAutoAttackProfileLabel(
+      state.profileLabel ?? autoAttackConfiguredProfileLabel(),
+    );
+    setAutoAttackLastError(state.lastError ?? "");
+  };
+
+  const refreshAutoAttackState = () => {
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoAttack = yield* AutoAttack;
+          return yield* autoAttack.getState();
+        }),
+      )
+      .then(applyAutoAttackState)
+      .catch((error) => {
+        console.error("Refresh auto attack state error:", error);
+      });
+  };
+
+  const syncEnabledAutoAttackProfile = (library: CombatProfileLibrary) => {
+    if (!autoAttackEnabled()) {
+      setAutoAttackProfileLabel(autoAttackConfiguredProfileLabel());
+      return;
+    }
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoAttack = yield* AutoAttack;
+          return yield* autoAttack.enable({
+            library,
+            profileRef: autoAttackStateToProfileRef(library.autoAttack),
+          });
+        }),
+      )
+      .then(applyAutoAttackState)
+      .catch((error) => {
+        console.error("Sync auto attack profile error:", error);
+        refreshAutoAttackState();
+      });
+  };
+
+  const applyCombatProfileLibrary = (library: CombatProfileLibrary) => {
+    setCombatProfileLibrary(library);
+    syncEnabledAutoAttackProfile(library);
+  };
+
+  const handleToggleAutoAttack = () => {
+    const nextEnabled = !autoAttackEnabled();
+    setAutoAttackEnabled(nextEnabled);
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const autoAttack = yield* AutoAttack;
+          return nextEnabled
+            ? yield* autoAttack.enable({
+                library: combatProfileLibrary(),
+                profileRef: autoAttackStateToProfileRef(
+                  combatProfileLibrary().autoAttack,
+                ),
+              })
+            : yield* autoAttack.disable();
+        }),
+      )
+      .then(applyAutoAttackState)
+      .catch((error) => {
+        console.error("Toggle auto attack error:", error);
+        refreshAutoAttackState();
+      });
+  };
+
+  const handleSelectAutoAttackProfile = (
+    mode: CombatProfileAutoAttackMode,
+    selectedProfileId?: string,
+  ) => {
+    void window.ipc.combatProfiles
+      .setAutoAttack(
+        mode === "selected" && selectedProfileId
+          ? { mode, selectedProfileId }
+          : { mode },
+      )
+      .then(applyCombatProfileLibrary)
+      .catch((error: unknown) => {
+        console.error("Set auto attack profile error:", error);
+      });
+  };
+
   const applyAutoZoneState = (state: AutoZoneState) => {
     setAutoZoneEnabled(state.enabled);
     setAutoZoneMap(state.map);
@@ -1009,8 +1139,9 @@ export default function App(props: {
     stopScript,
     scriptLoaded,
     scriptRunning,
-    setAutoAttackEnabled,
     autoAttackEnabled,
+    toggleAutoAttack: handleToggleAutoAttack,
+    toggleBank: handleOpenBank,
     optionItems,
     openWindow,
     openTopNavMenu: (menu) => setOpenTopNavMenu(menu),
@@ -1036,6 +1167,8 @@ export default function App(props: {
       window.ipc.settings.onChanged(applyAppSettings);
     const unsubscribeAccountLaunch =
       window.ipc.accounts.onGameLaunch(handleAccountLaunch);
+    const unsubscribeCombatProfiles =
+      window.ipc.combatProfiles.onChanged(applyCombatProfileLibrary);
     const unsubscribeScriptExecute = window.ipc.scripting.onExecute(
       (payload) => {
         void applyScriptPayload(payload)
@@ -1064,6 +1197,13 @@ export default function App(props: {
           console.error("Failed to load app settings:", error);
         });
     }
+
+    void window.ipc.combatProfiles
+      .getState()
+      .then(applyCombatProfileLibrary)
+      .catch((error) => {
+        console.error("Failed to load combat profiles:", error);
+      });
 
     const disposeGameLoadState = subscribeGameLoadState((state) => {
       setGameLoaded(state.loaded);
@@ -1110,6 +1250,18 @@ export default function App(props: {
     void runtime
       .runPromise(
         Effect.gen(function* () {
+          const autoAttack = yield* AutoAttack;
+          return yield* autoAttack.onState(applyAutoAttackState);
+        }),
+      )
+      .then(assignDisposer("autoAttack"))
+      .catch((error) => {
+        console.error("AutoAttack state subscription error:", error);
+      });
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
           const autoRelogin = yield* AutoRelogin;
           return yield* autoRelogin.onState(applyAutoReloginState);
         }),
@@ -1134,6 +1286,7 @@ export default function App(props: {
     onCleanup(() => {
       unsubscribeAppSettings();
       unsubscribeAccountLaunch();
+      unsubscribeCombatProfiles();
       unsubscribeScriptExecute();
       unsubscribeScriptStop();
       disposeGameLoadState();
@@ -1149,6 +1302,7 @@ export default function App(props: {
     }
     accountLaunchFibers.clear();
     settingsStateDisposer?.();
+    autoAttackStateDisposer?.();
     autoZoneStateDisposer?.();
     autoReloginStateDisposer?.();
   });
@@ -1163,7 +1317,20 @@ export default function App(props: {
           hotkeyBindings={() => settings().hotkeys.bindings}
           hotkeyPlatform={window.ipc.platform.os}
           autoAttackEnabled={autoAttackEnabled}
-          setAutoAttackEnabled={setAutoAttackEnabled}
+          autoAttackProfileLabel={autoAttackProfileLabel}
+          autoAttackConfiguredProfileLabel={autoAttackConfiguredProfileLabel}
+          autoAttackLastError={autoAttackLastError}
+          combatProfiles={() =>
+            combatProfileLibrary().profiles.filter(
+              (profile) => profile.id !== DEFAULT_COMBAT_PROFILE_ID,
+            )
+          }
+          autoAttackMode={() => combatProfileLibrary().autoAttack.mode}
+          selectedAutoAttackProfileId={() =>
+            combatProfileLibrary().autoAttack.selectedProfileId
+          }
+          handleToggleAutoAttack={handleToggleAutoAttack}
+          handleSelectAutoAttackProfile={handleSelectAutoAttackProfile}
           gameLoaded={gameLoaded}
           playerReady={playerReady}
           scriptLoaded={scriptLoaded}

--- a/app/src/renderer/windows/game/TopNav.tsx
+++ b/app/src/renderer/windows/game/TopNav.tsx
@@ -14,10 +14,13 @@ import {
 } from "solid-js";
 import { ChevronDown, CircleAlert, Clock, LoaderCircle } from "lucide-solid";
 import { formatOptionalHotkeyDisplay } from "@vexed/shared/hotkeyDisplay";
+import type {
+  CombatProfile,
+  CombatProfileAutoAttackMode,
+} from "../../../shared/combat-profiles";
 import {
   Button,
   type ButtonProps,
-  Checkbox,
   Input,
   Kbd,
   Menu,
@@ -62,7 +65,17 @@ export interface TopNavProps {
   readonly hotkeyBindings: Accessor<HotkeyBindings>;
   readonly hotkeyPlatform: AppPlatform;
   readonly autoAttackEnabled: Accessor<boolean>;
-  readonly setAutoAttackEnabled: Setter<boolean>;
+  readonly autoAttackProfileLabel: Accessor<string>;
+  readonly autoAttackConfiguredProfileLabel: Accessor<string>;
+  readonly autoAttackLastError: Accessor<string>;
+  readonly combatProfiles: Accessor<readonly CombatProfile[]>;
+  readonly autoAttackMode: Accessor<CombatProfileAutoAttackMode>;
+  readonly selectedAutoAttackProfileId: Accessor<string | undefined>;
+  readonly handleToggleAutoAttack: () => void;
+  readonly handleSelectAutoAttackProfile: (
+    mode: CombatProfileAutoAttackMode,
+    selectedProfileId?: string,
+  ) => void;
   readonly gameLoaded: Accessor<boolean>;
   readonly playerReady: Accessor<boolean>;
   readonly scriptLoaded: Accessor<boolean>;
@@ -239,6 +252,54 @@ export function TopNav(props: TopNavProps): JSX.Element {
         : autoReloginNeedsAttention()
           ? "alert"
           : undefined;
+
+  const autoAttackTriggerLabel = (): string => {
+    const runtimeLabel = props.autoAttackProfileLabel();
+    const configuredLabel = props.autoAttackConfiguredProfileLabel();
+    const error = props.autoAttackLastError();
+
+    if (error !== "") {
+      return `Auto Attack failed: ${error}`;
+    }
+
+    if (!props.autoAttackEnabled()) {
+      return configuredLabel === ""
+        ? "Auto Attack disabled"
+        : `Auto Attack disabled: ${configuredLabel}`;
+    }
+
+    if (
+      props.autoAttackMode() === "equipped-class" &&
+      runtimeLabel !== "" &&
+      runtimeLabel !== configuredLabel
+    ) {
+      return `Auto Attack enabled: ${configuredLabel}, using ${runtimeLabel}`;
+    }
+
+    return configuredLabel === ""
+      ? "Auto Attack enabled"
+      : `Auto Attack enabled: ${configuredLabel}`;
+  };
+
+  const autoAttackSelectionValue = (): string =>
+    props.autoAttackMode() === "selected"
+      ? `profile:${props.selectedAutoAttackProfileId() ?? ""}`
+      : props.autoAttackMode();
+
+  const handleAutoAttackSelectionChange = (details: { value: string }) => {
+    const value = details.value;
+    if (value === "generic" || value === "equipped-class") {
+      props.handleSelectAutoAttackProfile(value);
+      return;
+    }
+
+    if (value.startsWith("profile:")) {
+      props.handleSelectAutoAttackProfile(
+        "selected",
+        value.slice("profile:".length),
+      );
+    }
+  };
 
   onMount(() => {
     let lastTopNavHeight = 0;
@@ -907,20 +968,111 @@ export function TopNav(props: TopNavProps): JSX.Element {
         <div
           class="game-topnav__right"
           data-menu-open={
-            props.openMenu() === "pads" || props.openMenu() === "cells"
+            props.openMenu() === "combat" ||
+            props.openMenu() === "pads" ||
+            props.openMenu() === "cells"
               ? ""
               : undefined
           }
         >
-          <Checkbox
-            checked={props.autoAttackEnabled()}
-            disabled={gameInteractionDisabled()}
-            onChange={(event) =>
-              props.setAutoAttackEnabled(event.currentTarget.checked)
-            }
+          <Menu
+            open={props.openMenu() === "combat"}
+            onOpenChange={setMenuOpen("combat")}
           >
-            Auto
-          </Checkbox>
+            <TopNavMenuTrigger
+              aria-label={autoAttackTriggerLabel()}
+              aria-pressed={props.autoAttackEnabled()}
+              class={cn(
+                "game-topnav__combat-trigger",
+                props.autoAttackLastError() !== "" &&
+                  "game-topnav__trigger--alert",
+              )}
+              data-enabled={props.autoAttackEnabled() ? "" : undefined}
+              disabled={gameInteractionDisabled()}
+              expanded={props.openMenu() === "combat"}
+              onClick={toggleMenu("combat")}
+              title={autoAttackTriggerLabel()}
+            >
+              <span
+                aria-hidden="true"
+                class={cn(
+                  "game-topnav__combat-check",
+                  props.autoAttackEnabled() &&
+                    "game-topnav__combat-check--active",
+                )}
+              />
+              <span class="game-topnav__combat-label">
+                {props.autoAttackConfiguredProfileLabel()}
+              </span>
+              <ChevronDown
+                aria-hidden="true"
+                class="game-topnav__select-chevron"
+              />
+            </TopNavMenuTrigger>
+            <MenuContent class="game-menu game-menu--combat" portal={false}>
+              <MenuAutofocusAnchor />
+              <MenuGroup>
+                <MenuLabel>State</MenuLabel>
+                <MenuCheckboxItem
+                  checked={props.autoAttackEnabled()}
+                  class="game-menu__item"
+                  closeOnSelect={false}
+                  disabled={gameInteractionDisabled()}
+                  onClick={props.handleToggleAutoAttack}
+                  value="toggle-auto-attack"
+                >
+                  {props.autoAttackEnabled() ? "Enabled" : "Disabled"}
+                </MenuCheckboxItem>
+              </MenuGroup>
+              <MenuSeparator />
+              <MenuGroup>
+                <MenuLabel>Mode</MenuLabel>
+              </MenuGroup>
+              <MenuRadioGroup
+                value={autoAttackSelectionValue()}
+                onValueChange={handleAutoAttackSelectionChange}
+              >
+                <MenuRadioItem
+                  class="game-menu__item"
+                  closeOnSelect={false}
+                  value="equipped-class"
+                >
+                  <span class="game-menu__item-label">Match equipped class</span>
+                </MenuRadioItem>
+                <MenuRadioItem
+                  class="game-menu__item"
+                  closeOnSelect={false}
+                  value="generic"
+                >
+                  <span class="game-menu__item-label">Use generic</span>
+                </MenuRadioItem>
+              </MenuRadioGroup>
+              <Show when={props.combatProfiles().length > 0}>
+                <MenuSeparator />
+                <MenuGroup>
+                  <MenuLabel>Profiles</MenuLabel>
+                </MenuGroup>
+                <MenuRadioGroup
+                  value={autoAttackSelectionValue()}
+                  onValueChange={handleAutoAttackSelectionChange}
+                >
+                  <For each={props.combatProfiles()}>
+                    {(profile) => (
+                      <MenuRadioItem
+                        class="game-menu__item"
+                        closeOnSelect={false}
+                        value={`profile:${profile.id}`}
+                      >
+                        <span class="game-menu__item-label">
+                          {profile.label}
+                        </span>
+                      </MenuRadioItem>
+                    )}
+                  </For>
+                </MenuRadioGroup>
+              </Show>
+            </MenuContent>
+          </Menu>
 
           <div class="game-topnav__divider" />
 

--- a/app/src/renderer/windows/game/combatProfiles.ts
+++ b/app/src/renderer/windows/game/combatProfiles.ts
@@ -1,0 +1,215 @@
+import type { Aura, Monster } from "@vexed/game";
+import { Effect, Option, Ref } from "effect";
+import type {
+  CombatProfile,
+  CombatProfileAuraCondition,
+  CombatProfileCondition,
+  CombatProfileStatCondition,
+  CombatProfileStep,
+} from "../../../shared/combat-profiles";
+import { Combat } from "./flash/Services/Combat";
+import { Player } from "./flash/Services/Player";
+import { World } from "./flash/Services/World";
+
+export interface CombatProfileCursor {
+  readonly index: Ref.Ref<number>;
+}
+
+export const makeCombatProfileCursor = (): Effect.Effect<CombatProfileCursor> =>
+  Effect.map(Ref.make(0), (index) => ({ index }));
+
+const compare = (
+  actual: number,
+  op: CombatProfileStatCondition["op"],
+  expected: number,
+): boolean => (op === ">=" ? actual >= expected : actual <= expected);
+
+const statValue = (
+  current: number,
+  max: number,
+  unit: CombatProfileStatCondition["unit"],
+): number => {
+  if (unit === "value") {
+    return current;
+  }
+
+  return max > 0 ? (current / max) * 100 : 0;
+};
+
+const auraValue = (aura: Aura | undefined): number =>
+  aura === undefined ? 0 : (aura.stack ?? aura.value ?? 1);
+
+const getSelfEntId = Effect.gen(function* () {
+  const world = yield* World;
+  return yield* world.players.withSelf((me) => me.data.entID);
+});
+
+const getTargetAura = (condition: CombatProfileAuraCondition) =>
+  Effect.gen(function* () {
+    const combat = yield* Combat;
+    const world = yield* World;
+    const target = yield* combat.getTarget();
+
+    if (!target) {
+      return 0;
+    }
+
+    if (target.isMonster()) {
+      const aura = yield* world.monsters.getAura(
+        target.monMapId,
+        condition.auraName,
+      );
+      return auraValue(Option.isSome(aura) ? aura.value : undefined);
+    }
+
+    const aura = yield* world.players.getAura(
+      target.data.entID,
+      condition.auraName,
+    );
+    return auraValue(Option.isSome(aura) ? aura.value : undefined);
+  });
+
+const matchesStatCondition = (condition: CombatProfileStatCondition) =>
+  Effect.gen(function* () {
+    const player = yield* Player;
+    const world = yield* World;
+
+    if (condition.type === "self-hp") {
+      const hp = yield* player.getHp();
+      const maxHp = yield* player.getMaxHp();
+      return compare(
+        statValue(hp, maxHp, condition.unit),
+        condition.op,
+        condition.value,
+      );
+    }
+
+    if (condition.type === "self-mp") {
+      const mp = yield* player.getMp();
+      const maxMp = yield* player.getMaxMp();
+      return compare(
+        statValue(mp, maxMp, condition.unit),
+        condition.op,
+        condition.value,
+      );
+    }
+
+    const self = yield* world.players.withSelf((me) => ({
+      entId: me.data.entID,
+      username: me.username.toLowerCase(),
+    }));
+    if (Option.isNone(self)) {
+      return false;
+    }
+
+    const players = yield* world.players.getAll();
+    for (const ally of players.values()) {
+      if (
+        ally.data.entID === self.value.entId ||
+        ally.username.toLowerCase() === self.value.username
+      ) {
+        continue;
+      }
+
+      if (
+        compare(
+          statValue(ally.hp, ally.maxHp, condition.unit),
+          condition.op,
+          condition.value,
+        )
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
+const matchesAuraCondition = (condition: CombatProfileAuraCondition) =>
+  Effect.gen(function* () {
+    const world = yield* World;
+    const actual =
+      condition.type === "target-aura"
+        ? yield* getTargetAura(condition)
+        : yield* Effect.gen(function* () {
+            const entId = yield* getSelfEntId;
+            if (Option.isNone(entId)) {
+              return 0;
+            }
+
+            const aura = yield* world.players.getAura(
+              entId.value,
+              condition.auraName,
+            );
+            return auraValue(Option.isSome(aura) ? aura.value : undefined);
+          });
+
+    return compare(actual, condition.op, condition.value);
+  });
+
+const matchesCondition = (condition: CombatProfileCondition) => {
+  switch (condition.type) {
+    case "self-aura":
+    case "target-aura":
+      return matchesAuraCondition(condition);
+    case "self-hp":
+    case "self-mp":
+    case "ally-hp":
+      return matchesStatCondition(condition);
+  }
+};
+
+const matchesStep = (step: CombatProfileStep) =>
+  Effect.gen(function* () {
+    for (const condition of step.conditions) {
+      if (!(yield* matchesCondition(condition))) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+export const castNextCombatProfileStep = (
+  profile: CombatProfile,
+  cursor: CombatProfileCursor,
+) =>
+  Effect.gen(function* () {
+    const combat = yield* Combat;
+    const steps = profile.steps;
+    if (steps.length === 0) {
+      return false;
+    }
+
+    const startIndex = yield* Ref.get(cursor.index);
+
+    for (let offset = 0; offset < steps.length; offset += 1) {
+      const stepIndex = (startIndex + offset) % steps.length;
+      const step = steps[stepIndex];
+      if (!step || !(yield* matchesStep(step))) {
+        continue;
+      }
+
+      const shouldWait =
+        profile.cooldownMode === "wait-for-cooldown" &&
+        step.skipIfUnavailable !== true;
+
+      if (!shouldWait && !(yield* combat.canUseSkill(step.skill))) {
+        continue;
+      }
+
+      yield* Ref.set(cursor.index, (stepIndex + 1) % steps.length);
+      yield* combat.useSkill(step.skill, false, shouldWait);
+
+      if (step.waitMs !== undefined && step.waitMs > 0) {
+        yield* Effect.sleep(`${step.waitMs} millis`);
+      }
+
+      return true;
+    }
+
+    return false;
+  });
+
+export const isAttackableMonster = (monster: Monster): boolean =>
+  monster.alive && !monster.isDead();

--- a/app/src/renderer/windows/game/combatProfiles.ts
+++ b/app/src/renderer/windows/game/combatProfiles.ts
@@ -198,8 +198,8 @@ export const castNextCombatProfileStep = (
         continue;
       }
 
-      yield* Ref.set(cursor.index, (stepIndex + 1) % steps.length);
       yield* combat.useSkill(step.skill, false, shouldWait);
+      yield* Ref.set(cursor.index, (stepIndex + 1) % steps.length);
 
       if (step.waitMs !== undefined && step.waitMs > 0) {
         yield* Effect.sleep(`${step.waitMs} millis`);

--- a/app/src/renderer/windows/game/combatProfiles.ts
+++ b/app/src/renderer/windows/game/combatProfiles.ts
@@ -94,30 +94,31 @@ const matchesStatCondition = (condition: CombatProfileStatCondition) =>
       );
     }
 
+    const matchesPlayerHp = (hp: number, maxHp: number): boolean =>
+      compare(statValue(hp, maxHp, condition.unit), condition.op, condition.value);
+
     const self = yield* world.players.withSelf((me) => ({
       entId: me.data.entID,
+      hp: me.hp,
+      maxHp: me.maxHp,
       username: me.username.toLowerCase(),
     }));
-    if (Option.isNone(self)) {
-      return false;
+
+    if (Option.isSome(self) && matchesPlayerHp(self.value.hp, self.value.maxHp)) {
+      return true;
     }
 
     const players = yield* world.players.getAll();
-    for (const ally of players.values()) {
+    for (const roomPlayer of players.values()) {
       if (
-        ally.data.entID === self.value.entId ||
-        ally.username.toLowerCase() === self.value.username
+        Option.isSome(self) &&
+        (roomPlayer.data.entID === self.value.entId ||
+          roomPlayer.username.toLowerCase() === self.value.username)
       ) {
         continue;
       }
 
-      if (
-        compare(
-          statValue(ally.hp, ally.maxHp, condition.unit),
-          condition.op,
-          condition.value,
-        )
-      ) {
+      if (matchesPlayerHp(roomPlayer.hp, roomPlayer.maxHp)) {
         return true;
       }
     }

--- a/app/src/renderer/windows/game/commands.test.ts
+++ b/app/src/renderer/windows/game/commands.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Setter } from "solid-js";
 import type { HotkeyBindings } from "../../../shared/hotkeys";
 import { createGameCommands, type GameCommandRuntime } from "./commands";
 import type { TopNavOptionItem } from "./topNavOptions";
@@ -11,12 +10,6 @@ const createRuntime = (
 ): GameCommandRuntime => {
   let autoAttackEnabled = false;
 
-  const setAutoAttackEnabled: Setter<boolean> = (value) => {
-    autoAttackEnabled =
-      typeof value === "function" ? value(autoAttackEnabled) : value;
-    return autoAttackEnabled;
-  };
-
   return {
     bindings: () => [] satisfies HotkeyBindings,
     loadScript: noop,
@@ -24,8 +17,11 @@ const createRuntime = (
     stopScript: noop,
     scriptLoaded: () => true,
     scriptRunning: () => false,
-    setAutoAttackEnabled,
     autoAttackEnabled: () => autoAttackEnabled,
+    toggleAutoAttack: () => {
+      autoAttackEnabled = !autoAttackEnabled;
+    },
+    toggleBank: noop,
     optionItems: () => [],
     openWindow: noop,
     openTopNavMenu: noop,
@@ -66,6 +62,24 @@ describe("game commands", () => {
     findCommand(runtime, "toggleTopBar").run();
 
     expect(toggleTopBarVisible).toHaveBeenCalledOnce();
+  });
+
+  it("toggles auto attack through the runtime action", () => {
+    const toggleAutoAttack = vi.fn();
+    const runtime = createRuntime({ toggleAutoAttack });
+
+    findCommand(runtime, "toggleAutoattack").run();
+
+    expect(toggleAutoAttack).toHaveBeenCalledOnce();
+  });
+
+  it("toggles bank through the runtime action", () => {
+    const toggleBank = vi.fn();
+    const runtime = createRuntime({ toggleBank });
+
+    findCommand(runtime, "toggleBank").run();
+
+    expect(toggleBank).toHaveBeenCalledOnce();
   });
 
   it("dispatches option commands through top nav option items", () => {

--- a/app/src/renderer/windows/game/commands.ts
+++ b/app/src/renderer/windows/game/commands.ts
@@ -1,4 +1,4 @@
-import type { Accessor, Setter } from "solid-js";
+import type { Accessor } from "solid-js";
 import {
   GAME_COMMANDS,
   type CommandCategory,
@@ -23,8 +23,9 @@ export interface GameCommandRuntime {
   readonly stopScript: () => void;
   readonly scriptLoaded: Accessor<boolean>;
   readonly scriptRunning: Accessor<boolean>;
-  readonly setAutoAttackEnabled: Setter<boolean>;
   readonly autoAttackEnabled: Accessor<boolean>;
+  readonly toggleAutoAttack: () => void;
+  readonly toggleBank: () => void;
   readonly optionItems: Accessor<readonly TopNavOptionItem[]>;
   readonly openWindow: (id: WindowId) => void;
   readonly openTopNavMenu: (menu: GameTopNavMenu) => void;
@@ -134,8 +135,12 @@ const createCommandRunner = (
 
   if (id === "toggleAutoattack") {
     return () => {
-      runtime.setAutoAttackEnabled((enabled) => !enabled);
+      runtime.toggleAutoAttack();
     };
+  }
+
+  if (id === "toggleBank") {
+    return runtime.toggleBank;
   }
 
   if (id === "openOptionsMenu") {

--- a/app/src/renderer/windows/game/features/Layers/AutoAttack.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoAttack.ts
@@ -94,6 +94,13 @@ const make = Effect.gen(function* () {
       yield* emitCurrentState;
     });
 
+  const clearLastError = Effect.gen(function* () {
+    const lastError = yield* Ref.get(lastErrorRef);
+    if (lastError !== undefined) {
+      yield* setLastError(undefined);
+    }
+  });
+
   const selectTarget = Effect.gen(function* () {
     const currentTarget = yield* combat.getTarget();
     if (
@@ -131,21 +138,30 @@ const make = Effect.gen(function* () {
           continue;
         }
 
-        yield* combat.attackMonster(monMapId).pipe(
+        const attackFailed = yield* combat.attackMonster(monMapId).pipe(
+          Effect.as(false),
           Effect.catch((error) =>
             setLastError(
               error instanceof Error ? error.message : "Failed to attack",
-            ),
+            ).pipe(Effect.as(true)),
           ),
         );
 
-        const cast = yield* castNextCombatProfileStep(profile, cursor).pipe(
+        const { cast, castFailed } = yield* castNextCombatProfileStep(
+          profile,
+          cursor,
+        ).pipe(
+          Effect.map((cast) => ({ cast, castFailed: false })),
           Effect.catch((error) =>
             setLastError(
               error instanceof Error ? error.message : "Failed to use profile",
-            ).pipe(Effect.as(false)),
+            ).pipe(Effect.as({ cast: false, castFailed: true })),
           ),
         );
+
+        if (!attackFailed && !castFailed) {
+          yield* clearLastError;
+        }
 
         const delayMs = Math.max(
           MIN_LOOP_DELAY_MS,

--- a/app/src/renderer/windows/game/features/Layers/AutoAttack.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoAttack.ts
@@ -1,0 +1,252 @@
+import { Effect, Layer, Ref, Semaphore } from "effect";
+import {
+  findCombatProfileByRef,
+  type CombatProfile,
+} from "../../../../../shared/combat-profiles";
+import {
+  castNextCombatProfileStep,
+  isAttackableMonster,
+  makeCombatProfileCursor,
+} from "../../combatProfiles";
+import { Combat } from "../../flash/Services/Combat";
+import { Player } from "../../flash/Services/Player";
+import { World } from "../../flash/Services/World";
+import { Jobs } from "../../jobs/Services/Jobs";
+import {
+  AutoAttack,
+  type AutoAttackShape,
+  type AutoAttackStartOptions,
+  type AutoAttackState,
+  type AutoAttackStateListener,
+} from "../Services/AutoAttack";
+
+const AUTO_ATTACK_JOB_KEY = "features:auto-attack";
+const IDLE_DELAY_MS = 250;
+const MIN_LOOP_DELAY_MS = 50;
+
+const toState = (
+  enabled: boolean,
+  running: boolean,
+  profile: CombatProfile | undefined,
+  lastError?: string,
+): AutoAttackState => ({
+  enabled,
+  running,
+  ...(profile === undefined
+    ? {}
+    : {
+        profileId: profile.id,
+        profileLabel: profile.label,
+      }),
+  ...(lastError === undefined || lastError === "" ? {} : { lastError }),
+});
+
+const make = Effect.gen(function* () {
+  const combat = yield* Combat;
+  const jobs = yield* Jobs;
+  const player = yield* Player;
+  const world = yield* World;
+  const enabledRef = yield* Ref.make(false);
+  const profileRef = yield* Ref.make<CombatProfile | undefined>(undefined);
+  const lastErrorRef = yield* Ref.make<string | undefined>(undefined);
+  const updateSemaphore = yield* Semaphore.make(1);
+  const listeners = new Set<AutoAttackStateListener>();
+
+  const getState: AutoAttackShape["getState"] = () =>
+    Effect.all({
+      enabled: Ref.get(enabledRef),
+      running: jobs.isRunning(AUTO_ATTACK_JOB_KEY),
+      profile: Ref.get(profileRef),
+      lastError: Ref.get(lastErrorRef),
+    }).pipe(
+      Effect.map(({ enabled, running, profile, lastError }) =>
+        toState(enabled, running, profile, lastError),
+      ),
+    );
+
+  const emitState = (state: AutoAttackState) =>
+    Effect.gen(function* () {
+      if (listeners.size === 0) {
+        return;
+      }
+
+      yield* Effect.forEach(
+        Array.from(listeners),
+        (listener, listenerIndex) =>
+          Effect.sync(() => listener(state)).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logError({
+                message: "auto attack listener failed",
+                listenerIndex,
+                cause,
+              }),
+            ),
+          ),
+        { discard: true },
+      );
+    });
+
+  const emitCurrentState = Effect.flatMap(getState(), emitState);
+
+  const setLastError = (message: string | undefined) =>
+    Effect.gen(function* () {
+      yield* Ref.set(lastErrorRef, message);
+      yield* emitCurrentState;
+    });
+
+  const selectTarget = Effect.gen(function* () {
+    const currentTarget = yield* combat.getTarget();
+    if (
+      currentTarget?.isMonster() &&
+      isAttackableMonster(currentTarget)
+    ) {
+      return currentTarget.monMapId;
+    }
+
+    const monsters = yield* world.map.getCellMonsters();
+    const next = monsters.find(isAttackableMonster);
+    return next?.monMapId;
+  });
+
+  const loop = (profile: CombatProfile) =>
+    Effect.gen(function* () {
+      const cursor = yield* makeCombatProfileCursor();
+
+      while (yield* Ref.get(enabledRef)) {
+        const alive = yield* player
+          .isAlive()
+          .pipe(Effect.catch(() => Effect.succeed(false)));
+
+        if (!alive) {
+          yield* Effect.sleep(`${IDLE_DELAY_MS} millis`);
+          continue;
+        }
+
+        const monMapId = yield* selectTarget.pipe(
+          Effect.catch(() => Effect.sync((): number | undefined => undefined)),
+        );
+
+        if (monMapId === undefined) {
+          yield* Effect.sleep(`${IDLE_DELAY_MS} millis`);
+          continue;
+        }
+
+        yield* combat.attackMonster(monMapId).pipe(
+          Effect.catch((error) =>
+            setLastError(
+              error instanceof Error ? error.message : "Failed to attack",
+            ),
+          ),
+        );
+
+        const cast = yield* castNextCombatProfileStep(profile, cursor).pipe(
+          Effect.catch((error) =>
+            setLastError(
+              error instanceof Error ? error.message : "Failed to use profile",
+            ).pipe(Effect.as(false)),
+          ),
+        );
+
+        const delayMs = Math.max(
+          MIN_LOOP_DELAY_MS,
+          cast ? profile.delayMs : IDLE_DELAY_MS,
+        );
+        yield* Effect.sleep(`${delayMs} millis`);
+      }
+    }).pipe(
+      Effect.ensuring(
+        combat.cancelAutoAttack().pipe(
+          Effect.andThen(combat.cancelTarget()),
+          Effect.catch(() => Effect.void),
+        ),
+      ),
+    );
+
+  const resolveProfile = (options: AutoAttackStartOptions) =>
+    Effect.gen(function* () {
+      const className = yield* player
+        .getClassName()
+        .pipe(
+          Effect.catch(() => Effect.sync((): string | undefined => undefined)),
+        );
+
+      return findCombatProfileByRef(
+        options.library,
+        options.profileRef,
+        className,
+      );
+    });
+
+  const enable: AutoAttackShape["enable"] = (options) =>
+    updateSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        const profile = yield* resolveProfile(options);
+        yield* Ref.set(enabledRef, true);
+        yield* Ref.set(profileRef, profile);
+        yield* Ref.set(lastErrorRef, undefined);
+
+        yield* jobs.start(
+          AUTO_ATTACK_JOB_KEY,
+          loop(profile).pipe(
+            Effect.provideService(Combat, combat),
+            Effect.provideService(Player, player),
+            Effect.provideService(World, world),
+          ),
+          {
+            replace: true,
+          },
+        );
+
+        const state = yield* getState();
+        yield* emitState(state);
+        return state;
+      }),
+    );
+
+  const disable: AutoAttackShape["disable"] = () =>
+    updateSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        yield* Ref.set(enabledRef, false);
+        yield* jobs.stop(AUTO_ATTACK_JOB_KEY);
+        yield* combat.cancelAutoAttack().pipe(Effect.catch(() => Effect.void));
+        yield* combat.cancelTarget().pipe(Effect.catch(() => Effect.void));
+
+        const state = yield* getState();
+        yield* emitState(state);
+        return state;
+      }),
+    );
+
+  const onState: AutoAttackShape["onState"] = (listener, options) =>
+    Effect.gen(function* () {
+      yield* Effect.sync(() => {
+        listeners.add(listener);
+      });
+
+      if (options?.emitCurrent ?? true) {
+        yield* getState().pipe(
+          Effect.flatMap((state) => Effect.sync(() => listener(state))),
+          Effect.catchCause((cause) =>
+            Effect.sync(() => listeners.delete(listener)).pipe(
+              Effect.andThen(Effect.failCause(cause)),
+            ),
+          ),
+        );
+      }
+
+      return () => {
+        listeners.delete(listener);
+      };
+    });
+
+  yield* Effect.addFinalizer(() => disable().pipe(Effect.asVoid));
+
+  return {
+    getState,
+    onState,
+    enable,
+    disable,
+  } satisfies AutoAttackShape;
+});
+
+export const AutoAttackLive = Layer.effect(AutoAttack, make);

--- a/app/src/renderer/windows/game/features/Layers/AutoAttack.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoAttack.ts
@@ -197,11 +197,14 @@ const make = Effect.gen(function* () {
     updateSemaphore.withPermits(1)(
       Effect.gen(function* () {
         const profile = yield* resolveProfile(options);
+        const previousEnabled = yield* Ref.get(enabledRef);
+        const previousProfile = yield* Ref.get(profileRef);
+
         yield* Ref.set(enabledRef, true);
         yield* Ref.set(profileRef, profile);
         yield* Ref.set(lastErrorRef, undefined);
 
-        yield* jobs.start(
+        const startJob: Effect.Effect<boolean, unknown> = jobs.start(
           AUTO_ATTACK_JOB_KEY,
           loop(profile).pipe(
             Effect.provideService(Combat, combat),
@@ -211,6 +214,19 @@ const make = Effect.gen(function* () {
           {
             replace: true,
           },
+        );
+        yield* startJob.pipe(
+          Effect.tapError((error) =>
+            Effect.gen(function* () {
+              yield* Ref.set(enabledRef, previousEnabled);
+              yield* Ref.set(profileRef, previousProfile);
+              yield* setLastError(
+                error instanceof Error
+                  ? error.message
+                  : "Failed to start auto attack",
+              );
+            }),
+          ),
         );
 
         const state = yield* getState();

--- a/app/src/renderer/windows/game/features/Layers/Features.ts
+++ b/app/src/renderer/windows/game/features/Layers/Features.ts
@@ -1,5 +1,10 @@
 import { Layer } from "effect";
+import { AutoAttackLive } from "./AutoAttack";
 import { AutoReloginLive } from "./AutoRelogin";
 import { AutoZoneLive } from "./AutoZone";
 
-export const FeaturesLive = Layer.mergeAll(AutoReloginLive, AutoZoneLive);
+export const FeaturesLive = Layer.mergeAll(
+  AutoAttackLive,
+  AutoReloginLive,
+  AutoZoneLive,
+);

--- a/app/src/renderer/windows/game/features/Services/AutoAttack.ts
+++ b/app/src/renderer/windows/game/features/Services/AutoAttack.ts
@@ -1,0 +1,43 @@
+import { Effect, ServiceMap } from "effect";
+import type {
+  CombatProfileLibrary,
+  CombatProfileRef,
+} from "../../../../../shared/combat-profiles";
+
+export interface AutoAttackStartOptions {
+  readonly library: CombatProfileLibrary;
+  readonly profileRef: CombatProfileRef;
+}
+
+export interface AutoAttackState {
+  readonly enabled: boolean;
+  readonly running: boolean;
+  readonly profileId?: string;
+  readonly profileLabel?: string;
+  readonly lastError?: string;
+}
+
+export type AutoAttackStateDisposer = () => void;
+
+export type AutoAttackStateListener = (state: AutoAttackState) => void;
+
+export interface AutoAttackStateSubscriptionOptions {
+  readonly emitCurrent?: boolean;
+}
+
+export interface AutoAttackShape {
+  readonly getState: () => Effect.Effect<AutoAttackState>;
+  readonly onState: (
+    listener: AutoAttackStateListener,
+    options?: AutoAttackStateSubscriptionOptions,
+  ) => Effect.Effect<AutoAttackStateDisposer>;
+  readonly enable: (
+    options: AutoAttackStartOptions,
+  ) => Effect.Effect<AutoAttackState>;
+  readonly disable: () => Effect.Effect<AutoAttackState>;
+}
+
+export class AutoAttack extends ServiceMap.Service<
+  AutoAttack,
+  AutoAttackShape
+>()("features/Services/AutoAttack") {}

--- a/app/src/renderer/windows/game/features/Services/AutoAttack.ts
+++ b/app/src/renderer/windows/game/features/Services/AutoAttack.ts
@@ -33,7 +33,7 @@ export interface AutoAttackShape {
   ) => Effect.Effect<AutoAttackStateDisposer>;
   readonly enable: (
     options: AutoAttackStartOptions,
-  ) => Effect.Effect<AutoAttackState>;
+  ) => Effect.Effect<AutoAttackState, unknown>;
   readonly disable: () => Effect.Effect<AutoAttackState>;
 }
 

--- a/app/src/renderer/windows/game/style.css
+++ b/app/src/renderer/windows/game/style.css
@@ -93,9 +93,68 @@
   overflow: hidden;
 }
 
+.game-topnav__combat-trigger {
+  flex: 0 0 clamp(8.75rem, 18vw, 11.5rem);
+  width: clamp(8.75rem, 18vw, 11.5rem);
+  overflow: hidden;
+}
+
+.game-topnav__combat-trigger .button__content {
+  gap: 0.375rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.game-topnav__combat-trigger[data-enabled] {
+  background: rgba(var(--primary), 0.08);
+  border-color: rgba(var(--primary), 0.2);
+  box-shadow: inset 0 0 0 1px rgba(var(--primary), 0.06);
+}
+
+.game-topnav__combat-trigger[data-enabled]:hover,
+.game-topnav__combat-trigger[data-enabled][data-expanded] {
+  background: rgba(var(--primary), 0.12);
+  border-color: rgba(var(--primary), 0.28);
+}
+
+.game-topnav__combat-check {
+  border: 1px solid rgba(var(--border), 0.78);
+  border-radius: max(2px, calc(var(--radius-sm) - 2px));
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  flex: 0 0 auto;
+  height: 0.75rem;
+  position: relative;
+  width: 0.75rem;
+}
+
+.game-topnav__combat-check--active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.game-topnav__combat-check--active::after {
+  border-bottom: 1.5px solid var(--color-primary-foreground);
+  border-right: 1.5px solid var(--color-primary-foreground);
+  content: "";
+  height: 0.375rem;
+  left: 0.25rem;
+  position: absolute;
+  top: 0.0625rem;
+  transform: rotate(45deg);
+  width: 0.1875rem;
+}
+
+.game-topnav__combat-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .game-topnav__trigger-detail {
-  background: color-mix(in srgb, var(--color-muted) 76%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
+  background: rgba(var(--muted), 0.76);
+  border: 1px solid rgba(var(--border), 0.82);
   border-radius: max(2px, calc(var(--radius-sm) - 1px));
   color: var(--color-muted-foreground);
   display: inline-block;
@@ -308,6 +367,15 @@
   width: min(15rem, calc(100vw - 1rem)) !important;
 }
 
+.game-menu--combat {
+  width: min(16rem, calc(100vw - 1rem)) !important;
+}
+
+.game-menu--combat .menu__label {
+  padding-bottom: 0.25rem;
+  padding-top: 0.375rem;
+}
+
 .game-menu--compact {
   min-width: 7rem;
 }
@@ -356,10 +424,10 @@
 }
 
 .game-menu__item:focus-visible {
-  background: color-mix(in srgb, var(--color-ring) 14%, var(--color-accent));
+  background: rgba(var(--ring), 0.14);
   box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--color-ring) 68%, transparent),
-    0 0 0 2px color-mix(in srgb, var(--color-ring) 30%, transparent);
+    inset 0 0 0 1px rgba(var(--ring), 0.68),
+    0 0 0 2px rgba(var(--ring), 0.3);
   color: var(--color-foreground);
   outline: none;
 }

--- a/app/src/renderer/windows/game/topNavOptions.ts
+++ b/app/src/renderer/windows/game/topNavOptions.ts
@@ -4,6 +4,7 @@ export type GameTopNavMenu =
   | "windows"
   | "scripts"
   | "options"
+  | "combat"
   | "autozone"
   | "relogin"
   | "pads"

--- a/app/src/renderer/windows/settings/App.tsx
+++ b/app/src/renderer/windows/settings/App.tsx
@@ -139,7 +139,7 @@ const launchModes = [
 ] as const;
 
 const commandCategories: readonly CommandCategory[] = [
-  "Application",
+  "General",
   "Scripts",
   "Options",
   "Tools",
@@ -342,6 +342,48 @@ function HotkeyIconButton(props: {
         )}
       />
       <TooltipContent>{props.tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function HotkeyConflictPill(props: {
+  readonly conflicts: readonly string[];
+}): JSX.Element {
+  const count = () => props.conflicts.length;
+  const label = () =>
+    count() === 1 ? "Shortcut conflict" : `${count()} shortcut conflicts`;
+
+  return (
+    <Tooltip
+      closeDelay={0}
+      interactive={false}
+      openDelay={150}
+      positioning={{ placement: "top" }}
+      unmountOnExit
+    >
+      <TooltipTrigger
+        asChild={(tooltipTriggerProps) => (
+          <Button
+            {...(tooltipTriggerProps({
+              "aria-label": `${label()}: ${props.conflicts.join(", ")}`,
+              children: (
+                <>
+                  <CircleAlert class="button__icon" />
+                  {count()}
+                </>
+              ),
+              class: "hotkey-row__conflict-pill",
+              size: "xs",
+              type: "button",
+              variant: "ghost",
+            } as ButtonProps) as ButtonProps)}
+          />
+        )}
+      />
+      <TooltipContent class="hotkey-row__conflict-tooltip">
+        <span>Also used by</span>
+        <strong>{props.conflicts.join(", ")}</strong>
+      </TooltipContent>
     </Tooltip>
   );
 }
@@ -706,12 +748,12 @@ function HotkeySettingsSection(props: {
               data-conflict={conflicts().length > 0 ? "" : undefined}
             >
               <div class="hotkey-row__content">
-                <div class="hotkey-row__title">{command.label}</div>
-                <Show when={conflicts().length > 0}>
-                  <div class="hotkey-row__conflict">
-                    Also used by {conflicts().join(", ")}
-                  </div>
-                </Show>
+                <div class="hotkey-row__title-line">
+                  <div class="hotkey-row__title">{command.label}</div>
+                  <Show when={conflicts().length > 0}>
+                    <HotkeyConflictPill conflicts={conflicts()} />
+                  </Show>
+                </div>
               </div>
               <div class="hotkey-row__controls">
                 <div class="hotkey-row__binding">

--- a/app/src/renderer/windows/settings/style.css
+++ b/app/src/renderer/windows/settings/style.css
@@ -264,10 +264,6 @@
   border-bottom: 0;
 }
 
-.hotkey-row[data-conflict] {
-  border-bottom-color: rgba(var(--destructive), 0.45);
-}
-
 .hotkey-row__content {
   display: grid;
   flex: 1 1 auto;
@@ -282,10 +278,54 @@
   line-height: 1.25;
 }
 
-.hotkey-row__conflict {
+.hotkey-row__title-line {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+  min-width: 0;
+}
+
+.hotkey-row__conflict-pill.button {
+  background: rgba(var(--destructive), 0.12);
+  border-color: transparent;
+  border-radius: 999px;
   color: rgb(var(--destructive));
-  font-size: var(--text-base);
-  line-height: 1.35;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  height: var(--control-height-xs);
+  min-width: 0;
+  padding-inline: 0.375rem;
+}
+
+.hotkey-row__conflict-pill.button:hover,
+.hotkey-row__conflict-pill.button:focus-visible {
+  background: rgba(var(--destructive), 0.18);
+  border-color: transparent;
+  box-shadow: 0 0 0 1px rgba(var(--destructive), 0.14);
+}
+
+.hotkey-row__conflict-pill .button__icon {
+  height: 0.75rem;
+  width: 0.75rem;
+}
+
+.hotkey-row__conflict-tooltip.tooltip__content {
+  display: grid;
+  gap: 0.125rem;
+  text-align: left;
+  width: max-content;
+}
+
+.hotkey-row__conflict-tooltip span {
+  color: rgb(var(--muted-foreground));
+  font-size: var(--text-xs);
+}
+
+.hotkey-row__conflict-tooltip strong {
+  color: rgb(var(--foreground));
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .hotkey-row__controls {

--- a/app/src/renderer/windows/skills/App.tsx
+++ b/app/src/renderer/windows/skills/App.tsx
@@ -142,6 +142,7 @@ function App(): JSX.Element {
   );
   const [saving, setSaving] = createSignal(false);
   const [error, setError] = createSignal("");
+  let hydratedProfileId = "";
 
   const selectedProfile = createMemo(
     () =>
@@ -165,6 +166,11 @@ function App(): JSX.Element {
       return;
     }
 
+    if (profile.id === hydratedProfileId) {
+      return;
+    }
+
+    hydratedProfileId = profile.id;
     setLabel(profile.label);
     setClassName(profile.className ?? "");
     setRole(profile.role);
@@ -196,15 +202,17 @@ function App(): JSX.Element {
 
   const runUpdate = async (
     update: Promise<CombatProfileLibrary>,
-  ): Promise<void> => {
+  ): Promise<boolean> => {
     setSaving(true);
     setError("");
     try {
       const nextLibrary = await update;
       setLibrary(nextLibrary);
+      return true;
     } catch (cause) {
       console.error("Combat profile update failed:", cause);
       setError(cause instanceof Error ? cause.message : "Update failed");
+      return false;
     } finally {
       setSaving(false);
     }
@@ -239,6 +247,10 @@ function App(): JSX.Element {
   };
 
   const saveSelected = async (): Promise<void> => {
+    if (saving()) {
+      return;
+    }
+
     const profile = buildSelectedProfileDraft();
     if (!profile) {
       return;
@@ -248,6 +260,10 @@ function App(): JSX.Element {
   };
 
   const createProfile = async (): Promise<void> => {
+    if (saving()) {
+      return;
+    }
+
     const baseLabel = "New Profile";
     const id = makeCombatProfileId(`${baseLabel} ${Date.now()}`);
     const profile: CombatProfile = {
@@ -264,18 +280,28 @@ function App(): JSX.Element {
       })),
     };
 
-    await runUpdate(window.ipc.combatProfiles.saveProfile(profile));
-    setSelectedId(id);
+    const saved = await runUpdate(window.ipc.combatProfiles.saveProfile(profile));
+    if (saved) {
+      setSelectedId(id);
+    }
   };
 
   const deleteSelected = async (): Promise<void> => {
+    if (saving()) {
+      return;
+    }
+
     const profile = selectedProfile();
     if (!profile || profile.id === DEFAULT_COMBAT_PROFILE_ID) {
       return;
     }
 
-    await runUpdate(window.ipc.combatProfiles.deleteProfile(profile.id));
-    setSelectedId(DEFAULT_COMBAT_PROFILE_ID);
+    const deleted = await runUpdate(
+      window.ipc.combatProfiles.deleteProfile(profile.id),
+    );
+    if (deleted) {
+      setSelectedId(DEFAULT_COMBAT_PROFILE_ID);
+    }
   };
 
   const updateStep = (
@@ -358,7 +384,12 @@ function App(): JSX.Element {
           <Show when={saving()}>
             <Spinner class="skills-sync-spinner" size="sm" />
           </Show>
-          <Button size="sm" variant="secondary" onClick={createProfile}>
+          <Button
+            disabled={saving()}
+            size="sm"
+            variant="secondary"
+            onClick={createProfile}
+          >
             New
           </Button>
           <Button
@@ -414,6 +445,7 @@ function App(): JSX.Element {
                         {...(triggerProps({
                           class: "skills-profile-delete",
                           disabled:
+                            saving() ||
                             selectedId() === DEFAULT_COMBAT_PROFILE_ID,
                           size: "sm",
                           variant: "ghost",
@@ -434,6 +466,7 @@ function App(): JSX.Element {
                     <AlertDialogFooter>
                       <AlertDialogCancel>Cancel</AlertDialogCancel>
                       <AlertDialogAction
+                        disabled={saving()}
                         variant="destructive"
                         onClick={() => void deleteSelected()}
                       >

--- a/app/src/renderer/windows/skills/App.tsx
+++ b/app/src/renderer/windows/skills/App.tsx
@@ -62,7 +62,7 @@ type ConditionType = CombatProfileCondition["type"];
 const conditionTypes = [
   { value: "self-hp", label: "Self HP" },
   { value: "self-mp", label: "Self MP" },
-  { value: "ally-hp", label: "Any ally HP" },
+  { value: "ally-hp", label: "Any player HP" },
   { value: "self-aura", label: "Self aura" },
   { value: "target-aura", label: "Target aura" },
 ] as const satisfies readonly {
@@ -119,7 +119,7 @@ const conditionLabel = (condition: CombatProfileCondition): string => {
     case "self-mp":
       return `MP ${condition.op} ${condition.value}${condition.unit === "percent" ? "%" : ""}`;
     case "ally-hp":
-      return `Ally HP ${condition.op} ${condition.value}${condition.unit === "percent" ? "%" : ""}`;
+      return `Any player HP ${condition.op} ${condition.value}${condition.unit === "percent" ? "%" : ""}`;
     case "self-aura":
       return `Self ${condition.auraName} ${condition.op} ${condition.value}`;
     case "target-aura":

--- a/app/src/renderer/windows/skills/App.tsx
+++ b/app/src/renderer/windows/skills/App.tsx
@@ -71,6 +71,7 @@ const conditionTypes = [
 }[];
 
 const skillIndices = [0, 1, 2, 3, 4, 5] as const;
+const selectedProfileStorageKey = "vexed.skills.selectedProfileId";
 
 const isStatCondition = (
   condition: CombatProfileCondition,
@@ -126,11 +127,38 @@ const conditionLabel = (condition: CombatProfileCondition): string => {
   }
 };
 
+const readLastSelectedProfileId = (): string | undefined => {
+  try {
+    return window.localStorage.getItem(selectedProfileStorageKey) ?? undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const writeLastSelectedProfileId = (profileId: string): void => {
+  try {
+    window.localStorage.setItem(selectedProfileStorageKey, profileId);
+  } catch {
+    // Selection persistence is best-effort; editing still works without storage.
+  }
+};
+
+const getPreferredProfileId = (
+  profiles: readonly CombatProfile[],
+  preferredId: string | undefined,
+): string =>
+  profiles.find((profile) => profile.id === preferredId)?.id ??
+  profiles.find((profile) => profile.id !== DEFAULT_COMBAT_PROFILE_ID)?.id ??
+  profiles[0]?.id ??
+  DEFAULT_COMBAT_PROFILE_ID;
+
 function App(): JSX.Element {
   const [library, setLibrary] = createSignal<CombatProfileLibrary>(
     DEFAULT_COMBAT_PROFILE_LIBRARY,
   );
-  const [selectedId, setSelectedId] = createSignal(DEFAULT_COMBAT_PROFILE_ID);
+  const [selectedId, setSelectedId] = createSignal(
+    readLastSelectedProfileId() ?? DEFAULT_COMBAT_PROFILE_ID,
+  );
   const [label, setLabel] = createSignal("Generic");
   const [className, setClassName] = createSignal("");
   const [role, setRole] = createSignal(DEFAULT_COMBAT_PROFILE_ROLE);
@@ -159,6 +187,10 @@ function App(): JSX.Element {
     );
     return generic ? [generic, ...rest] : rest;
   });
+  const selectProfile = (profileId: string): void => {
+    setSelectedId(profileId);
+    writeLastSelectedProfileId(profileId);
+  };
 
   createEffect(() => {
     const profile = selectedProfile();
@@ -182,7 +214,9 @@ function App(): JSX.Element {
     const unsubscribe = window.ipc.combatProfiles.onChanged((nextLibrary) => {
       setLibrary(nextLibrary);
       if (!nextLibrary.profiles.some((profile) => profile.id === selectedId())) {
-        setSelectedId(nextLibrary.profiles[0]?.id ?? DEFAULT_COMBAT_PROFILE_ID);
+        selectProfile(
+          getPreferredProfileId(nextLibrary.profiles, readLastSelectedProfileId()),
+        );
       }
     });
 
@@ -190,7 +224,9 @@ function App(): JSX.Element {
       .getState()
       .then((nextLibrary) => {
         setLibrary(nextLibrary);
-        setSelectedId(nextLibrary.profiles[0]?.id ?? DEFAULT_COMBAT_PROFILE_ID);
+        selectProfile(
+          getPreferredProfileId(nextLibrary.profiles, readLastSelectedProfileId()),
+        );
       })
       .catch((cause: unknown) => {
         console.error("Failed to load combat profiles:", cause);
@@ -282,7 +318,7 @@ function App(): JSX.Element {
 
     const saved = await runUpdate(window.ipc.combatProfiles.saveProfile(profile));
     if (saved) {
-      setSelectedId(id);
+      selectProfile(id);
     }
   };
 
@@ -300,7 +336,7 @@ function App(): JSX.Element {
       window.ipc.combatProfiles.deleteProfile(profile.id),
     );
     if (deleted) {
-      setSelectedId(DEFAULT_COMBAT_PROFILE_ID);
+      selectProfile(getPreferredProfileId(library().profiles, undefined));
     }
   };
 
@@ -413,7 +449,7 @@ function App(): JSX.Element {
               onValueChange={(details) => {
                 const id = details.value[0];
                 if (id) {
-                  setSelectedId(id);
+                  selectProfile(id);
                 }
               }}
             >

--- a/app/src/renderer/windows/skills/App.tsx
+++ b/app/src/renderer/windows/skills/App.tsx
@@ -1,0 +1,708 @@
+/* @refresh reload */
+import "../../polyfills";
+import "./style.css";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+  AppShell,
+  AppShellBody,
+  AppShellHeader,
+  AppShellHeaderLeft,
+  AppShellHeaderRight,
+  AppShellTitle,
+  Button,
+  type ButtonProps,
+  Card,
+  CardContent,
+  CardFrame,
+  CardFrameHeader,
+  CardFrameTitle,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+} from "@vexed/ui";
+import { Save, X } from "lucide-solid";
+import {
+  For,
+  Index,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  type JSX,
+} from "solid-js";
+import {
+  DEFAULT_COMBAT_PROFILE_ID,
+  DEFAULT_COMBAT_PROFILE_DELAY_MS,
+  DEFAULT_COMBAT_PROFILE_LIBRARY,
+  DEFAULT_COMBAT_PROFILE_ROLE,
+  makeCombatProfileId,
+  type CombatProfile,
+  type CombatProfileCondition,
+  type CombatProfileLibrary,
+  type CombatProfileStep,
+} from "../../../shared/combat-profiles";
+import { mountWindow } from "../mount";
+
+type ConditionType = CombatProfileCondition["type"];
+
+const conditionTypes = [
+  { value: "self-hp", label: "Self HP" },
+  { value: "self-mp", label: "Self MP" },
+  { value: "ally-hp", label: "Any ally HP" },
+  { value: "self-aura", label: "Self aura" },
+  { value: "target-aura", label: "Target aura" },
+] as const satisfies readonly {
+  readonly value: ConditionType;
+  readonly label: string;
+}[];
+
+const skillIndices = [0, 1, 2, 3, 4, 5] as const;
+
+const isStatCondition = (
+  condition: CombatProfileCondition,
+): condition is Extract<
+  CombatProfileCondition,
+  { readonly type: "self-hp" | "self-mp" | "ally-hp" }
+> =>
+  condition.type === "self-hp" ||
+  condition.type === "self-mp" ||
+  condition.type === "ally-hp";
+
+const auraNameValue = (condition: CombatProfileCondition): string =>
+  isStatCondition(condition) ? "" : condition.auraName;
+
+const conditionUnitValue = (condition: CombatProfileCondition): string =>
+  isStatCondition(condition) ? condition.unit : "percent";
+
+const createCondition = (type: ConditionType): CombatProfileCondition => {
+  if (type === "self-aura" || type === "target-aura") {
+    return {
+      type,
+      auraName: "",
+      op: ">=",
+      value: 1,
+    };
+  }
+
+  return {
+    type,
+    op: "<=",
+    value: type === "self-mp" ? 20 : 50,
+    unit: "percent",
+  };
+};
+
+const clampRuleValue = (value: string): number => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+};
+
+const conditionLabel = (condition: CombatProfileCondition): string => {
+  switch (condition.type) {
+    case "self-hp":
+      return `HP ${condition.op} ${condition.value}${condition.unit === "percent" ? "%" : ""}`;
+    case "self-mp":
+      return `MP ${condition.op} ${condition.value}${condition.unit === "percent" ? "%" : ""}`;
+    case "ally-hp":
+      return `Ally HP ${condition.op} ${condition.value}${condition.unit === "percent" ? "%" : ""}`;
+    case "self-aura":
+      return `Self ${condition.auraName} ${condition.op} ${condition.value}`;
+    case "target-aura":
+      return `Target ${condition.auraName} ${condition.op} ${condition.value}`;
+  }
+};
+
+function App(): JSX.Element {
+  const [library, setLibrary] = createSignal<CombatProfileLibrary>(
+    DEFAULT_COMBAT_PROFILE_LIBRARY,
+  );
+  const [selectedId, setSelectedId] = createSignal(DEFAULT_COMBAT_PROFILE_ID);
+  const [label, setLabel] = createSignal("Generic");
+  const [className, setClassName] = createSignal("");
+  const [role, setRole] = createSignal(DEFAULT_COMBAT_PROFILE_ROLE);
+  const [delayMs, setDelayMs] = createSignal(
+    String(DEFAULT_COMBAT_PROFILE_DELAY_MS),
+  );
+  const [draftSteps, setDraftSteps] = createSignal<readonly CombatProfileStep[]>(
+    DEFAULT_COMBAT_PROFILE_LIBRARY.profiles[0]?.steps ?? [],
+  );
+  const [saving, setSaving] = createSignal(false);
+  const [error, setError] = createSignal("");
+
+  const selectedProfile = createMemo(
+    () =>
+      library().profiles.find((profile) => profile.id === selectedId()) ??
+      library().profiles[0],
+  );
+  const profileOptions = createMemo(() => {
+    const profiles = library().profiles;
+    const generic = profiles.find(
+      (profile) => profile.id === DEFAULT_COMBAT_PROFILE_ID,
+    );
+    const rest = profiles.filter(
+      (profile) => profile.id !== DEFAULT_COMBAT_PROFILE_ID,
+    );
+    return generic ? [generic, ...rest] : rest;
+  });
+
+  createEffect(() => {
+    const profile = selectedProfile();
+    if (!profile) {
+      return;
+    }
+
+    setLabel(profile.label);
+    setClassName(profile.className ?? "");
+    setRole(profile.role);
+    setDelayMs(String(profile.delayMs));
+    setDraftSteps(profile.steps.map((step) => ({ ...step })));
+  });
+
+  onMount(() => {
+    const unsubscribe = window.ipc.combatProfiles.onChanged((nextLibrary) => {
+      setLibrary(nextLibrary);
+      if (!nextLibrary.profiles.some((profile) => profile.id === selectedId())) {
+        setSelectedId(nextLibrary.profiles[0]?.id ?? DEFAULT_COMBAT_PROFILE_ID);
+      }
+    });
+
+    void window.ipc.combatProfiles
+      .getState()
+      .then((nextLibrary) => {
+        setLibrary(nextLibrary);
+        setSelectedId(nextLibrary.profiles[0]?.id ?? DEFAULT_COMBAT_PROFILE_ID);
+      })
+      .catch((cause: unknown) => {
+        console.error("Failed to load combat profiles:", cause);
+        setError("Failed to load profiles");
+      });
+
+    onCleanup(unsubscribe);
+  });
+
+  const runUpdate = async (
+    update: Promise<CombatProfileLibrary>,
+  ): Promise<void> => {
+    setSaving(true);
+    setError("");
+    try {
+      const nextLibrary = await update;
+      setLibrary(nextLibrary);
+    } catch (cause) {
+      console.error("Combat profile update failed:", cause);
+      setError(cause instanceof Error ? cause.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const buildSelectedProfileDraft = (): CombatProfile | null => {
+    const profile = selectedProfile();
+    if (!profile) {
+      return null;
+    }
+
+    const parsedDelay = Number.parseInt(delayMs(), 10);
+    const trimmedClassName = className().trim();
+    const profileWithoutClassName = {
+      id: profile.id,
+      label: profile.label,
+      role: profile.role,
+      delayMs: profile.delayMs,
+      cooldownMode: profile.cooldownMode,
+      timeoutMs: profile.timeoutMs,
+      steps: draftSteps(),
+    } satisfies CombatProfile;
+    return {
+      ...profileWithoutClassName,
+      label: label().trim() || profile.label,
+      ...(trimmedClassName === "" ? {} : { className: trimmedClassName }),
+      role: role().trim() || DEFAULT_COMBAT_PROFILE_ROLE,
+      delayMs: Number.isFinite(parsedDelay)
+        ? Math.max(0, parsedDelay)
+        : profile.delayMs,
+    };
+  };
+
+  const saveSelected = async (): Promise<void> => {
+    const profile = buildSelectedProfileDraft();
+    if (!profile) {
+      return;
+    }
+
+    await runUpdate(window.ipc.combatProfiles.saveProfile(profile));
+  };
+
+  const createProfile = async (): Promise<void> => {
+    const baseLabel = "New Profile";
+    const id = makeCombatProfileId(`${baseLabel} ${Date.now()}`);
+    const profile: CombatProfile = {
+      id,
+      label: baseLabel,
+      role: DEFAULT_COMBAT_PROFILE_ROLE,
+      delayMs: DEFAULT_COMBAT_PROFILE_DELAY_MS,
+      cooldownMode: "use-if-ready",
+      timeoutMs: 10_000,
+      steps: [1, 2, 3, 4].map((skill) => ({
+        id: `${id}-${skill}`,
+        skill,
+        conditions: [],
+      })),
+    };
+
+    await runUpdate(window.ipc.combatProfiles.saveProfile(profile));
+    setSelectedId(id);
+  };
+
+  const deleteSelected = async (): Promise<void> => {
+    const profile = selectedProfile();
+    if (!profile || profile.id === DEFAULT_COMBAT_PROFILE_ID) {
+      return;
+    }
+
+    await runUpdate(window.ipc.combatProfiles.deleteProfile(profile.id));
+    setSelectedId(DEFAULT_COMBAT_PROFILE_ID);
+  };
+
+  const updateStep = (
+    stepIndex: number,
+    update: (step: CombatProfileStep) => CombatProfileStep,
+  ): void => {
+    setDraftSteps((steps) =>
+      steps.map((step, index) => (index === stepIndex ? update(step) : step)),
+    );
+  };
+
+  const addStep = (): void => {
+    const id = `${selectedId()}-step-${Date.now()}`;
+    setDraftSteps((steps) => [
+      ...steps,
+      {
+        id,
+        skill: 1,
+        conditions: [],
+      },
+    ]);
+  };
+
+  const removeStep = (stepIndex: number): void => {
+    setDraftSteps((steps) => steps.filter((_, index) => index !== stepIndex));
+  };
+
+  const updateStepSkill = (stepIndex: number, skill: number): void => {
+    updateStep(stepIndex, (step) => ({
+      ...step,
+      skill,
+    }));
+  };
+
+  const updateCondition = (
+    stepIndex: number,
+    conditionIndex: number,
+    update: (condition: CombatProfileCondition) => CombatProfileCondition,
+  ): void => {
+    updateStep(stepIndex, (step) => ({
+      ...step,
+      conditions: step.conditions.map((condition, index) =>
+        index === conditionIndex ? update(condition) : condition,
+      ),
+    }));
+  };
+
+  const addCondition = (stepIndex: number): void => {
+    updateStep(stepIndex, (step) => ({
+      ...step,
+      conditions: [...step.conditions, createCondition("self-hp")],
+    }));
+  };
+
+  const removeCondition = (
+    stepIndex: number,
+    conditionIndex: number,
+  ): void => {
+    updateStep(stepIndex, (step) => ({
+      ...step,
+      conditions: step.conditions.filter((_, index) => index !== conditionIndex),
+    }));
+  };
+
+  const updateConditionType = (
+    stepIndex: number,
+    conditionIndex: number,
+    type: ConditionType,
+  ): void => {
+    updateCondition(stepIndex, conditionIndex, () => createCondition(type));
+  };
+
+  return (
+    <AppShell class="skills-window">
+      <AppShellHeader class="skills-header" maxWidth={false}>
+        <AppShellHeaderLeft>
+          <AppShellTitle>Skills</AppShellTitle>
+        </AppShellHeaderLeft>
+        <AppShellHeaderRight class="skills-header__actions">
+          <Show when={saving()}>
+            <Spinner class="skills-sync-spinner" size="sm" />
+          </Show>
+          <Button size="sm" variant="secondary" onClick={createProfile}>
+            New
+          </Button>
+          <Button
+            disabled={saving()}
+            size="sm"
+            onClick={() => void saveSelected()}
+          >
+            <Save class="button__icon" />
+            Save
+          </Button>
+        </AppShellHeaderRight>
+      </AppShellHeader>
+
+      <AppShellBody>
+        <div class="skills-body">
+          <div class="skills-profile-dropdown">
+            <span>Profile</span>
+            <Select
+              class="skills-profile-dropdown__select"
+              value={[selectedId()]}
+              onValueChange={(details) => {
+                const id = details.value[0];
+                if (id) {
+                  setSelectedId(id);
+                }
+              }}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Profile" />
+              </SelectTrigger>
+              <SelectContent>
+                <For each={profileOptions()}>
+                  {(profile) => (
+                    <SelectItem value={profile.id}>{profile.label}</SelectItem>
+                  )}
+                </For>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <section class="skills-editor">
+            <Show when={error()}>
+              {(message) => <div class="skills-error">{message()}</div>}
+            </Show>
+
+            <CardFrame>
+              <CardFrameHeader class="skills-frame-header">
+                <CardFrameTitle>Details</CardFrameTitle>
+                <AlertDialog>
+                  <AlertDialogTrigger
+                    asChild={(triggerProps) => (
+                      <Button
+                        {...(triggerProps({
+                          class: "skills-profile-delete",
+                          disabled:
+                            selectedId() === DEFAULT_COMBAT_PROFILE_ID,
+                          size: "sm",
+                          variant: "ghost",
+                        } as ButtonProps) as ButtonProps)}
+                      >
+                        Delete profile
+                      </Button>
+                    )}
+                  />
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete profile</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Delete {selectedProfile()?.label ?? "this profile"}?
+                        This skill profile will be permanently removed.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        variant="destructive"
+                        onClick={() => void deleteSelected()}
+                      >
+                        Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </CardFrameHeader>
+              <Card>
+                <CardContent class="skills-form">
+                  <label>
+                    <span>Name</span>
+                    <Input
+                      value={label()}
+                      onInput={(event) => setLabel(event.currentTarget.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Class name</span>
+                    <Input
+                      placeholder="Any class"
+                      value={className()}
+                      onInput={(event) =>
+                        setClassName(event.currentTarget.value)
+                      }
+                    />
+                  </label>
+                  <label>
+                    <span>Role</span>
+                    <Input
+                      value={role()}
+                      onInput={(event) => setRole(event.currentTarget.value)}
+                    />
+                  </label>
+                  <label>
+                    <span>Delay (ms)</span>
+                    <Input
+                      inputMode="numeric"
+                      value={delayMs()}
+                      onInput={(event) => setDelayMs(event.currentTarget.value)}
+                    />
+                  </label>
+                </CardContent>
+              </Card>
+            </CardFrame>
+
+            <CardFrame>
+              <CardFrameHeader class="skills-frame-header">
+                <CardFrameTitle>Rotation</CardFrameTitle>
+                <Button
+                  class="skills-add-skill-button"
+                  size="sm"
+                  variant="ghost"
+                  onClick={addStep}
+                >
+                  + Skill
+                </Button>
+              </CardFrameHeader>
+              <Card>
+                <CardContent class="skills-steps">
+                  <Index each={draftSteps()}>
+                    {(step, stepIndex) => (
+                      <div class="skills-step">
+                        <div class="skills-step__header">
+                          <label class="skills-inline-field">
+                            <span>Skill</span>
+                            <Select
+                              class="skills-select skills-select--skill"
+                              value={[String(step().skill)]}
+                              onValueChange={(details) =>
+                                updateStepSkill(
+                                  stepIndex,
+                                  Number.parseInt(
+                                    details.value[0] ?? "1",
+                                    10,
+                                  ),
+                                )
+                              }
+                            >
+                              <SelectTrigger>
+                                <SelectValue placeholder="Skill" />
+                              </SelectTrigger>
+                              <SelectContent>
+                              <For each={skillIndices}>
+                                {(skill) => (
+                                  <SelectItem value={String(skill)}>
+                                    {skill}
+                                  </SelectItem>
+                                )}
+                              </For>
+                              </SelectContent>
+                            </Select>
+                          </label>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => addCondition(stepIndex)}
+                          >
+                            + Rule
+                          </Button>
+                          <Button
+                            aria-label={`Remove skill ${step().skill}`}
+                            size="icon-sm"
+                            variant="ghost"
+                            onClick={() => removeStep(stepIndex)}
+                          >
+                            <X class="button__icon" />
+                          </Button>
+                        </div>
+                        <div class="skills-rules">
+                          <Show
+                            when={step().conditions.length > 0}
+                            fallback={
+                              <div class="skills-empty-rule">
+                                This skill has no rules and can run whenever it
+                                is ready.
+                              </div>
+                            }
+                          >
+                            <Index each={step().conditions}>
+                              {(condition, conditionIndex) => (
+                                <div class="skills-rule">
+                                  <Select
+                                    class="skills-select"
+                                    value={[condition().type]}
+                                    onValueChange={(details) =>
+                                      updateConditionType(
+                                        stepIndex,
+                                        conditionIndex,
+                                        (details.value[0] ??
+                                          "self-hp") as ConditionType,
+                                      )
+                                    }
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Rule type" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                    <For each={conditionTypes}>
+                                      {(option) => (
+                                        <SelectItem value={option.value}>
+                                          {option.label}
+                                        </SelectItem>
+                                      )}
+                                    </For>
+                                    </SelectContent>
+                                  </Select>
+                                  <Show when={!isStatCondition(condition())}>
+                                    <Input
+                                      placeholder="Aura name"
+                                      value={auraNameValue(condition())}
+                                      onInput={(event) =>
+                                        updateCondition(
+                                          stepIndex,
+                                          conditionIndex,
+                                          (current) =>
+                                            isStatCondition(current)
+                                              ? current
+                                              : {
+                                                  ...current,
+                                                  auraName:
+                                                    event.currentTarget.value,
+                                                },
+                                        )
+                                      }
+                                    />
+                                  </Show>
+                                  <Select
+                                    class="skills-select skills-select--op"
+                                    value={[condition().op]}
+                                    onValueChange={(details) =>
+                                      updateCondition(
+                                        stepIndex,
+                                        conditionIndex,
+                                        (current) => ({
+                                          ...current,
+                                          op: (details.value[0] ?? "<=") as
+                                            | "<="
+                                            | ">=",
+                                        }),
+                                      )
+                                    }
+                                  >
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Op" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      <SelectItem value="<=">&lt;=</SelectItem>
+                                      <SelectItem value=">=">&gt;=</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                  <Input
+                                    inputMode="numeric"
+                                    value={String(condition().value)}
+                                    onInput={(event) =>
+                                      updateCondition(
+                                        stepIndex,
+                                        conditionIndex,
+                                        (current) => ({
+                                          ...current,
+                                          value: clampRuleValue(
+                                            event.currentTarget.value,
+                                          ),
+                                        }),
+                                      )
+                                    }
+                                  />
+                                  <Show when={isStatCondition(condition())}>
+                                    <Select
+                                      class="skills-select skills-select--unit"
+                                      value={[conditionUnitValue(condition())]}
+                                      onValueChange={(details) =>
+                                        updateCondition(
+                                          stepIndex,
+                                          conditionIndex,
+                                          (current) =>
+                                            isStatCondition(current)
+                                              ? {
+                                                  ...current,
+                                                  unit: (details.value[0] ??
+                                                    "percent") as
+                                                    | "percent"
+                                                    | "value",
+                                                }
+                                          : current,
+                                        )
+                                      }
+                                    >
+                                      <SelectTrigger>
+                                        <SelectValue placeholder="Unit" />
+                                      </SelectTrigger>
+                                      <SelectContent>
+                                        <SelectItem value="percent">%</SelectItem>
+                                        <SelectItem value="value">
+                                          Value
+                                        </SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                  </Show>
+                                  <Button
+                                    aria-label={`Remove rule ${conditionLabel(condition())}`}
+                                    size="icon-sm"
+                                    variant="ghost"
+                                    onClick={() =>
+                                      removeCondition(
+                                        stepIndex,
+                                        conditionIndex,
+                                      )
+                                    }
+                                  >
+                                    <X class="button__icon" />
+                                  </Button>
+                                </div>
+                              )}
+                            </Index>
+                          </Show>
+                        </div>
+                      </div>
+                    )}
+                  </Index>
+                </CardContent>
+              </Card>
+            </CardFrame>
+          </section>
+        </div>
+      </AppShellBody>
+    </AppShell>
+  );
+}
+
+mountWindow(() => <App />);

--- a/app/src/renderer/windows/skills/style.css
+++ b/app/src/renderer/windows/skills/style.css
@@ -1,0 +1,257 @@
+@import "../../styles.css";
+
+.skills-window {
+  background:
+    linear-gradient(180deg, rgba(var(--muted), 0.32), transparent 9rem),
+    var(--color-background);
+}
+
+.skills-header .app-shell__header-layout {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
+}
+
+.skills-header .app-shell__title {
+  text-wrap: balance;
+}
+
+.skills-header .app-shell__header-left {
+  flex: none;
+  min-width: 0;
+}
+
+.skills-header__actions {
+  justify-self: end;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+
+.skills-header__actions::-webkit-scrollbar {
+  display: none;
+}
+
+.skills-header__actions .button {
+  flex: 0 0 auto;
+}
+
+.skills-sync-spinner.spinner {
+  border-width: 1.5px;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  height: 0.875rem;
+  opacity: 0.9;
+  width: 0.875rem;
+}
+
+.skills-body {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
+  min-height: 0;
+  padding: 1rem;
+}
+
+.skills-profile-dropdown {
+  align-items: center;
+  display: inline-grid;
+  gap: 0.375rem;
+  grid-template-columns: auto minmax(12rem, 18rem);
+  justify-self: start;
+  min-width: 0;
+}
+
+.skills-profile-dropdown > span:first-child {
+  color: var(--color-muted-foreground);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.skills-profile-dropdown__select {
+  min-width: 0;
+  width: 100%;
+}
+
+.skills-editor {
+  display: grid;
+  gap: 1rem;
+  grid-auto-rows: max-content;
+  min-width: 0;
+  overflow: auto;
+}
+
+.skills-frame-header {
+  align-items: center;
+  padding: 0.375rem 0.375rem 0.375rem 0.75rem !important;
+}
+
+.skills-frame-header .card-frame__title {
+  font-size: var(--text-md);
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.skills-profile-delete.button {
+  color: var(--color-destructive-foreground);
+  transition: background-color var(--duration-fast) ease;
+}
+
+.skills-profile-delete.button:not(:disabled):hover,
+.skills-profile-delete.button:not(:disabled):active {
+  background: rgba(var(--destructive), 0.16);
+}
+
+.skills-add-skill-button.button {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  transition: background-color var(--duration-fast) ease;
+}
+
+.skills-add-skill-button.button:not(:disabled):hover,
+.skills-add-skill-button.button:not(:disabled):active {
+  background: var(--color-background);
+}
+
+.skills-form {
+  display: grid;
+  gap: 0.875rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.skills-form label {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.skills-form span {
+  color: var(--color-muted-foreground);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.skills-steps {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.skills-step {
+  border: 0;
+  border-radius: var(--radius-md);
+  display: grid;
+  gap: 0.625rem;
+  padding: 0.625rem;
+}
+
+.skills-step__header {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(7rem, 8rem) auto auto minmax(0, 1fr);
+}
+
+.skills-step__header > button:last-child {
+  justify-self: end;
+}
+
+.skills-inline-field {
+  align-items: center;
+  display: grid;
+  column-gap: 0.625rem;
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.skills-inline-field span {
+  color: var(--color-muted-foreground);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.skills-rules {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.skills-rule {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns:
+    minmax(9rem, 1.1fr)
+    minmax(0, 1.3fr)
+    minmax(5rem, 0.5fr)
+    minmax(5.5rem, 0.6fr)
+    minmax(5.25rem, 0.5fr)
+    auto;
+}
+
+.skills-rule .input {
+  min-width: 0;
+}
+
+.skills-select {
+  min-width: 0;
+  width: 100%;
+}
+
+.skills-select .select__trigger {
+  min-width: 0;
+}
+
+.skills-empty-rule {
+  border: 1px dashed rgba(var(--border), 0.82);
+  border-radius: var(--radius-sm);
+  color: var(--color-muted-foreground);
+  font-size: var(--text-sm);
+  padding: 0.5rem 0.625rem;
+}
+
+.skills-step__rules {
+  color: var(--color-muted-foreground);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.skills-step__rules span {
+  background: rgba(var(--muted), 0.55);
+  border: 1px solid rgba(var(--border), 0.78);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  line-height: 1;
+  padding: 0.25rem 0.375rem;
+}
+
+.skills-error {
+  background: rgba(var(--destructive), 0.14);
+  border: 1px solid rgba(var(--destructive), 0.36);
+  border-radius: var(--radius-md);
+  color: var(--color-destructive-foreground);
+  padding: 0.625rem 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .skills-profile-dropdown {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .skills-form {
+    grid-template-columns: 1fr;
+  }
+
+  .skills-step__header,
+  .skills-rule {
+    grid-template-columns: 1fr;
+  }
+
+  .skills-step__header > button:last-child {
+    justify-self: stretch;
+  }
+}

--- a/app/src/shared/combat-profiles.test.ts
+++ b/app/src/shared/combat-profiles.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_COMBAT_PROFILE_ID,
+  autoAttackStateToProfileRef,
+  findCombatProfileByRef,
+  normalizeCombatProfileLibrary,
+} from "./combat-profiles";
+
+describe("combat profile library", () => {
+  it("seeds the generic profile for missing input", () => {
+    const library = normalizeCombatProfileLibrary(undefined);
+
+    expect(library.profiles).toEqual([
+      expect.objectContaining({
+        id: DEFAULT_COMBAT_PROFILE_ID,
+        label: "Generic",
+        steps: [
+          expect.objectContaining({ skill: 1 }),
+          expect.objectContaining({ skill: 2 }),
+          expect.objectContaining({ skill: 3 }),
+          expect.objectContaining({ skill: 4 }),
+        ],
+      }),
+    ]);
+    expect(library.autoAttack).toEqual({ mode: "equipped-class" });
+  });
+
+  it("normalizes profiles without mirroring class-name keyed storage", () => {
+    const library = normalizeCombatProfileLibrary({
+      profiles: [
+        {
+          id: "vhl-solo",
+          label: "Void Highlord Solo",
+          className: "  Void   Highlord ",
+          role: "Solo",
+          delayMs: 250.9,
+          cooldownMode: "wait-for-cooldown",
+          timeoutMs: 20_500.5,
+          steps: [
+            {
+              id: "heal",
+              skill: 4,
+              conditions: [
+                {
+                  type: "self-hp",
+                  op: "<=",
+                  value: 60,
+                  unit: "percent",
+                },
+                {
+                  type: "target-aura",
+                  auraName: "  Shred ",
+                  op: ">=",
+                  value: 1,
+                },
+              ],
+              waitMs: 100,
+              skipIfUnavailable: true,
+            },
+          ],
+        },
+      ],
+      autoAttack: {
+        mode: "selected",
+        selectedProfileId: "vhl-solo",
+      },
+    });
+
+    expect(library.profiles[1]).toEqual({
+      id: "vhl-solo",
+      label: "Void Highlord Solo",
+      className: "Void   Highlord",
+      role: "Solo",
+      delayMs: 250,
+      cooldownMode: "wait-for-cooldown",
+      timeoutMs: 20_500,
+      steps: [
+        {
+          id: "heal",
+          skill: 4,
+          conditions: [
+            {
+              type: "self-hp",
+              op: "<=",
+              value: 60,
+              unit: "percent",
+            },
+            {
+              type: "target-aura",
+              auraName: "Shred",
+              op: ">=",
+              value: 1,
+            },
+          ],
+          waitMs: 100,
+          skipIfUnavailable: true,
+        },
+      ],
+    });
+    expect(autoAttackStateToProfileRef(library.autoAttack)).toEqual({
+      mode: "selected",
+      profileId: "vhl-solo",
+    });
+  });
+
+  it("falls back to generic when a selected profile no longer exists", () => {
+    const library = normalizeCombatProfileLibrary({
+      profiles: [],
+      autoAttack: {
+        mode: "selected",
+        selectedProfileId: "missing",
+      },
+    });
+
+    expect(library.autoAttack).toEqual({ mode: "equipped-class" });
+    expect(findCombatProfileByRef(library, { mode: "selected", profileId: "missing" }).id).toBe(
+      DEFAULT_COMBAT_PROFILE_ID,
+    );
+  });
+
+  it("resolves equipped-class profiles case-insensitively", () => {
+    const library = normalizeCombatProfileLibrary({
+      profiles: [
+        {
+          id: "archmage-farm",
+          label: "ArchMage Farm",
+          className: "ArchMage",
+          role: "Farm",
+          steps: [{ skill: 3 }],
+        },
+      ],
+    });
+
+    expect(findCombatProfileByRef(library, "equipped-class", "archmage").id).toBe(
+      "archmage-farm",
+    );
+    expect(
+      findCombatProfileByRef(library, "equipped-class", "void highlord").id,
+    ).toBe(DEFAULT_COMBAT_PROFILE_ID);
+  });
+});

--- a/app/src/shared/combat-profiles.ts
+++ b/app/src/shared/combat-profiles.ts
@@ -1,0 +1,410 @@
+export const COMBAT_PROFILE_LIBRARY_VERSION = 1 as const;
+
+export const DEFAULT_COMBAT_PROFILE_ID = "generic-base";
+export const DEFAULT_COMBAT_PROFILE_ROLE = "Base";
+export const DEFAULT_COMBAT_PROFILE_DELAY_MS = 150;
+export const DEFAULT_COMBAT_PROFILE_TIMEOUT_MS = 10_000;
+
+export const CombatProfileCooldownModes = [
+  "use-if-ready",
+  "wait-for-cooldown",
+] as const;
+
+export type CombatProfileCooldownMode =
+  (typeof CombatProfileCooldownModes)[number];
+
+export const CombatProfileAutoAttackModes = [
+  "generic",
+  "equipped-class",
+  "selected",
+] as const;
+
+export type CombatProfileAutoAttackMode =
+  (typeof CombatProfileAutoAttackModes)[number];
+
+export type CombatProfileThresholdUnit = "percent" | "value";
+export type CombatProfileComparison = "<=" | ">=";
+
+export type CombatProfileStatCondition = {
+  readonly type: "self-hp" | "self-mp" | "ally-hp";
+  readonly op: CombatProfileComparison;
+  readonly value: number;
+  readonly unit: CombatProfileThresholdUnit;
+};
+
+export type CombatProfileAuraCondition = {
+  readonly type: "self-aura" | "target-aura";
+  readonly auraName: string;
+  readonly op: CombatProfileComparison;
+  readonly value: number;
+};
+
+export type CombatProfileCondition =
+  | CombatProfileStatCondition
+  | CombatProfileAuraCondition;
+
+export interface CombatProfileStep {
+  readonly id: string;
+  readonly skill: number;
+  readonly conditions: readonly CombatProfileCondition[];
+  readonly waitMs?: number;
+  readonly skipIfUnavailable?: boolean;
+}
+
+export interface CombatProfile {
+  readonly id: string;
+  readonly label: string;
+  readonly className?: string;
+  readonly role: string;
+  readonly delayMs: number;
+  readonly cooldownMode: CombatProfileCooldownMode;
+  readonly timeoutMs: number;
+  readonly steps: readonly CombatProfileStep[];
+}
+
+export interface CombatProfileRefSelected {
+  readonly mode: "selected";
+  readonly profileId: string;
+}
+
+export type CombatProfileRef =
+  | "generic"
+  | "equipped-class"
+  | CombatProfileRefSelected;
+
+export interface CombatProfileAutoAttackState {
+  readonly mode: CombatProfileAutoAttackMode;
+  readonly selectedProfileId?: string;
+}
+
+export interface CombatProfileLibrary {
+  readonly version: typeof COMBAT_PROFILE_LIBRARY_VERSION;
+  readonly profiles: readonly CombatProfile[];
+  readonly autoAttack: CombatProfileAutoAttackState;
+}
+
+const profileIdPattern = /^[a-z0-9][a-z0-9._-]*$/u;
+const MAX_DELAY_MS = 60_000;
+const MAX_TIMEOUT_MS = 60_000;
+const MAX_LABEL_LENGTH = 80;
+const MAX_ROLE_LENGTH = 40;
+const MAX_CLASS_NAME_LENGTH = 80;
+const MAX_AURA_NAME_LENGTH = 80;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isCooldownMode = (value: unknown): value is CombatProfileCooldownMode =>
+  typeof value === "string" &&
+  CombatProfileCooldownModes.includes(value as CombatProfileCooldownMode);
+
+const isAutoAttackMode = (
+  value: unknown,
+): value is CombatProfileAutoAttackMode =>
+  typeof value === "string" &&
+  CombatProfileAutoAttackModes.includes(value as CombatProfileAutoAttackMode);
+
+const isDefined = <T>(value: T | undefined): value is T =>
+  value !== undefined;
+
+const clampInt = (
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number => {
+  const parsed = typeof value === "number" ? value : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+};
+
+const trimString = (value: unknown, maxLength: number): string | undefined => {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed.slice(0, maxLength);
+};
+
+export const normalizeCombatProfileClassName = (value: string): string =>
+  value.trim().replace(/\s+/gu, " ").toLowerCase();
+
+export const makeCombatProfileId = (label: string): string => {
+  const normalized = label
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/gu, "")
+    .replace(/[^a-z0-9]+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+
+  return normalized === "" ? "profile" : normalized;
+};
+
+const normalizeProfileId = (
+  value: unknown,
+  fallbackLabel: string,
+  reservedIds: ReadonlySet<string>,
+): string => {
+  const explicit = trimString(value, 80);
+  const base =
+    explicit !== undefined && profileIdPattern.test(explicit)
+      ? explicit
+      : makeCombatProfileId(fallbackLabel);
+
+  if (!reservedIds.has(base)) {
+    return base;
+  }
+
+  for (let suffix = 2; suffix < 10_000; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!reservedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return `${base}-${Date.now()}`;
+};
+
+const normalizeComparison = (value: unknown): CombatProfileComparison =>
+  value === ">=" ? ">=" : "<=";
+
+const normalizeThresholdUnit = (value: unknown): CombatProfileThresholdUnit =>
+  value === "value" ? "value" : "percent";
+
+const normalizeCondition = (
+  value: unknown,
+): CombatProfileCondition | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (
+    value["type"] === "self-hp" ||
+    value["type"] === "self-mp" ||
+    value["type"] === "ally-hp"
+  ) {
+    const unit = normalizeThresholdUnit(value["unit"]);
+    return {
+      type: value["type"],
+      op: normalizeComparison(value["op"]),
+      unit,
+      value: clampInt(value["value"], 0, 0, unit === "percent" ? 100 : 999_999),
+    };
+  }
+
+  if (value["type"] === "self-aura" || value["type"] === "target-aura") {
+    const auraName = trimString(value["auraName"], MAX_AURA_NAME_LENGTH);
+    if (auraName === undefined) {
+      return undefined;
+    }
+
+    return {
+      type: value["type"],
+      auraName,
+      op: normalizeComparison(value["op"]),
+      value: clampInt(value["value"], 0, 0, 999),
+    };
+  }
+
+  return undefined;
+};
+
+const normalizeStep = (
+  value: unknown,
+  index: number,
+): CombatProfileStep | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const skill = clampInt(value["skill"], Number.NaN, 0, 5);
+  if (!Number.isFinite(skill)) {
+    return undefined;
+  }
+
+  const conditions = Array.isArray(value["conditions"])
+    ? value["conditions"].map(normalizeCondition).filter(isDefined)
+    : [];
+
+  const waitMs = clampInt(value["waitMs"], 0, 0, MAX_TIMEOUT_MS);
+
+  return {
+    id: trimString(value["id"], 80) ?? `step-${index + 1}`,
+    skill,
+    conditions,
+    ...(waitMs > 0 ? { waitMs } : {}),
+    ...(value["skipIfUnavailable"] === true ? { skipIfUnavailable: true } : {}),
+  };
+};
+
+const genericProfile = (): CombatProfile => ({
+  id: DEFAULT_COMBAT_PROFILE_ID,
+  label: "Generic",
+  role: DEFAULT_COMBAT_PROFILE_ROLE,
+  delayMs: DEFAULT_COMBAT_PROFILE_DELAY_MS,
+  cooldownMode: "use-if-ready",
+  timeoutMs: DEFAULT_COMBAT_PROFILE_TIMEOUT_MS,
+  steps: [1, 2, 3, 4].map((skill) => ({
+    id: `generic-${skill}`,
+    skill,
+    conditions: [],
+  })),
+});
+
+export const DEFAULT_COMBAT_PROFILE_LIBRARY: CombatProfileLibrary = {
+  version: COMBAT_PROFILE_LIBRARY_VERSION,
+  profiles: [genericProfile()],
+  autoAttack: {
+    mode: "equipped-class",
+  },
+};
+
+const normalizeProfile = (
+  value: unknown,
+  reservedIds: Set<string>,
+): CombatProfile | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const label = trimString(value["label"], MAX_LABEL_LENGTH) ?? "Profile";
+  const id = normalizeProfileId(value["id"], label, reservedIds);
+  reservedIds.add(id);
+
+  const className = trimString(value["className"], MAX_CLASS_NAME_LENGTH);
+  const role =
+    trimString(value["role"], MAX_ROLE_LENGTH) ?? DEFAULT_COMBAT_PROFILE_ROLE;
+  const steps = Array.isArray(value["steps"])
+    ? value["steps"].map(normalizeStep).filter(isDefined)
+    : [];
+
+  return {
+    id,
+    label,
+    ...(className === undefined ? {} : { className }),
+    role,
+    delayMs: clampInt(
+      value["delayMs"],
+      DEFAULT_COMBAT_PROFILE_DELAY_MS,
+      0,
+      MAX_DELAY_MS,
+    ),
+    cooldownMode: isCooldownMode(value["cooldownMode"])
+      ? value["cooldownMode"]
+      : "use-if-ready",
+    timeoutMs: clampInt(
+      value["timeoutMs"],
+      DEFAULT_COMBAT_PROFILE_TIMEOUT_MS,
+      0,
+      MAX_TIMEOUT_MS,
+    ),
+    steps:
+      steps.length > 0
+        ? steps
+        : genericProfile().steps.map((step) => ({ ...step })),
+  };
+};
+
+const normalizeAutoAttackState = (
+  value: unknown,
+  profileIds: ReadonlySet<string>,
+): CombatProfileAutoAttackState => {
+  if (!isRecord(value)) {
+    return DEFAULT_COMBAT_PROFILE_LIBRARY.autoAttack;
+  }
+
+  const mode = isAutoAttackMode(value["mode"]) ? value["mode"] : "equipped-class";
+  const selectedProfileId = trimString(value["selectedProfileId"], 80);
+
+  if (
+    mode === "selected" &&
+    selectedProfileId !== undefined &&
+    profileIds.has(selectedProfileId)
+  ) {
+    return { mode, selectedProfileId };
+  }
+
+  return { mode: mode === "selected" ? "equipped-class" : mode };
+};
+
+export const normalizeCombatProfileLibrary = (
+  value: unknown,
+): CombatProfileLibrary => {
+  const reservedIds = new Set<string>();
+  const rawProfiles = isRecord(value) && Array.isArray(value["profiles"])
+    ? value["profiles"]
+    : [];
+  const profiles = rawProfiles
+    .map((profile) => normalizeProfile(profile, reservedIds))
+    .filter(isDefined);
+
+  if (!profiles.some((profile) => profile.id === DEFAULT_COMBAT_PROFILE_ID)) {
+    profiles.unshift(genericProfile());
+    reservedIds.add(DEFAULT_COMBAT_PROFILE_ID);
+  }
+
+  const profileIds = new Set(profiles.map((profile) => profile.id));
+  return {
+    version: COMBAT_PROFILE_LIBRARY_VERSION,
+    profiles,
+    autoAttack: normalizeAutoAttackState(
+      isRecord(value) ? value["autoAttack"] : undefined,
+      profileIds,
+    ),
+  };
+};
+
+export const findCombatProfileByRef = (
+  library: CombatProfileLibrary,
+  ref: CombatProfileRef,
+  equippedClassName?: string,
+): CombatProfile => {
+  const fallback =
+    library.profiles.find((profile) => profile.id === DEFAULT_COMBAT_PROFILE_ID) ??
+    genericProfile();
+
+  if (ref === "generic") {
+    return fallback;
+  }
+
+  if (ref === "equipped-class") {
+    const normalizedClassName =
+      equippedClassName === undefined
+        ? undefined
+        : normalizeCombatProfileClassName(equippedClassName);
+    if (normalizedClassName === undefined || normalizedClassName === "") {
+      return fallback;
+    }
+
+    return (
+      library.profiles.find(
+        (profile) =>
+          profile.className !== undefined &&
+          normalizeCombatProfileClassName(profile.className) ===
+            normalizedClassName,
+      ) ?? fallback
+    );
+  }
+
+  return (
+    library.profiles.find((profile) => profile.id === ref.profileId) ?? fallback
+  );
+};
+
+export const autoAttackStateToProfileRef = (
+  state: CombatProfileAutoAttackState,
+): CombatProfileRef => {
+  if (state.mode === "generic") {
+    return "generic";
+  }
+
+  if (state.mode === "selected" && state.selectedProfileId !== undefined) {
+    return { mode: "selected", profileId: state.selectedProfileId };
+  }
+
+  return "equipped-class";
+};

--- a/app/src/shared/commands.test.ts
+++ b/app/src/shared/commands.test.ts
@@ -49,6 +49,14 @@ describe("game command registry", () => {
     ).toEqual(expect.objectContaining({ category: "Tools" }));
   });
 
+  it("groups primary game toggles under general", () => {
+    expect(
+      GAME_COMMANDS.filter((command) => command.category === "General").map(
+        (command) => command.id,
+      ),
+    ).toEqual(["toggleTopBar", "toggleAutoattack", "toggleBank"]);
+  });
+
   it("validates command ids", () => {
     expect(isGameCommandId("loadScript")).toBe(true);
     expect(isGameCommandId("missing-command")).toBe(false);

--- a/app/src/shared/commands.test.ts
+++ b/app/src/shared/commands.test.ts
@@ -57,6 +57,12 @@ describe("game command registry", () => {
     ).toEqual(["toggleTopBar", "toggleAutoattack", "toggleBank"]);
   });
 
+  it("defaults toggle bank to mod+b", () => {
+    expect(
+      getDefaultHotkeys().find((binding) => binding.id === "toggleBank")?.value,
+    ).toBe("Mod+B");
+  });
+
   it("validates command ids", () => {
     expect(isGameCommandId("loadScript")).toBe(true);
     expect(isGameCommandId("missing-command")).toBe(false);

--- a/app/src/shared/commands.ts
+++ b/app/src/shared/commands.ts
@@ -1,7 +1,7 @@
 export type CommandScope = "game";
 
 export type CommandCategory =
-  | "Application"
+  | "General"
   | "Scripts"
   | "Options"
   | "Tools"
@@ -20,6 +20,7 @@ export type GameCommandId =
   | "openPacketLogger"
   | "openPacketSpammer"
   | "toggleAutoattack"
+  | "toggleBank"
   | "toggleInfiniteRange"
   | "toggleProvokeCell"
   | "toggleEnemyMagnet"
@@ -49,7 +50,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
   {
     id: "toggleTopBar",
     scope: "game",
-    category: "Application",
+    category: "General",
     label: "Toggle Top Bar",
     keywords: ["top", "bar", "navigation", "chrome"],
     defaultHotkey: "Mod+Shift+T",
@@ -137,9 +138,17 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
   {
     id: "toggleAutoattack",
     scope: "game",
-    category: "Options",
-    label: "Toggle Autoattack",
+    category: "General",
+    label: "Toggle Auto Attack",
     keywords: ["auto", "attack"],
+    defaultHotkey: "Alt+A",
+  },
+  {
+    id: "toggleBank",
+    scope: "game",
+    category: "General",
+    label: "Toggle Bank",
+    keywords: ["bank"],
     defaultHotkey: "",
   },
   {

--- a/app/src/shared/commands.ts
+++ b/app/src/shared/commands.ts
@@ -149,7 +149,7 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     category: "General",
     label: "Toggle Bank",
     keywords: ["bank"],
-    defaultHotkey: "",
+    defaultHotkey: "Mod+B",
   },
   {
     id: "toggleInfiniteRange",

--- a/app/src/shared/ipc.ts
+++ b/app/src/shared/ipc.ts
@@ -19,6 +19,11 @@ import type {
   EnvironmentQuestAutoRegisterOptions,
   EnvironmentState,
 } from "./environment";
+import type {
+  CombatProfile,
+  CombatProfileAutoAttackState,
+  CombatProfileLibrary,
+} from "./combat-profiles";
 
 export type {
   ArmyBarrierPayload,
@@ -47,6 +52,22 @@ export type {
   ThemeTokenName,
   ThemeVariant,
 } from "./settings";
+
+export type {
+  CombatProfile,
+  CombatProfileAutoAttackMode,
+  CombatProfileAutoAttackState,
+  CombatProfileAuraCondition,
+  CombatProfileComparison,
+  CombatProfileCondition,
+  CombatProfileCooldownMode,
+  CombatProfileLibrary,
+  CombatProfileRef,
+  CombatProfileRefSelected,
+  CombatProfileStatCondition,
+  CombatProfileStep,
+  CombatProfileThresholdUnit,
+} from "./combat-profiles";
 
 export type {
   EnvironmentItemRules,
@@ -123,6 +144,14 @@ export const EnvironmentIpcChannels = {
   fetchBoostsResponse: "environment:fetch-boosts-response",
   syncToAll: "environment:sync-to-all",
   changed: "environment:changed",
+} as const;
+
+export const CombatProfilesIpcChannels = {
+  getState: "combat-profiles:get-state",
+  saveProfile: "combat-profiles:save-profile",
+  deleteProfile: "combat-profiles:delete-profile",
+  setAutoAttack: "combat-profiles:set-auto-attack",
+  changed: "combat-profiles:changed",
 } as const;
 
 export interface ScriptExecutePayload {
@@ -530,6 +559,39 @@ export interface EnvironmentBridge {
   ): () => void;
 }
 
+export interface CombatProfilesInvokeChannels {
+  readonly [CombatProfilesIpcChannels.getState]: IpcInvokeDefinition<
+    [],
+    CombatProfileLibrary
+  >;
+  readonly [CombatProfilesIpcChannels.saveProfile]: IpcInvokeDefinition<
+    [profile: CombatProfile],
+    CombatProfileLibrary
+  >;
+  readonly [CombatProfilesIpcChannels.deleteProfile]: IpcInvokeDefinition<
+    [profileId: string],
+    CombatProfileLibrary
+  >;
+  readonly [CombatProfilesIpcChannels.setAutoAttack]: IpcInvokeDefinition<
+    [state: CombatProfileAutoAttackState],
+    CombatProfileLibrary
+  >;
+}
+
+export interface CombatProfilesRendererEventChannels {
+  readonly [CombatProfilesIpcChannels.changed]: [state: CombatProfileLibrary];
+}
+
+export interface CombatProfilesBridge {
+  getState(): Promise<CombatProfileLibrary>;
+  saveProfile(profile: CombatProfile): Promise<CombatProfileLibrary>;
+  deleteProfile(profileId: string): Promise<CombatProfileLibrary>;
+  setAutoAttack(
+    state: CombatProfileAutoAttackState,
+  ): Promise<CombatProfileLibrary>;
+  onChanged(listener: (state: CombatProfileLibrary) => void): () => void;
+}
+
 export type AppPlatform = "mac" | "windows" | "linux";
 
 export interface PlatformBridge {
@@ -539,6 +601,7 @@ export interface PlatformBridge {
 export interface AppBridge {
   readonly accounts: AccountManagerBridge;
   readonly army: ArmyBridge;
+  readonly combatProfiles: CombatProfilesBridge;
   readonly environment: EnvironmentBridge;
   readonly platform: PlatformBridge;
   readonly scripting: ScriptingBridge;

--- a/app/src/shared/windows.ts
+++ b/app/src/shared/windows.ts
@@ -2,6 +2,7 @@ export const WindowIds = {
   AccountManager: "account-manager",
   Settings: "settings",
   Environment: "environment",
+  Skills: "skills",
   FastTravels: "fast-travels",
   LoaderGrabber: "loader-grabber",
   Follower: "follower",
@@ -68,6 +69,19 @@ export const gameWindowGroups: readonly WindowGroup[] = [
   {
     name: "Tools",
     items: [
+      {
+        id: WindowIds.Skills,
+        label: "Skills",
+        description: "Build combat profiles used by auto attack and scripts.",
+        scope: "game-child",
+        closeBehavior: "hide",
+        dimensions: {
+          width: 760,
+          height: 560,
+          minWidth: 680,
+          minHeight: 500,
+        },
+      },
       {
         id: WindowIds.Environment,
         label: "Environment",

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -204,8 +204,25 @@ export function SelectItem(props: SelectItemProps): JSX.Element {
     "value",
   ]);
   const context = useContext(SelectItemsContext);
+  const childLabel = (): string | undefined => {
+    const child = local.children;
+    if (typeof child === "string" || typeof child === "number") {
+      return String(child);
+    }
+
+    if (
+      Array.isArray(child) &&
+      child.every(
+        (part) => typeof part === "string" || typeof part === "number",
+      )
+    ) {
+      return child.join("");
+    }
+
+    return undefined;
+  };
   const item = createMemo<SelectOption>(() => ({
-    label: local.item?.label ?? local.label ?? local.value,
+    label: local.item?.label ?? local.label ?? childLabel() ?? local.value,
     value: local.item?.value ?? local.value,
     ...(local.disabled === undefined ? {} : { disabled: local.disabled }),
   }));

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -212,6 +212,7 @@ export function SelectItem(props: SelectItemProps): JSX.Element {
 
     if (
       Array.isArray(child) &&
+      child.length > 0 &&
       child.every(
         (part) => typeof part === "string" || typeof part === "number",
       )

--- a/packages/ui/src/components/components.test.tsx
+++ b/packages/ui/src/components/components.test.tsx
@@ -779,6 +779,81 @@ describe("Select", () => {
       document.body.querySelectorAll("[data-slot='select-item']"),
     ).toHaveLength(2);
   });
+
+  it("uses numeric item children as trigger labels", () => {
+    renderUi(() => (
+      <Select value={["42"]}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select value" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="42">{42}</SelectItem>
+        </SelectContent>
+      </Select>
+    ));
+
+    const trigger = document.body.querySelector(
+      "[data-slot='select-trigger']",
+    );
+    expect(trigger?.textContent).toContain("42");
+  });
+
+  it("uses string and numeric item child arrays as trigger labels", () => {
+    renderUi(() => (
+      <Select value={["hello"]}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select value" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="hello">{["Hello", " ", "World"]}</SelectItem>
+        </SelectContent>
+      </Select>
+    ));
+
+    const trigger = document.body.querySelector(
+      "[data-slot='select-trigger']",
+    );
+    expect(trigger?.textContent).toContain("Hello World");
+  });
+
+  it("prefers explicit item labels over child labels", () => {
+    renderUi(() => (
+      <Select value={["custom"]}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select value" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem label="Custom Label" value="custom">
+            Child Label
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    ));
+
+    const trigger = document.body.querySelector(
+      "[data-slot='select-trigger']",
+    );
+    expect(trigger?.textContent).toContain("Custom Label");
+    expect(trigger?.textContent).not.toContain("Child Label");
+  });
+
+  it("falls back to item value for empty child arrays", () => {
+    renderUi(() => (
+      <Select value={["fallback"]}>
+        <SelectTrigger>
+          <SelectValue placeholder="Select value" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="fallback">{[]}</SelectItem>
+        </SelectContent>
+      </Select>
+    ));
+
+    const trigger = document.body.querySelector(
+      "[data-slot='select-trigger']",
+    );
+    expect(trigger?.textContent).toContain("fallback");
+  });
 });
 
 describe("Combobox", () => {

--- a/packages/ui/src/components/components.test.tsx
+++ b/packages/ui/src/components/components.test.tsx
@@ -769,9 +769,12 @@ describe("Select", () => {
       </Select>
     ));
 
-    expect(
-      document.body.querySelector("[data-slot='select-trigger']"),
-    ).not.toBeNull();
+    const trigger = document.body.querySelector(
+      "[data-slot='select-trigger']",
+    );
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toContain("Solid");
+    expect(trigger?.textContent).not.toContain("solid");
     expect(
       document.body.querySelectorAll("[data-slot='select-item']"),
     ).toHaveLength(2);


### PR DESCRIPTION
## Summary
- add persisted combat profile storage and a Skills window for profile CRUD
- wire auto attack to combat profiles with generic, class match, and selected profile modes
- add topbar controls, hotkeys, and shared UI select label handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Combat profiles system for defining/managing skill rotations
  * Auto Attack feature integrated with combat profiles
  * New Skills window for editing combat profiles
  * In-game Combat dropdown for auto-attack control and profile selection
  * New Toggle Bank command

* **Improvements**
  * Redesigned hotkey conflict UI with conflict pills
  * Command category reorganization and related UI updates

* **Tests**
  * Added unit tests covering combat profiles, IPC bridges, and command behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->