### PR TITLE
fix: coalesce dev runner restarts

### DIFF
--- a/app/esbuild.config.js
+++ b/app/esbuild.config.js
@@ -92,6 +92,10 @@ const DEV_BUILD_NOTIFY_DEBOUNCE_MS = 150;
 const WATCH_PARENT_POLL_MS = 1000;
 const WATCH_FORCE_EXIT_MS = 2500;
 const pendingDevBuildLabels = new Set();
+// Watch mode uses separate esbuild contexts; notify the runner only after the
+// active context batch has settled so it does not restart on partial output.
+let activeDevBuilds = 0;
+let devBuildHadError = false;
 let devBuildNotifyTimer;
 
 function selectDevBuildNotifyLabel(labels) {
@@ -123,6 +127,10 @@ function flushDevBuildNotify() {
     devBuildNotifyTimer = undefined;
   }
 
+  if (activeDevBuilds > 0) {
+    return;
+  }
+
   if (pendingDevBuildLabels.size === 0) {
     return;
   }
@@ -142,12 +150,14 @@ function flushDevBuildNotify() {
   );
 }
 
-function queueDevBuildNotify(label) {
+function scheduleDevBuildNotifyFlush() {
   if (!devBuildNotifyPath) {
     return;
   }
 
-  pendingDevBuildLabels.add(label);
+  if (activeDevBuilds > 0 || pendingDevBuildLabels.size === 0) {
+    return;
+  }
 
   if (devBuildNotifyTimer) {
     clearTimeout(devBuildNotifyTimer);
@@ -159,23 +169,71 @@ function queueDevBuildNotify(label) {
   );
 }
 
+function queueDevBuildNotify(label) {
+  if (!devBuildNotifyPath) {
+    return;
+  }
+
+  pendingDevBuildLabels.add(label);
+  scheduleDevBuildNotifyFlush();
+}
+
+function markDevBuildStarted() {
+  if (!devBuildNotifyPath) {
+    return;
+  }
+
+  activeDevBuilds += 1;
+  if (devBuildNotifyTimer) {
+    clearTimeout(devBuildNotifyTimer);
+    devBuildNotifyTimer = undefined;
+  }
+}
+
+function markDevBuildFinished(result) {
+  if (!devBuildNotifyPath) {
+    return;
+  }
+
+  if (result.errors.length > 0) {
+    devBuildHadError = true;
+  }
+
+  activeDevBuilds = Math.max(0, activeDevBuilds - 1);
+
+  if (activeDevBuilds > 0) {
+    return;
+  }
+
+  if (devBuildHadError) {
+    pendingDevBuildLabels.clear();
+    devBuildHadError = false;
+    return;
+  }
+
+  scheduleDevBuildNotifyFlush();
+}
+
 function createDevBuildNotifyPlugin(label) {
   let skippedInitialNotify = false;
 
   return {
     name: `vexed-dev-build-notify:${label}`,
     setup(build) {
+      build.onStart(() => {
+        markDevBuildStarted();
+      });
+
       build.onEnd((result) => {
-        if (result.errors.length > 0) {
-          return;
+        if (result.errors.length === 0) {
+          if (skipInitialDevBuildNotify && !skippedInitialNotify) {
+            skippedInitialNotify = true;
+          } else {
+            queueDevBuildNotify(label);
+          }
         }
 
-        if (skipInitialDevBuildNotify && !skippedInitialNotify) {
-          skippedInitialNotify = true;
-          return;
-        }
-
-        queueDevBuildNotify(label);
+        markDevBuildFinished(result);
       });
     },
   };

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -11,7 +11,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { Console, Data, Effect, Queue, Ref } from "effect";
+import { Console, Data, Effect, Option, Queue, Ref } from "effect";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { ChildProcess } from "effect/unstable/process";
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner";
@@ -188,6 +188,15 @@ const stopChild = (label: string, child: ChildProcessHandle) =>
 const isRendererOnlyRebuild = (targets: ReadonlySet<DevBuildTarget>): boolean =>
   targets.size > 0 && [...targets].every((target) => target === "renderer");
 
+const addDevBuildTargets = (
+  targetSet: Set<DevBuildTarget>,
+  targets: Iterable<DevBuildTarget>,
+): void => {
+  for (const target of targets) {
+    targetSet.add(target);
+  }
+};
+
 const toDevBuildTarget = (label: unknown): DevBuildTarget => {
   switch (label) {
     case "main":
@@ -320,6 +329,91 @@ const reloadRendererWindows = Effect.sync(() => {
   );
 });
 
+const takeNextEvent = (
+  events: Queue.Queue<DevEvent>,
+  bufferedEvents: Array<DevEvent>,
+) =>
+  Effect.sync(() => bufferedEvents.shift()).pipe(
+    Effect.flatMap((event) =>
+      event === undefined ? Queue.take(events) : Effect.succeed(event),
+    ),
+  );
+
+const pollEvent = (events: Queue.Queue<DevEvent>) =>
+  Queue.poll(events).pipe(
+    Effect.map((event) => (Option.isSome(event) ? event.value : null)),
+  );
+
+// Rebuild notices can arrive while Electron is stopping. Coalesce adjacent
+// rebuilds so one source edit cannot create a start/stop/start cascade.
+const collectQueuedRebuildTargets = (
+  events: Queue.Queue<DevEvent>,
+  bufferedEvents: Array<DevEvent>,
+  initialTargets: ReadonlySet<DevBuildTarget>,
+) =>
+  Effect.gen(function* () {
+    const targets = new Set(initialTargets);
+
+    while (true) {
+      const event = yield* pollEvent(events);
+      if (event === null) {
+        return targets;
+      }
+
+      if (event._tag === "rebuild") {
+        addDevBuildTargets(targets, event.targets);
+        continue;
+      }
+
+      if (event._tag === "electron-exit" && event.managed) {
+        continue;
+      }
+
+      bufferedEvents.push(event);
+      return targets;
+    }
+  });
+
+const collectSettledRebuildTargets = (
+  events: Queue.Queue<DevEvent>,
+  bufferedEvents: Array<DevEvent>,
+  initialTargets: ReadonlySet<DevBuildTarget>,
+) =>
+  Effect.gen(function* () {
+    let targets = yield* collectQueuedRebuildTargets(
+      events,
+      bufferedEvents,
+      initialTargets,
+    );
+
+    while (true) {
+      const event = yield* Queue.take(events).pipe(
+        Effect.timeoutOption(`${RESTART_DEBOUNCE_MS} millis`),
+      );
+
+      if (!Option.isSome(event)) {
+        return targets;
+      }
+
+      if (event.value._tag === "rebuild") {
+        addDevBuildTargets(targets, event.value.targets);
+        targets = yield* collectQueuedRebuildTargets(
+          events,
+          bufferedEvents,
+          targets,
+        );
+        continue;
+      }
+
+      if (event.value._tag === "electron-exit" && event.value.managed) {
+        continue;
+      }
+
+      bufferedEvents.push(event.value);
+      return targets;
+    }
+  });
+
 const watchCompileExit = (
   events: Queue.Queue<DevEvent>,
   compileWatch: ChildProcessHandle,
@@ -381,6 +475,7 @@ const runDevLoop = () =>
     yield* runRequiredCommand("initial compile", ["compile"], APP_DIR, baseEnv);
 
     const events = yield* Queue.make<DevEvent>();
+    const bufferedEvents: Array<DevEvent> = [];
     const activeElectron = yield* Ref.make<ActiveElectron | null>(null);
 
     yield* installNotifyWatcher(events);
@@ -417,11 +512,17 @@ const runDevLoop = () =>
     yield* startElectron;
 
     while (true) {
-      const event = yield* Queue.take(events);
+      const event = yield* takeNextEvent(events, bufferedEvents);
 
       switch (event._tag) {
         case "rebuild": {
-          if (isRendererOnlyRebuild(event.targets)) {
+          let targets = yield* collectSettledRebuildTargets(
+            events,
+            bufferedEvents,
+            event.targets,
+          );
+
+          if (isRendererOnlyRebuild(targets)) {
             yield* Console.log(
               "[dev-runner] renderer rebuild detected; reloading windows",
             );
@@ -433,6 +534,11 @@ const runDevLoop = () =>
             "[dev-runner] rebuild detected; restarting electron",
           );
           yield* stopActiveElectron;
+          targets = yield* collectSettledRebuildTargets(
+            events,
+            bufferedEvents,
+            targets,
+          );
           yield* startElectron;
           break;
         }


### PR DESCRIPTION
## Summary
- Batch esbuild watch notifications until active main/preload/renderer rebuilds settle.
- Coalesce queued dev-runner rebuild events around Electron restarts.

## Root Cause
Separate esbuild watch contexts could emit multiple successful build notices for one source change, and the runner processed each notice as an independent restart while Electron was still shutting down or starting back up.
