### PR TITLE
feat: add game hotkey toast feedback

### DIFF
--- a/app/src/main/windows.integration.test.ts
+++ b/app/src/main/windows.integration.test.ts
@@ -51,9 +51,9 @@ describe("app window wiring", () => {
     expect(source).toContain("optionHotkey");
     expect(source).not.toContain("Cmd/Ctrl");
     expect(appSource).toContain(
-      "hotkeyBindings={() => settings().hotkeys.bindings}",
+      "hotkeyBindings: () => settings().hotkeys.bindings",
     );
-    expect(appSource).toContain("hotkeyPlatform={window.ipc.platform.os}");
+    expect(appSource).toContain("hotkeyPlatform: window.ipc.platform.os");
   });
 
   it("mounts the game renderer through the shared window mount", () => {
@@ -202,6 +202,10 @@ describe("app window wiring", () => {
     expect(windowHtml).toContain('data-ready="false"');
     expect(gameHtml).toContain('data-ready="false"');
     expect(gameHtml).toContain("background: rgb(var(--background));");
+    expect(gameHtml).toContain('wmode="opaque"');
+    expect(gameHtml.indexOf('id="swf"')).toBeLessThan(
+      gameHtml.indexOf('id="root"'),
+    );
   });
 
   it("seeds the settings renderer from shared mount settings", () => {

--- a/app/src/main/windows.integration.test.ts
+++ b/app/src/main/windows.integration.test.ts
@@ -203,9 +203,11 @@ describe("app window wiring", () => {
     expect(gameHtml).toContain('data-ready="false"');
     expect(gameHtml).toContain("background: rgb(var(--background));");
     expect(gameHtml).toContain('wmode="opaque"');
-    expect(gameHtml.indexOf('id="swf"')).toBeLessThan(
-      gameHtml.indexOf('id="root"'),
-    );
+    const swfIndex = gameHtml.indexOf('id="swf"');
+    const rootIndex = gameHtml.indexOf('id="root"');
+    expect(swfIndex).toBeGreaterThan(-1);
+    expect(rootIndex).toBeGreaterThan(-1);
+    expect(swfIndex).toBeLessThan(rootIndex);
   });
 
   it("seeds the settings renderer from shared mount settings", () => {

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -2,7 +2,7 @@
 import "../../polyfills";
 import "./entrypoint";
 import "./style.css";
-import { Spinner } from "@vexed/ui";
+import { Spinner, Toaster, createToastController } from "@vexed/ui";
 import { mountWindow } from "../mount";
 import { Data, Effect, Fiber } from "effect";
 import {
@@ -55,15 +55,23 @@ import {
   type AutoZoneSupportedMap,
 } from "./features/Services/AutoZone";
 import { Follower } from "./features/Services/Follower";
-import { TopNav } from "./TopNav";
-import { createGameCommands } from "./commands";
+import {
+  TopNav,
+  TopNavHiddenOptionsMenu,
+  type TopNavOptionsMenuContentProps,
+} from "./TopNav";
+import { createGameCommands, type GameCommand } from "./commands";
 import { GameHotkeys } from "./hotkeys";
 import {
   getGameLoadState,
   onGameLoaded,
   subscribeGameLoadState,
 } from "./loadState";
-import type { GameTopNavMenu, TopNavOptionItem } from "./topNavOptions";
+import {
+  findTopNavOption,
+  type GameTopNavMenu,
+  type TopNavOptionItem,
+} from "./topNavOptions";
 import { ScriptRunner } from "./scripting/Services/ScriptRunner";
 
 const ACCOUNT_SCRIPT_STATUS_POLL_MS = 1000;
@@ -204,6 +212,10 @@ export default function App(props: {
   const [selectedCell, setSelectedCell] = createSignal(DEFAULT_CELL);
   const [selectedPad, setSelectedPad] = createSignal(DEFAULT_PAD);
   const [travelBusy, setTravelBusy] = createSignal(false);
+  const hotkeyToasts = createToastController({
+    defaultDuration: 1200,
+    limit: 1,
+  });
 
   let settingsStateDisposer: (() => void) | undefined;
   let autoAttackStateDisposer: (() => void) | undefined;
@@ -1181,18 +1193,47 @@ export default function App(props: {
     },
     optionItems,
     openWindow,
-    openTopNavMenu: (menu) => setOpenTopNavMenu(menu),
+    toggleTopNavMenu: (menu) =>
+      setOpenTopNavMenu((current) => (current === menu ? null : menu)),
     toggleTopBarVisible: () => {
       setOpenTopNavMenu(null);
       setTopBarVisible((visible) => !visible);
     },
   });
 
+  const getHotkeyToastTitle = (command: GameCommand): string | null => {
+    const option = findTopNavOption(optionItems(), command.id);
+    if (option !== undefined) {
+      return `${option.label} ${option.checked ? "On" : "Off"}`;
+    }
+
+    return null;
+  };
+
+  const handleHotkeyCommandRun = (command: GameCommand): void => {
+    if (openTopNavMenu() === "options") return;
+
+    const title = getHotkeyToastTitle(command);
+    if (title === null) return;
+
+    hotkeyToasts.info(title, {
+      dismissible: false,
+      duration: 1200,
+      id: "game-hotkey-feedback",
+    });
+  };
+
   createEffect(() => {
     document.documentElement.toggleAttribute(
       "data-top-bar-hidden",
       !topBarVisible(),
     );
+  });
+
+  createEffect(() => {
+    if (openTopNavMenu() === "options") {
+      hotkeyToasts.closeAll();
+    }
   });
 
   onCleanup(() => {
@@ -1437,15 +1478,50 @@ export default function App(props: {
     autoReloginStateDisposer?.();
   });
 
+  const topNavOptionsMenuProps: TopNavOptionsMenuContentProps = {
+    hotkeyBindings: () => settings().hotkeys.bindings,
+    hotkeyPlatform: window.ipc.platform.os,
+    optionItems,
+    gameLoaded,
+    playerReady,
+    walkSpeed,
+    setWalkSpeed,
+    handleSetWalkSpeed,
+    frameRate,
+    setFrameRate,
+    handleSetFrameRate,
+    customName,
+    setCustomName,
+    handleSetCustomName,
+    customGuild,
+    setCustomGuild,
+    handleSetCustomGuild,
+  };
+
   return (
     <main class="game-shell">
-      <GameHotkeys commands={() => gameCommands} />
+      <Toaster
+        class="game-toast-banner"
+        controller={hotkeyToasts}
+        placement="top-center"
+      />
+      <GameHotkeys
+        commands={() => gameCommands}
+        onCommandRun={handleHotkeyCommandRun}
+      />
+      <Show when={!topBarVisible()}>
+        <TopNavHiddenOptionsMenu
+          {...topNavOptionsMenuProps}
+          open={() => openTopNavMenu() === "options"}
+          setOpen={(open) => setOpenTopNavMenu(open ? "options" : null)}
+        />
+      </Show>
       <Show when={topBarVisible()}>
         <TopNav
           openMenu={openTopNavMenu}
           setOpenMenu={setOpenTopNavMenu}
-          hotkeyBindings={() => settings().hotkeys.bindings}
-          hotkeyPlatform={window.ipc.platform.os}
+          hotkeyBindings={topNavOptionsMenuProps.hotkeyBindings}
+          hotkeyPlatform={topNavOptionsMenuProps.hotkeyPlatform}
           autoAttackEnabled={autoAttackEnabled}
           autoAttackProfileLabel={autoAttackProfileLabel}
           autoAttackConfiguredProfileLabel={autoAttackConfiguredProfileLabel}
@@ -1470,19 +1546,19 @@ export default function App(props: {
           loadScript={loadScript}
           startScript={startScript}
           stopScript={stopScript}
-          optionItems={optionItems}
-          walkSpeed={walkSpeed}
-          setWalkSpeed={setWalkSpeed}
-          handleSetWalkSpeed={handleSetWalkSpeed}
-          frameRate={frameRate}
-          setFrameRate={setFrameRate}
-          handleSetFrameRate={handleSetFrameRate}
-          customName={customName}
-          setCustomName={setCustomName}
-          handleSetCustomName={handleSetCustomName}
-          customGuild={customGuild}
-          setCustomGuild={setCustomGuild}
-          handleSetCustomGuild={handleSetCustomGuild}
+          optionItems={topNavOptionsMenuProps.optionItems}
+          walkSpeed={topNavOptionsMenuProps.walkSpeed}
+          setWalkSpeed={topNavOptionsMenuProps.setWalkSpeed}
+          handleSetWalkSpeed={topNavOptionsMenuProps.handleSetWalkSpeed}
+          frameRate={topNavOptionsMenuProps.frameRate}
+          setFrameRate={topNavOptionsMenuProps.setFrameRate}
+          handleSetFrameRate={topNavOptionsMenuProps.handleSetFrameRate}
+          customName={topNavOptionsMenuProps.customName}
+          setCustomName={topNavOptionsMenuProps.setCustomName}
+          handleSetCustomName={topNavOptionsMenuProps.handleSetCustomName}
+          customGuild={topNavOptionsMenuProps.customGuild}
+          setCustomGuild={topNavOptionsMenuProps.setCustomGuild}
+          handleSetCustomGuild={topNavOptionsMenuProps.handleSetCustomGuild}
           autoZoneEnabled={autoZoneEnabled}
           autoZoneMap={autoZoneMap}
           handleToggleAutoZone={handleToggleAutoZone}

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -1218,7 +1218,6 @@ export default function App(props: {
 
     hotkeyToasts.info(title, {
       dismissible: false,
-      duration: 1200,
       id: "game-hotkey-feedback",
     });
   };

--- a/app/src/renderer/windows/game/TopNav.tsx
+++ b/app/src/renderer/windows/game/TopNav.tsx
@@ -59,32 +59,11 @@ import {
   type TopNavOptionItem,
 } from "./topNavOptions";
 
-export interface TopNavProps {
-  readonly openMenu: Accessor<GameTopNavMenu | null>;
-  readonly setOpenMenu: Setter<GameTopNavMenu | null>;
+export interface TopNavOptionsMenuContentProps {
   readonly hotkeyBindings: Accessor<HotkeyBindings>;
   readonly hotkeyPlatform: AppPlatform;
-  readonly autoAttackEnabled: Accessor<boolean>;
-  readonly autoAttackProfileLabel: Accessor<string>;
-  readonly autoAttackConfiguredProfileLabel: Accessor<string>;
-  readonly autoAttackLastError: Accessor<string>;
-  readonly combatProfiles: Accessor<readonly CombatProfile[]>;
-  readonly autoAttackMode: Accessor<CombatProfileAutoAttackMode>;
-  readonly selectedAutoAttackProfileId: Accessor<string | undefined>;
-  readonly handleToggleAutoAttack: () => void;
-  readonly handleSelectAutoAttackProfile: (
-    mode: CombatProfileAutoAttackMode,
-    selectedProfileId?: string,
-  ) => void;
   readonly gameLoaded: Accessor<boolean>;
   readonly playerReady: Accessor<boolean>;
-  readonly scriptLoaded: Accessor<boolean>;
-  readonly scriptRunning: Accessor<boolean>;
-  readonly scriptStatus: Accessor<string>;
-  readonly scriptDiagnosticsCount: Accessor<number>;
-  readonly loadScript: () => void | Promise<void>;
-  readonly startScript: () => void;
-  readonly stopScript: () => void;
   readonly optionItems: Accessor<readonly TopNavOptionItem[]>;
   readonly walkSpeed: Accessor<string>;
   readonly setWalkSpeed: Setter<string>;
@@ -98,6 +77,30 @@ export interface TopNavProps {
   readonly customGuild: Accessor<string>;
   readonly setCustomGuild: Setter<string>;
   readonly handleSetCustomGuild: () => void;
+}
+
+export interface TopNavProps extends TopNavOptionsMenuContentProps {
+  readonly openMenu: Accessor<GameTopNavMenu | null>;
+  readonly setOpenMenu: Setter<GameTopNavMenu | null>;
+  readonly autoAttackEnabled: Accessor<boolean>;
+  readonly autoAttackProfileLabel: Accessor<string>;
+  readonly autoAttackConfiguredProfileLabel: Accessor<string>;
+  readonly autoAttackLastError: Accessor<string>;
+  readonly combatProfiles: Accessor<readonly CombatProfile[]>;
+  readonly autoAttackMode: Accessor<CombatProfileAutoAttackMode>;
+  readonly selectedAutoAttackProfileId: Accessor<string | undefined>;
+  readonly handleToggleAutoAttack: () => void;
+  readonly handleSelectAutoAttackProfile: (
+    mode: CombatProfileAutoAttackMode,
+    selectedProfileId?: string,
+  ) => void;
+  readonly scriptLoaded: Accessor<boolean>;
+  readonly scriptRunning: Accessor<boolean>;
+  readonly scriptStatus: Accessor<string>;
+  readonly scriptDiagnosticsCount: Accessor<number>;
+  readonly loadScript: () => void | Promise<void>;
+  readonly startScript: () => void;
+  readonly stopScript: () => void;
   readonly autoZoneEnabled: Accessor<boolean>;
   readonly autoZoneMap: Accessor<AutoZoneSupportedMap | undefined>;
   readonly handleToggleAutoZone: () => void;
@@ -196,6 +199,149 @@ function TopNavMenuTrigger(props: TopNavMenuTriggerProps): JSX.Element {
         />
       )}
     />
+  );
+}
+
+export function TopNavOptionsMenuContent(
+  props: TopNavOptionsMenuContentProps,
+): JSX.Element {
+  const gameInteractionDisabled = () =>
+    !props.gameLoaded() || !props.playerReady();
+
+  const clickOption =
+    (option: TopNavOptionItem): JSX.EventHandler<HTMLDivElement, MouseEvent> =>
+    () => {
+      if (option.disabled) {
+        return;
+      }
+      option.onSelect();
+    };
+
+  const stopMenuInputKeyPropagation: JSX.EventHandler<
+    HTMLInputElement,
+    KeyboardEvent
+  > = (event) => {
+    if (event.key !== "Escape" && event.key !== "Tab") {
+      event.stopPropagation();
+    }
+  };
+
+  return (
+    <>
+      <MenuAutofocusAnchor />
+      <div class="game-options-grid">
+        <For each={props.optionItems()}>
+          {(option) => (
+            <MenuCheckboxItem
+              checked={option.checked}
+              class="game-menu__item"
+              closeOnSelect={false}
+              disabled={option.disabled}
+              onClick={clickOption(option)}
+              value={option.id}
+            >
+              <span class="game-menu__option-content">
+                <span class="game-menu__item-label">{option.label}</span>
+                <Show
+                  when={formatOptionalHotkeyDisplay(
+                    optionHotkey(props.hotkeyBindings(), option.id),
+                    props.hotkeyPlatform,
+                  )}
+                >
+                  {(shortcut) => <Kbd>{shortcut()}</Kbd>}
+                </Show>
+              </span>
+            </MenuCheckboxItem>
+          )}
+        </For>
+      </div>
+      <MenuSeparator />
+      <div class="game-menu__fields">
+        <label class="game-menu__field">
+          <span>Walk Speed</span>
+          <Input
+            disabled={gameInteractionDisabled()}
+            size="sm"
+            value={props.walkSpeed()}
+            onBlur={props.handleSetWalkSpeed}
+            onKeyDown={stopMenuInputKeyPropagation}
+            onInput={(event) => props.setWalkSpeed(event.currentTarget.value)}
+          />
+        </label>
+        <label class="game-menu__field">
+          <span>FPS</span>
+          <Input
+            disabled={gameInteractionDisabled()}
+            size="sm"
+            value={props.frameRate()}
+            onBlur={props.handleSetFrameRate}
+            onKeyDown={stopMenuInputKeyPropagation}
+            onInput={(event) => props.setFrameRate(event.currentTarget.value)}
+          />
+        </label>
+        <label class="game-menu__field game-menu__field--wide">
+          <span>Custom Name</span>
+          <Input
+            disabled={gameInteractionDisabled()}
+            placeholder="Keep current name"
+            size="sm"
+            value={props.customName()}
+            onBlur={props.handleSetCustomName}
+            onKeyDown={stopMenuInputKeyPropagation}
+            onInput={(event) => props.setCustomName(event.currentTarget.value)}
+          />
+        </label>
+        <label class="game-menu__field game-menu__field--wide">
+          <span>Custom Guild</span>
+          <Input
+            disabled={gameInteractionDisabled()}
+            placeholder="Keep current guild"
+            size="sm"
+            value={props.customGuild()}
+            onBlur={props.handleSetCustomGuild}
+            onKeyDown={stopMenuInputKeyPropagation}
+            onInput={(event) => props.setCustomGuild(event.currentTarget.value)}
+          />
+        </label>
+      </div>
+    </>
+  );
+}
+
+export interface TopNavHiddenOptionsMenuProps extends TopNavOptionsMenuContentProps {
+  readonly open: Accessor<boolean>;
+  readonly setOpen: (open: boolean) => void;
+}
+
+export function TopNavHiddenOptionsMenu(
+  props: TopNavHiddenOptionsMenuProps,
+): JSX.Element {
+  return (
+    <div class="game-hidden-options-menu">
+      <Menu
+        open={props.open()}
+        positioning={{
+          gutter: 8,
+          placement: "bottom",
+          strategy: "fixed",
+        }}
+        onOpenChange={(details) => props.setOpen(details.open)}
+      >
+        <MenuTrigger
+          aria-hidden="true"
+          class="game-hidden-options-menu__anchor"
+          tabIndex={-1}
+        >
+          Options
+        </MenuTrigger>
+        <MenuContent
+          class="game-menu game-menu--options game-hidden-options-menu__content"
+          portal={false}
+        >
+          <TopNavOptionsMenuContent {...props} />
+        </MenuContent>
+      </Menu>
+    </div>
   );
 }
 
@@ -404,15 +550,6 @@ export function TopNav(props: TopNavProps): JSX.Element {
       .validPads()
       .some((validPad) => validPad.toLowerCase() === pad.toLowerCase());
 
-  const clickOption =
-    (option: TopNavOptionItem): JSX.EventHandler<HTMLDivElement, MouseEvent> =>
-    () => {
-      if (option.disabled) {
-        return;
-      }
-      option.onSelect();
-    };
-
   const stopMenuInputKeyPropagation: JSX.EventHandler<
     HTMLInputElement,
     KeyboardEvent
@@ -582,92 +719,7 @@ export function TopNav(props: TopNavProps): JSX.Element {
               Options
             </TopNavMenuTrigger>
             <MenuContent class="game-menu game-menu--options" portal={false}>
-              <MenuAutofocusAnchor />
-              <div class="game-options-grid">
-                <For each={props.optionItems()}>
-                  {(option) => (
-                    <MenuCheckboxItem
-                      checked={option.checked}
-                      class="game-menu__item"
-                      closeOnSelect={false}
-                      disabled={option.disabled}
-                      onClick={clickOption(option)}
-                      value={option.id}
-                    >
-                      <span class="game-menu__option-content">
-                        <span class="game-menu__item-label">
-                          {option.label}
-                        </span>
-                        <Show
-                          when={formatOptionalHotkeyDisplay(
-                            optionHotkey(props.hotkeyBindings(), option.id),
-                            props.hotkeyPlatform,
-                          )}
-                        >
-                          {(shortcut) => <Kbd>{shortcut()}</Kbd>}
-                        </Show>
-                      </span>
-                    </MenuCheckboxItem>
-                  )}
-                </For>
-              </div>
-              <MenuSeparator />
-              <div class="game-menu__fields">
-                <label class="game-menu__field">
-                  <span>Walk Speed</span>
-                  <Input
-                    disabled={gameInteractionDisabled()}
-                    size="sm"
-                    value={props.walkSpeed()}
-                    onBlur={props.handleSetWalkSpeed}
-                    onKeyDown={stopMenuInputKeyPropagation}
-                    onInput={(event) =>
-                      props.setWalkSpeed(event.currentTarget.value)
-                    }
-                  />
-                </label>
-                <label class="game-menu__field">
-                  <span>FPS</span>
-                  <Input
-                    disabled={gameInteractionDisabled()}
-                    size="sm"
-                    value={props.frameRate()}
-                    onBlur={props.handleSetFrameRate}
-                    onKeyDown={stopMenuInputKeyPropagation}
-                    onInput={(event) =>
-                      props.setFrameRate(event.currentTarget.value)
-                    }
-                  />
-                </label>
-                <label class="game-menu__field game-menu__field--wide">
-                  <span>Custom Name</span>
-                  <Input
-                    disabled={gameInteractionDisabled()}
-                    placeholder="Keep current name"
-                    size="sm"
-                    value={props.customName()}
-                    onBlur={props.handleSetCustomName}
-                    onKeyDown={stopMenuInputKeyPropagation}
-                    onInput={(event) =>
-                      props.setCustomName(event.currentTarget.value)
-                    }
-                  />
-                </label>
-                <label class="game-menu__field game-menu__field--wide">
-                  <span>Custom Guild</span>
-                  <Input
-                    disabled={gameInteractionDisabled()}
-                    placeholder="Keep current guild"
-                    size="sm"
-                    value={props.customGuild()}
-                    onBlur={props.handleSetCustomGuild}
-                    onKeyDown={stopMenuInputKeyPropagation}
-                    onInput={(event) =>
-                      props.setCustomGuild(event.currentTarget.value)
-                    }
-                  />
-                </label>
-              </div>
+              <TopNavOptionsMenuContent {...props} />
             </MenuContent>
           </Menu>
 
@@ -1037,7 +1089,9 @@ export function TopNav(props: TopNavProps): JSX.Element {
                   closeOnSelect={false}
                   value="equipped-class"
                 >
-                  <span class="game-menu__item-label">Match equipped class</span>
+                  <span class="game-menu__item-label">
+                    Match equipped class
+                  </span>
                 </MenuRadioItem>
                 <MenuRadioItem
                   class="game-menu__item"

--- a/app/src/renderer/windows/game/commands.test.ts
+++ b/app/src/renderer/windows/game/commands.test.ts
@@ -29,7 +29,7 @@ const createRuntime = (
     toggleBank: noop,
     optionItems: () => [],
     openWindow: noop,
-    openTopNavMenu: noop,
+    toggleTopNavMenu: noop,
     toggleTopBarVisible: noop,
     ...overrides,
   };
@@ -51,13 +51,13 @@ const findCommand = (
 };
 
 describe("game commands", () => {
-  it("opens the top nav options menu", () => {
-    const openTopNavMenu = vi.fn();
-    const runtime = createRuntime({ openTopNavMenu });
+  it("toggles the top nav options menu", () => {
+    const toggleTopNavMenu = vi.fn();
+    const runtime = createRuntime({ toggleTopNavMenu });
 
-    findCommand(runtime, "openOptionsMenu").run();
+    findCommand(runtime, "toggleOptionsMenu").run();
 
-    expect(openTopNavMenu).toHaveBeenCalledWith("options");
+    expect(toggleTopNavMenu).toHaveBeenCalledWith("options");
   });
 
   it("toggles top bar visibility", () => {

--- a/app/src/renderer/windows/game/commands.ts
+++ b/app/src/renderer/windows/game/commands.ts
@@ -30,7 +30,7 @@ export interface GameCommandRuntime {
   readonly toggleBank: () => void;
   readonly optionItems: Accessor<readonly TopNavOptionItem[]>;
   readonly openWindow: (id: WindowId) => void;
-  readonly openTopNavMenu: (menu: GameTopNavMenu) => void;
+  readonly toggleTopNavMenu: (menu: GameTopNavMenu) => void;
   readonly toggleTopBarVisible: () => void;
 }
 
@@ -158,8 +158,8 @@ const createCommandRunner = (
     return runtime.toggleBank;
   }
 
-  if (id === "openOptionsMenu") {
-    return () => runtime.openTopNavMenu("options");
+  if (id === "toggleOptionsMenu") {
+    return () => runtime.toggleTopNavMenu("options");
   }
 
   if (id === "toggleTopBar") {

--- a/app/src/renderer/windows/game/hotkeys.tsx
+++ b/app/src/renderer/windows/game/hotkeys.tsx
@@ -5,7 +5,7 @@ import type { GameCommand } from "./commands";
 
 function GameHotkeyRegistration(props: {
   readonly command: GameCommand;
-  readonly onCommandRun?: (command: GameCommand) => void;
+  readonly onCommandRun?: ((command: GameCommand) => void) | undefined;
 }): JSX.Element {
   createHotkey(
     () => props.command.hotkey() as RegisterableHotkey,
@@ -31,7 +31,7 @@ function GameHotkeyRegistration(props: {
 
 export function GameHotkeys(props: {
   readonly commands: Accessor<readonly GameCommand[]>;
-  readonly onCommandRun?: (command: GameCommand) => void;
+  readonly onCommandRun?: ((command: GameCommand) => void) | undefined;
 }): JSX.Element {
   return (
     <For each={props.commands()}>
@@ -39,9 +39,7 @@ export function GameHotkeys(props: {
         <Show when={command.hotkey()}>
           <GameHotkeyRegistration
             command={command}
-            {...(props.onCommandRun === undefined
-              ? {}
-              : { onCommandRun: props.onCommandRun })}
+            onCommandRun={props.onCommandRun}
           />
         </Show>
       )}

--- a/app/src/renderer/windows/game/hotkeys.tsx
+++ b/app/src/renderer/windows/game/hotkeys.tsx
@@ -5,6 +5,7 @@ import type { GameCommand } from "./commands";
 
 function GameHotkeyRegistration(props: {
   readonly command: GameCommand;
+  readonly onCommandRun?: (command: GameCommand) => void;
 }): JSX.Element {
   createHotkey(
     () => props.command.hotkey() as RegisterableHotkey,
@@ -14,6 +15,7 @@ function GameHotkeyRegistration(props: {
       }
 
       props.command.run();
+      props.onCommandRun?.(props.command);
     },
     () => ({
       enabled: props.command.enabled() && props.command.hotkey() !== "",
@@ -29,12 +31,18 @@ function GameHotkeyRegistration(props: {
 
 export function GameHotkeys(props: {
   readonly commands: Accessor<readonly GameCommand[]>;
+  readonly onCommandRun?: (command: GameCommand) => void;
 }): JSX.Element {
   return (
     <For each={props.commands()}>
       {(command) => (
         <Show when={command.hotkey()}>
-          <GameHotkeyRegistration command={command} />
+          <GameHotkeyRegistration
+            command={command}
+            {...(props.onCommandRun === undefined
+              ? {}
+              : { onCommandRun: props.onCommandRun })}
+          />
         </Show>
       )}
     </For>

--- a/app/src/renderer/windows/game/index.html
+++ b/app/src/renderer/windows/game/index.html
@@ -1,24 +1,27 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-ready="false">
   <head>
     <link rel="stylesheet" href="./index.css" />
     <style>
       body {
         background: rgb(var(--background));
+        isolation: isolate;
         margin: 0;
         padding: 0;
         overflow: hidden;
+        position: relative;
         width: 100vw;
         height: 100vh;
       }
       #root {
+        isolation: isolate;
         position: fixed;
         top: 0;
         left: 0;
         width: 100%;
         height: 100%;
         pointer-events: none;
-        z-index: 10;
+        z-index: 2147483647;
       }
       #swf {
         position: absolute;
@@ -26,7 +29,7 @@
         top: var(--topnav-offset, var(--topnav-height, 28px));
         width: 100%;
         height: calc(100% - var(--topnav-offset, var(--topnav-height, 28px)));
-        z-index: 1;
+        z-index: 0;
       }
       html[data-top-bar-hidden] #swf {
         top: 0;
@@ -35,11 +38,8 @@
     </style>
   </head>
   <body>
+    <embed id="swf" src="../../../../assets/loader.swf" wmode="opaque" />
     <div id="root"></div>
-    <embed
-      id="swf"
-      src="../../../../assets/loader.swf"
-    />
     <script src="./index.js" type="module"></script>
   </body>
 </html>

--- a/app/src/renderer/windows/game/style.css
+++ b/app/src/renderer/windows/game/style.css
@@ -25,6 +25,27 @@
   z-index: 10000;
 }
 
+.game-toast-banner.toaster--top-center {
+  top: calc(var(--topnav-offset, var(--topnav-height, 32px)) + 0.5rem);
+  z-index: 2147483647;
+}
+
+:root[data-top-bar-hidden] .game-toast-banner.toaster--top-center {
+  top: 0.5rem;
+}
+
+.game-toast-banner .toast-banner {
+  min-width: min(18rem, calc(100vw - 1rem));
+}
+
+.game-toast-banner .toast-banner--info {
+  background: rgb(var(--popover));
+  border-color: rgba(var(--info), 0.42);
+  box-shadow:
+    0 10px 28px rgba(var(--black), 0.2),
+    0 1px 2px rgba(var(--black), 0.12);
+}
+
 .game-topnav {
   align-items: center;
   display: flex;
@@ -231,7 +252,8 @@
 }
 
 .game-topnav__status-slot[data-kind="alert"] .game-topnav__alert-icon {
-  animation: game-topnav-alert-pulse 1.2s cubic-bezier(0.23, 1, 0.32, 1) infinite;
+  animation: game-topnav-alert-pulse 1.2s cubic-bezier(0.23, 1, 0.32, 1)
+    infinite;
   will-change: opacity;
 }
 
@@ -318,7 +340,6 @@
   width: 0.75rem;
 }
 
-
 .game-topnav__trigger:disabled,
 .game-topnav__button:disabled,
 .game-topnav__select-trigger:disabled {
@@ -361,6 +382,39 @@
 
 .game-menu--options {
   min-width: min(24rem, calc(100vw - 1rem));
+}
+
+.game-hidden-options-menu {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 10001;
+}
+
+.game-hidden-options-menu .menu__positioner {
+  pointer-events: auto;
+  z-index: 10001;
+}
+
+.game-hidden-options-menu__anchor {
+  background: transparent;
+  border: 0;
+  height: 1px;
+  left: 50%;
+  opacity: 0;
+  overflow: hidden;
+  padding: 0;
+  pointer-events: none;
+  position: fixed;
+  top: 0.5rem;
+  transform: translateX(-50%);
+  width: 1px;
+}
+
+.game-hidden-options-menu__content {
+  box-shadow:
+    0 14px 42px rgba(var(--black), 0.18),
+    0 2px 8px rgba(var(--black), 0.1);
 }
 
 .game-menu--autozone {
@@ -487,7 +541,6 @@
   flex: 0 1 auto;
 }
 
-
 .game-menu__status {
   color: var(--color-muted-foreground);
   display: grid;
@@ -581,7 +634,6 @@
   justify-content: space-between;
   padding: 0 0.25rem;
 }
-
 
 .game-menu__delay-control {
   align-items: center;

--- a/app/src/shared/commands.ts
+++ b/app/src/shared/commands.ts
@@ -12,7 +12,7 @@ export type GameCommandId =
   | "loadScript"
   | "toggleScript"
   | "stopScript"
-  | "openOptionsMenu"
+  | "toggleOptionsMenu"
   | "openEnvironment"
   | "openFastTravels"
   | "openLoaderGrabber"
@@ -81,11 +81,11 @@ export const GAME_COMMANDS: readonly CommandDefinition[] = [
     defaultHotkey: "Mod+Shift+X",
   },
   {
-    id: "openOptionsMenu",
+    id: "toggleOptionsMenu",
     scope: "game",
     category: "Options",
-    label: "Open Options Menu",
-    keywords: ["menu", "options", "settings"],
+    label: "Toggle Options Menu",
+    keywords: ["menu", "options", "settings", "open", "close"],
     defaultHotkey: "Mod+Shift+,",
   },
   {

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -1,0 +1,361 @@
+import {
+  createEffect,
+  createSignal,
+  Index,
+  onCleanup,
+  Show,
+  splitProps,
+  type Accessor,
+  type JSX,
+} from "solid-js";
+import { CircleAlert, CircleCheck, Info, TriangleAlert, X } from "lucide-solid";
+import { cn } from "../lib/cn";
+
+export type ToastVariant = "default" | "error" | "info" | "success" | "warning";
+export type ToastPlacement =
+  | "bottom-center"
+  | "bottom-right"
+  | "top-center"
+  | "top-right";
+
+export interface ToastHandle {
+  readonly close: () => void;
+}
+
+export interface ToastOptions {
+  readonly action?: JSX.Element;
+  readonly class?: string;
+  readonly description?: JSX.Element;
+  readonly dismissible?: boolean;
+  readonly duration?: number | null;
+  readonly icon?: JSX.Element | null;
+  readonly id?: string;
+  readonly onRemove?: () => void;
+  readonly testId?: string;
+  readonly title?: JSX.Element;
+}
+
+export interface ToastItem extends Required<Pick<ToastOptions, "dismissible">> {
+  readonly action?: JSX.Element;
+  readonly class?: string;
+  readonly description?: JSX.Element;
+  readonly duration: number | null;
+  readonly icon?: JSX.Element | null;
+  readonly id: string;
+  readonly key?: string;
+  readonly onRemove?: () => void;
+  readonly open: boolean;
+  readonly testId?: string;
+  readonly title?: JSX.Element;
+  readonly variant: ToastVariant;
+  readonly version: number;
+}
+
+export interface ToastController {
+  readonly close: (id: string) => void;
+  readonly closeAll: () => void;
+  readonly error: (
+    title: JSX.Element,
+    options?: Omit<ToastOptions, "title">,
+  ) => ToastHandle;
+  readonly info: (
+    title: JSX.Element,
+    options?: Omit<ToastOptions, "title">,
+  ) => ToastHandle;
+  readonly remove: (id: string) => void;
+  readonly show: (
+    options: ToastOptions & { variant?: ToastVariant },
+  ) => ToastHandle;
+  readonly success: (
+    title: JSX.Element,
+    options?: Omit<ToastOptions, "title">,
+  ) => ToastHandle;
+  readonly toasts: Accessor<readonly ToastItem[]>;
+  readonly warning: (
+    title: JSX.Element,
+    options?: Omit<ToastOptions, "title">,
+  ) => ToastHandle;
+}
+
+export interface CreateToastControllerOptions {
+  readonly defaultDuration?: number;
+  readonly limit?: number;
+}
+
+export interface ToasterProps
+  extends Omit<JSX.HTMLAttributes<HTMLDivElement>, "class"> {
+  readonly class?: string;
+  readonly controller: ToastController;
+  readonly placement?: ToastPlacement;
+  readonly removeDelay?: number;
+}
+
+export interface ToastBannerProps
+  extends Omit<JSX.HTMLAttributes<HTMLDivElement>, "class"> {
+  readonly class?: string;
+  readonly controller: Pick<ToastController, "close" | "remove">;
+  readonly removeDelay?: number;
+  readonly toast: ToastItem;
+}
+
+const DEFAULT_TOAST_DURATION = 5000;
+const DEFAULT_REMOVE_DELAY = 180;
+
+const defaultToastIcon = (variant: ToastVariant): JSX.Element | null => {
+  if (variant === "success") {
+    return <CircleCheck aria-hidden="true" />;
+  }
+
+  if (variant === "info") {
+    return <Info aria-hidden="true" />;
+  }
+
+  if (variant === "warning") {
+    return <TriangleAlert aria-hidden="true" />;
+  }
+
+  if (variant === "error") {
+    return <CircleAlert aria-hidden="true" />;
+  }
+
+  return null;
+};
+
+export const createToastController = (
+  options: CreateToastControllerOptions = {},
+): ToastController => {
+  const defaultDuration = options.defaultDuration ?? DEFAULT_TOAST_DURATION;
+  const limit = options.limit ?? 4;
+  const [toasts, setToasts] = createSignal<readonly ToastItem[]>([]);
+  let nextToastId = 1;
+
+  const close = (id: string): void => {
+    setToasts((current) =>
+      current.map((toast) =>
+        toast.id === id ? { ...toast, open: false } : toast,
+      ),
+    );
+  };
+
+  const closeAll = (): void => {
+    setToasts((current) => current.map((toast) => ({ ...toast, open: false })));
+  };
+
+  const remove = (id: string): void => {
+    let removed: ToastItem | undefined;
+    setToasts((current) =>
+      current.filter((toast) => {
+        if (toast.id === id) {
+          removed = toast;
+          return false;
+        }
+        return true;
+      }),
+    );
+    removed?.onRemove?.();
+  };
+
+  const show = (
+    toastOptions: ToastOptions & { variant?: ToastVariant },
+  ): ToastHandle => {
+    const key = toastOptions.id;
+    const id = key ? `${key}-${nextToastId++}` : `${nextToastId++}`;
+    let toastId = id;
+
+    setToasts((current) => {
+      const existingToast =
+        key === undefined
+          ? undefined
+          : current.find((toast) => toast.key === key);
+      toastId = existingToast?.id ?? id;
+
+      const nextToast: ToastItem = {
+        dismissible: toastOptions.dismissible ?? true,
+        duration:
+          toastOptions.duration === undefined
+            ? defaultDuration
+            : toastOptions.duration,
+        id: toastId,
+        open: true,
+        variant: toastOptions.variant ?? "default",
+        version: (existingToast?.version ?? 0) + 1,
+        ...(toastOptions.action === undefined
+          ? {}
+          : { action: toastOptions.action }),
+        ...(toastOptions.class === undefined
+          ? {}
+          : { class: toastOptions.class }),
+        ...(toastOptions.description === undefined
+          ? {}
+          : { description: toastOptions.description }),
+        ...(toastOptions.icon === undefined ? {} : { icon: toastOptions.icon }),
+        ...(key === undefined ? {} : { key }),
+        ...(toastOptions.onRemove === undefined
+          ? {}
+          : { onRemove: toastOptions.onRemove }),
+        ...(toastOptions.testId === undefined
+          ? {}
+          : { testId: toastOptions.testId }),
+        ...(toastOptions.title === undefined
+          ? {}
+          : { title: toastOptions.title }),
+      };
+
+      return [
+        nextToast,
+        ...current.filter((toast) => toast.id !== nextToast.id),
+      ].slice(0, limit);
+    });
+
+    return { close: () => close(toastId) };
+  };
+
+  const showWithVariant =
+    (variant: ToastVariant) =>
+    (title: JSX.Element, toastOptions: Omit<ToastOptions, "title"> = {}) =>
+      show({ ...toastOptions, title, variant });
+
+  return {
+    close,
+    closeAll,
+    error: showWithVariant("error"),
+    info: showWithVariant("info"),
+    remove,
+    show,
+    success: showWithVariant("success"),
+    toasts,
+    warning: showWithVariant("warning"),
+  };
+};
+
+export function Toaster(props: ToasterProps): JSX.Element {
+  const [local, rest] = splitProps(props, [
+    "class",
+    "controller",
+    "placement",
+    "removeDelay",
+  ]);
+
+  return (
+    <div
+      {...rest}
+      class={cn(
+        "toaster",
+        `toaster--${local.placement ?? "top-center"}`,
+        local.class,
+      )}
+      data-slot="toaster"
+    >
+      <Index each={local.controller.toasts()}>
+        {(toast) => (
+          <ToastBanner
+            controller={local.controller}
+            {...(local.removeDelay === undefined
+              ? {}
+              : { removeDelay: local.removeDelay })}
+            toast={toast()}
+          />
+        )}
+      </Index>
+    </div>
+  );
+}
+
+export function ToastBanner(props: ToastBannerProps): JSX.Element {
+  const [dismissed, setDismissed] = createSignal(false);
+  let autoCloseTimer: ReturnType<typeof setTimeout> | undefined;
+  let removeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const visible = () => props.toast.open && !dismissed();
+  const close = (): void => {
+    setDismissed(true);
+    props.controller.close(props.toast.id);
+  };
+
+  createEffect(() => {
+    props.toast.version;
+    if (!props.toast.open) return;
+
+    setDismissed(false);
+    if (removeTimer !== undefined) {
+      clearTimeout(removeTimer);
+      removeTimer = undefined;
+    }
+  });
+
+  createEffect(() => {
+    if (autoCloseTimer !== undefined) {
+      clearTimeout(autoCloseTimer);
+      autoCloseTimer = undefined;
+    }
+
+    const duration = props.toast.duration;
+    props.toast.version;
+    if (visible() && duration !== null && duration > 0) {
+      autoCloseTimer = setTimeout(close, duration);
+    }
+  });
+
+  createEffect(() => {
+    if (visible()) return;
+    if (removeTimer !== undefined) return;
+
+    removeTimer = setTimeout(
+      () => props.controller.remove(props.toast.id),
+      props.removeDelay ?? DEFAULT_REMOVE_DELAY,
+    );
+  });
+
+  onCleanup(() => {
+    if (autoCloseTimer !== undefined) clearTimeout(autoCloseTimer);
+    if (removeTimer !== undefined) clearTimeout(removeTimer);
+  });
+
+  const icon = () =>
+    props.toast.icon === undefined
+      ? defaultToastIcon(props.toast.variant)
+      : props.toast.icon;
+
+  return (
+    <div
+      class={cn(
+        "toast-banner",
+        `toast-banner--${props.toast.variant}`,
+        props.toast.class,
+        props.class,
+      )}
+      data-slot="toast"
+      data-state={visible() ? "open" : "closed"}
+      data-testid={props.toast.testId}
+      role={props.toast.variant === "error" ? "alert" : "status"}
+      aria-live={props.toast.variant === "error" ? "assertive" : "polite"}
+    >
+      <Show when={icon()}>
+        {(toastIcon) => <div class="toast-banner__icon">{toastIcon()}</div>}
+      </Show>
+      <div class="toast-banner__body">
+        <Show when={props.toast.title}>
+          {(title) => <div class="toast-banner__title">{title()}</div>}
+        </Show>
+        <Show when={props.toast.description}>
+          {(description) => (
+            <div class="toast-banner__description">{description()}</div>
+          )}
+        </Show>
+      </div>
+      <Show when={props.toast.action}>
+        {(action) => <div class="toast-banner__action">{action()}</div>}
+      </Show>
+      <Show when={props.toast.dismissible}>
+        <button
+          aria-label="Dismiss notification"
+          class="toast-banner__close"
+          onClick={close}
+          type="button"
+        >
+          <X aria-hidden="true" />
+        </button>
+      </Show>
+    </div>
+  );
+}

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -158,15 +158,12 @@ export const createToastController = (
   const show = (
     toastOptions: ToastOptions & { variant?: ToastVariant },
   ): ToastHandle => {
-    const key = toastOptions.id;
-    const id = key ? `${key}-${nextToastId++}` : `${nextToastId++}`;
+    const id = toastOptions.id ?? `${nextToastId++}`;
     let toastId = id;
+    let evictedToasts: ToastItem[] = [];
 
     setToasts((current) => {
-      const existingToast =
-        key === undefined
-          ? undefined
-          : current.find((toast) => toast.key === key);
+      const existingToast = current.find((toast) => toast.id === id);
       toastId = existingToast?.id ?? id;
 
       const nextToast: ToastItem = {
@@ -189,7 +186,6 @@ export const createToastController = (
           ? {}
           : { description: toastOptions.description }),
         ...(toastOptions.icon === undefined ? {} : { icon: toastOptions.icon }),
-        ...(key === undefined ? {} : { key }),
         ...(toastOptions.onRemove === undefined
           ? {}
           : { onRemove: toastOptions.onRemove }),
@@ -201,11 +197,17 @@ export const createToastController = (
           : { title: toastOptions.title }),
       };
 
-      return [
+      const nextToasts = [
         nextToast,
         ...current.filter((toast) => toast.id !== nextToast.id),
-      ].slice(0, limit);
+      ];
+      evictedToasts = nextToasts.slice(limit);
+      return nextToasts.slice(0, limit);
     });
+
+    for (const toast of evictedToasts) {
+      toast.onRemove?.();
+    }
 
     return { close: () => close(toastId) };
   };

--- a/packages/ui/src/components/components.test.tsx
+++ b/packages/ui/src/components/components.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSignal, type JSX } from "solid-js";
 import { render } from "solid-js/web";
 import {
@@ -101,6 +101,9 @@ import {
   TooltipButtonTrigger,
   TooltipContent,
   TooltipTrigger,
+  Toaster,
+  createToastController,
+  type ToastController,
 } from "../index";
 
 const disposers: Array<() => void> = [];
@@ -183,6 +186,7 @@ async function highlightFirstComboboxItem(input: HTMLInputElement | null) {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   for (const dispose of disposers.splice(0)) {
     dispose();
   }
@@ -659,6 +663,48 @@ describe("Alert", () => {
   });
 });
 
+describe("Toaster", () => {
+  it("renders dismissible toast banners", () => {
+    let controller: ToastController | undefined;
+    const root = renderUi(() => {
+      controller = createToastController();
+      return <Toaster controller={controller} removeDelay={0} />;
+    });
+
+    controller!.success("Saved", {
+      description: "Hotkey applied.",
+      duration: null,
+      testId: "saved-toast",
+    });
+
+    const toast = root.querySelector("[data-testid='saved-toast']");
+    expect(toast?.textContent).toContain("Saved");
+    expect(toast?.textContent).toContain("Hotkey applied.");
+    expect(toast?.getAttribute("role")).toBe("status");
+    expect(root.querySelector(".toast-banner__close")).not.toBeNull();
+  });
+
+  it("replaces older toasts with the same id", async () => {
+    vi.useFakeTimers();
+    let controller: ToastController | undefined;
+    const root = renderUi(() => {
+      controller = createToastController();
+      return <Toaster controller={controller} removeDelay={0} />;
+    });
+
+    controller!.info("First", { duration: null, id: "hotkey-feedback" });
+    const firstToast = root.querySelector("[data-slot='toast']");
+    controller!.info("Second", { duration: null, id: "hotkey-feedback" });
+    vi.runOnlyPendingTimers();
+    await Promise.resolve();
+
+    expect(root.querySelector("[data-slot='toast']")).toBe(firstToast);
+    expect(root.textContent).not.toContain("First");
+    expect(root.textContent).toContain("Second");
+    vi.useRealTimers();
+  });
+});
+
 describe("Dialog", () => {
   it("renders open dialog content and close action", () => {
     renderUi(() => (
@@ -769,9 +815,7 @@ describe("Select", () => {
       </Select>
     ));
 
-    const trigger = document.body.querySelector(
-      "[data-slot='select-trigger']",
-    );
+    const trigger = document.body.querySelector("[data-slot='select-trigger']");
     expect(trigger).not.toBeNull();
     expect(trigger?.textContent).toContain("Solid");
     expect(trigger?.textContent).not.toContain("solid");
@@ -792,9 +836,7 @@ describe("Select", () => {
       </Select>
     ));
 
-    const trigger = document.body.querySelector(
-      "[data-slot='select-trigger']",
-    );
+    const trigger = document.body.querySelector("[data-slot='select-trigger']");
     expect(trigger?.textContent).toContain("42");
   });
 
@@ -810,9 +852,7 @@ describe("Select", () => {
       </Select>
     ));
 
-    const trigger = document.body.querySelector(
-      "[data-slot='select-trigger']",
-    );
+    const trigger = document.body.querySelector("[data-slot='select-trigger']");
     expect(trigger?.textContent).toContain("Hello World");
   });
 
@@ -830,9 +870,7 @@ describe("Select", () => {
       </Select>
     ));
 
-    const trigger = document.body.querySelector(
-      "[data-slot='select-trigger']",
-    );
+    const trigger = document.body.querySelector("[data-slot='select-trigger']");
     expect(trigger?.textContent).toContain("Custom Label");
     expect(trigger?.textContent).not.toContain("Child Label");
   });
@@ -849,9 +887,7 @@ describe("Select", () => {
       </Select>
     ));
 
-    const trigger = document.body.querySelector(
-      "[data-slot='select-trigger']",
-    );
+    const trigger = document.body.querySelector("[data-slot='select-trigger']");
     expect(trigger?.textContent).toContain("fallback");
   });
 });

--- a/packages/ui/src/components/components.test.tsx
+++ b/packages/ui/src/components/components.test.tsx
@@ -698,10 +698,52 @@ describe("Toaster", () => {
     vi.runOnlyPendingTimers();
     await Promise.resolve();
 
-    expect(root.querySelector("[data-slot='toast']")).toBe(firstToast);
+    expect(firstToast).not.toBeNull();
+    expect(root.querySelectorAll("[data-slot='toast']")).toHaveLength(1);
     expect(root.textContent).not.toContain("First");
     expect(root.textContent).toContain("Second");
     vi.useRealTimers();
+  });
+
+  it("preserves caller-provided ids for close and remove", () => {
+    let controller: ToastController | undefined;
+    const root = renderUi(() => {
+      controller = createToastController();
+      return <Toaster controller={controller} removeDelay={0} />;
+    });
+
+    controller!.info("Settings updated", {
+      duration: null,
+      id: "settings-toast",
+    });
+    expect(root.textContent).toContain("Settings updated");
+
+    controller!.close("settings-toast");
+
+    expect(
+      root.querySelector("[data-slot='toast']")?.getAttribute("data-state"),
+    ).toBe("closed");
+
+    controller!.remove("settings-toast");
+
+    expect(root.textContent).not.toContain("Settings updated");
+  });
+
+  it("runs onRemove for toasts evicted by the limit", () => {
+    const onRemove = vi.fn();
+    let controller: ToastController | undefined;
+    renderUi(() => {
+      controller = createToastController({ limit: 1 });
+      return <Toaster controller={controller} removeDelay={0} />;
+    });
+
+    controller!.info("First", {
+      duration: null,
+      onRemove,
+    });
+    controller!.info("Second", { duration: null });
+
+    expect(onRemove).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -302,6 +302,20 @@ export {
   type TooltipButtonTriggerProps,
 } from "./components/TooltipButton";
 export {
+  createToastController,
+  Toaster,
+  ToastBanner,
+  type CreateToastControllerOptions,
+  type ToastBannerProps,
+  type ToastController,
+  type ToastHandle,
+  type ToastItem,
+  type ToastOptions,
+  type ToastPlacement,
+  type ToasterProps,
+  type ToastVariant,
+} from "./components/Toast";
+export {
   VisuallyHidden,
   type VisuallyHiddenProps,
 } from "./components/VisuallyHidden";

--- a/packages/ui/src/styles/components.css
+++ b/packages/ui/src/styles/components.css
@@ -1968,6 +1968,224 @@ a.badge--destructive:hover {
   justify-self: end;
 }
 
+/* Toast */
+
+.toaster {
+  display: flex;
+  gap: 0.25rem;
+  max-width: min(35rem, calc(100vw - 1rem));
+  pointer-events: none;
+  position: fixed;
+  z-index: 60;
+}
+
+.toaster--top-center,
+.toaster--bottom-center {
+  align-items: center;
+  flex-direction: column;
+  left: 50%;
+  transform: translateX(-50%);
+  width: max-content;
+}
+
+.toaster--top-right,
+.toaster--bottom-right {
+  align-items: flex-end;
+  flex-direction: column;
+  right: 0.5rem;
+  width: min(35rem, calc(100vw - 1rem));
+}
+
+.toaster--top-center,
+.toaster--top-right {
+  top: 0.5rem;
+}
+
+.toaster--bottom-center,
+.toaster--bottom-right {
+  bottom: 0.5rem;
+}
+
+.toast-banner {
+  align-items: center;
+  background: rgba(var(--popover), 0.98);
+  border: 1px solid rgba(var(--border), 0.9);
+  border-radius: 0.875rem;
+  box-shadow:
+    0 8px 24px rgba(var(--black), 0.14),
+    0 1px 2px rgba(var(--black), 0.08);
+  color: rgb(var(--popover-foreground));
+  display: flex;
+  font-family: var(--font-sans);
+  gap: 0.375rem;
+  line-height: 1.4;
+  max-width: 100%;
+  min-height: 2.125rem;
+  min-width: 0;
+  opacity: 1;
+  padding: 0.4375rem 0.5rem 0.4375rem 0.625rem;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition:
+    opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  width: max-content;
+}
+
+.toast-banner[data-state="closed"] {
+  opacity: 0;
+  transform: translateY(-2px);
+}
+
+.toast-banner--error {
+  background: rgba(var(--destructive), 0.1);
+  border-color: rgba(var(--destructive), 0.34);
+}
+
+.toast-banner--info {
+  background: rgba(var(--info), 0.1);
+  border-color: rgba(var(--info), 0.34);
+}
+
+.toast-banner--success {
+  background: rgba(var(--success), 0.1);
+  border-color: rgba(var(--success), 0.34);
+}
+
+.toast-banner--warning {
+  background: rgba(var(--warning), 0.12);
+  border-color: rgba(var(--warning), 0.36);
+}
+
+.toast-banner__icon {
+  color: rgb(var(--muted-foreground));
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.toast-banner--error .toast-banner__icon {
+  color: rgb(var(--destructive-foreground));
+}
+
+.toast-banner--info .toast-banner__icon {
+  color: rgb(var(--info-foreground));
+}
+
+.toast-banner--success .toast-banner__icon {
+  color: rgb(var(--success-foreground));
+}
+
+.toast-banner--warning .toast-banner__icon {
+  color: rgb(var(--warning-foreground));
+}
+
+.toast-banner__icon svg {
+  height: 0.875rem;
+  stroke-width: 2.25;
+  width: 0.875rem;
+}
+
+.toast-banner__body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.toast-banner__title {
+  font-size: var(--text-base);
+  font-weight: 500;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.toast-banner__description {
+  color: rgb(var(--muted-foreground));
+  font-size: var(--text-sm);
+  line-height: 1.35;
+  margin-top: 0.125rem;
+  overflow-wrap: anywhere;
+}
+
+.toast-banner__action {
+  align-items: center;
+  color: rgb(var(--info-foreground));
+  display: inline-flex;
+  flex: 0 0 auto;
+  gap: 0.375rem;
+  font-size: var(--text-base);
+  font-weight: 500;
+  line-height: 1.25;
+}
+
+.toast-banner__close {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  color: rgb(var(--muted-foreground));
+  cursor: var(--cursor-interactive);
+  display: inline-flex;
+  flex: 0 0 auto;
+  height: 1.125rem;
+  justify-content: center;
+  margin: 0 -0.1875rem 0 0;
+  padding: 0;
+  width: 1.125rem;
+}
+
+.toast-banner__close:hover,
+.toast-banner__close:focus-visible {
+  background: rgba(var(--muted), 0.72);
+  color: rgb(var(--foreground));
+  outline: none;
+}
+
+.toast-banner__close:focus-visible {
+  box-shadow:
+    0 0 0 1px rgb(var(--background)),
+    0 0 0 3px rgba(var(--ring), 0.42);
+}
+
+.toast-banner__close svg {
+  height: 0.6875rem;
+  stroke-width: 2.25;
+  width: 0.6875rem;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  :root:not([data-reduce-motion="on"]) .toast-banner {
+    transition:
+      opacity 160ms cubic-bezier(0.23, 1, 0.32, 1),
+      transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  @starting-style {
+    :root:not([data-reduce-motion="on"]) .toast-banner[data-state="open"] {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root:not([data-reduce-motion="off"]) .toast-banner {
+    transition: none !important;
+    transform: none !important;
+  }
+
+  :root:not([data-reduce-motion="off"]) .toast-banner[data-state="closed"] {
+    opacity: 0;
+  }
+}
+
+:root[data-reduce-motion="on"] .toast-banner {
+  transition: none !important;
+  transform: none !important;
+}
+
+:root[data-reduce-motion="on"] .toast-banner[data-state="closed"] {
+  opacity: 0;
+}
+
 /* Dialog */
 
 .dialog__overlay {


### PR DESCRIPTION
## Summary

- Add shared toast UI and use it for game option hotkey feedback.
- Keep the options menu reachable when the top bar is hidden.
- Put the renderer overlay above the Flash game surface and make the hotkey toast opaque so game content cannot bleed through it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added toast notifications providing visual feedback when executing hotkey commands
  * Options menu now toggles visibility instead of only opening
  * Toast system supports customizable display options and dismiss behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/397?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->