### PR TITLE
refactor: add ui icon component

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,6 @@
     "@vexed/ui": "workspace:*",
     "abort-controller": "^3.0.0",
     "effect": "4.0.0-beta.43",
-    "lucide-solid": "^1.14.0",
     "solid-js": "^1.9.12",
     "yaml": "^2.8.3"
   },

--- a/app/src/renderer/windows/account-manager/App.tsx
+++ b/app/src/renderer/windows/account-manager/App.tsx
@@ -3,6 +3,7 @@ import "../../polyfills";
 import "./style.css";
 import { createHotkey } from "@tanstack/solid-hotkeys";
 import {
+  Icon,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -50,21 +51,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@vexed/ui";
-import {
-  CircleQuestionMark,
-  Eye,
-  EyeOff,
-  FolderOpen,
-  Pencil,
-  Play,
-  Plus,
-  RefreshCw,
-  Search,
-  Trash2,
-  UserPlus,
-  Users,
-  X,
-} from "lucide-solid";
 import {
   For,
   Show,
@@ -335,7 +321,7 @@ function AccountDeleteTrigger(props: {
                 {...(dialogTriggerProps(
                   tooltipTriggerProps({
                     "aria-label": props["aria-label"],
-                    children: <Trash2 class="button__icon" />,
+                    children: <Icon icon="trash_2" class="button__icon" />,
                     class: "account-row__delete",
                     disabled: props.disabled,
                     size: "icon-lg",
@@ -1108,7 +1094,7 @@ function App(): JSX.Element {
         </AppShellHeaderLeft>
         <AppShellHeaderRight>
           <Button onClick={openCreateDialog}>
-            <Plus class="button__icon" />
+            <Icon icon="plus" class="button__icon" />
             Add Account
           </Button>
         </AppShellHeaderRight>
@@ -1118,7 +1104,7 @@ function App(): JSX.Element {
           <div class="account-manager__controls">
             <InputGroup class="account-search">
               <InputGroupAddon>
-                <Search aria-hidden="true" />
+                <Icon icon="search" aria-hidden="true" />
               </InputGroupAddon>
               <InputGroupInput
                 ref={(element) => {
@@ -1152,7 +1138,7 @@ function App(): JSX.Element {
                               serversLoading() || serverRefreshCoolingDown(),
                           } as ButtonProps) as ButtonProps)}
                         >
-                          <RefreshCw class="button__icon" />
+                          <Icon icon="refresh_cw" class="button__icon" />
                         </Button>
                       )}
                     />
@@ -1343,7 +1329,7 @@ function App(): JSX.Element {
                                 variant: "ghost",
                               } as ButtonProps) as ButtonProps)}
                             >
-                              <Pencil class="button__icon" />
+                              <Icon icon="pencil" class="button__icon" />
                             </Button>
                           )}
                         />
@@ -1363,7 +1349,7 @@ function App(): JSX.Element {
                               variant: "ghost",
                             } as ButtonProps) as ButtonProps)}
                           >
-                            <FolderOpen class="button__icon" />
+                            <Icon icon="folder_open" class="button__icon" />
                           </Button>
                         )}
                       />
@@ -1383,7 +1369,7 @@ function App(): JSX.Element {
                                 variant: "ghost",
                               } as ButtonProps) as ButtonProps)}
                             >
-                              <X class="button__icon" />
+                              <Icon icon="x" class="button__icon" />
                             </Button>
                           )}
                         />
@@ -1422,7 +1408,10 @@ function App(): JSX.Element {
                             variant: "ghost",
                           } as ButtonProps) as ButtonProps)}
                         >
-                          <CircleQuestionMark class="button__icon" />
+                          <Icon
+                            icon="circle_question_mark"
+                            class="button__icon"
+                          />
                         </Button>
                       )}
                     />
@@ -1494,7 +1483,7 @@ function App(): JSX.Element {
                     onClick={openCreateGroupDialog}
                     disabled={busy()}
                   >
-                    <Plus class="button__icon" />
+                    <Icon icon="plus" class="button__icon" />
                     New Group
                   </Button>
                   <Button
@@ -1502,7 +1491,7 @@ function App(): JSX.Element {
                     onClick={openEditGroupDialog}
                     disabled={busy() || selectedGroupName() === ""}
                   >
-                    <Pencil class="button__icon" />
+                    <Icon icon="pencil" class="button__icon" />
                     Edit
                   </Button>
                   <AlertDialog>
@@ -1514,7 +1503,7 @@ function App(): JSX.Element {
                             disabled: busy() || selectedGroupName() === "",
                           } as ButtonProps) as ButtonProps)}
                         >
-                          <Trash2 class="button__icon" />
+                          <Icon icon="trash_2" class="button__icon" />
                           Delete
                         </Button>
                       )}
@@ -1565,7 +1554,7 @@ function App(): JSX.Element {
                           busy() || selectedAccountUsernames().size === 0,
                       } as ButtonProps) as ButtonProps)}
                     >
-                      <Trash2 class="button__icon" />
+                      <Icon icon="trash_2" class="button__icon" />
                       Remove
                     </Button>
                   )}
@@ -1592,7 +1581,7 @@ function App(): JSX.Element {
                 onClick={handleLaunch}
                 disabled={busy() || selectedLaunchUsernames().length === 0}
               >
-                <Play class="button__icon" />
+                <Icon icon="play" class="button__icon" />
                 Start
               </Button>
             </div>
@@ -1625,9 +1614,9 @@ function App(): JSX.Element {
                       <EmptyMedia variant="icon">
                         <Show
                           when={accounts().length === 0}
-                          fallback={<Users aria-hidden="true" />}
+                          fallback={<Icon icon="users" aria-hidden="true" />}
                         >
-                          <UserPlus aria-hidden="true" />
+                          <Icon icon="user_plus" aria-hidden="true" />
                         </Show>
                       </EmptyMedia>
                       <EmptyTitle>
@@ -1703,14 +1692,14 @@ function App(): JSX.Element {
                           }
                           disabled={busy()}
                         >
-                          <Play class="button__icon" />
+                          <Icon icon="play" class="button__icon" />
                         </AccountActionButton>
                         <AccountActionButton
                           aria-label={`Edit ${account.label}`}
                           tooltip="Edit account"
                           onClick={() => openEditDialog(account)}
                         >
-                          <Pencil class="button__icon" />
+                          <Icon icon="pencil" class="button__icon" />
                         </AccountActionButton>
                         <AlertDialog>
                           <AccountDeleteTrigger
@@ -1794,7 +1783,7 @@ function App(): JSX.Element {
                   <span>Accounts</span>
                   <InputGroup class="account-group-dialog__search">
                     <InputGroupAddon>
-                      <Search aria-hidden="true" />
+                      <Icon icon="search" aria-hidden="true" />
                     </InputGroupAddon>
                     <InputGroupInput
                       value={groupSearchQuery()}
@@ -1851,7 +1840,7 @@ function App(): JSX.Element {
                       disabled={busy()}
                       type="button"
                     >
-                      <Trash2 class="button__icon" />
+                      <Icon icon="trash_2" class="button__icon" />
                       Delete
                     </AlertDialogTrigger>
                     <AlertDialogContent class="account-dialog">
@@ -1960,9 +1949,9 @@ function App(): JSX.Element {
                       >
                         <Show
                           when={passwordVisible()}
-                          fallback={<Eye class="button__icon" />}
+                          fallback={<Icon icon="eye" class="button__icon" />}
                         >
-                          <EyeOff class="button__icon" />
+                          <Icon icon="eye_off" class="button__icon" />
                         </Show>
                       </Button>
                     </InputGroupAddon>
@@ -2000,7 +1989,7 @@ function App(): JSX.Element {
                       disabled={busy()}
                       type="button"
                     >
-                      <Trash2 class="button__icon" />
+                      <Icon icon="trash_2" class="button__icon" />
                       Delete
                     </AlertDialogTrigger>
                     <AlertDialogContent class="account-dialog">

--- a/app/src/renderer/windows/environment/App.tsx
+++ b/app/src/renderer/windows/environment/App.tsx
@@ -2,6 +2,7 @@
 import "../../polyfills";
 import "./style.css";
 import {
+  Icon,
   AppShell,
   AppShellBody,
   AppShellHeader,
@@ -20,7 +21,6 @@ import {
   Input,
   Spinner,
 } from "@vexed/ui";
-import { Download, Plus, Share2, Trash2, X } from "lucide-solid";
 import {
   For,
   Show,
@@ -349,7 +349,7 @@ function App(): JSX.Element {
             disabled={clearingAll() || totalCount() === 0}
             onClick={() => void clearAll()}
           >
-            <Trash2 class="button__icon" />
+            <Icon icon="trash_2" class="button__icon" />
             Clear all
           </Button>
           <Button
@@ -360,7 +360,10 @@ function App(): JSX.Element {
             disabled={syncing()}
             onClick={() => void syncToAll()}
           >
-            <Show when={syncing()} fallback={<Share2 class="button__icon" />}>
+            <Show
+              when={syncing()}
+              fallback={<Icon icon="share_2" class="button__icon" />}
+            >
               <Spinner class="environment-sync-spinner" size="sm" />
             </Show>
             Sync to all
@@ -390,7 +393,7 @@ function App(): JSX.Element {
                     void runStateUpdate(window.ipc.environment.clearItems())
                   }
                 >
-                  <Trash2 class="button__icon" />
+                  <Icon icon="trash_2" class="button__icon" />
                   Clear
                 </Button>
               }
@@ -443,7 +446,7 @@ function App(): JSX.Element {
                   aria-label="Add drop"
                   disabled={!itemInput().trim()}
                 >
-                  <Plus class="button__icon" />
+                  <Icon icon="plus" class="button__icon" />
                 </IconButton>
               </form>
 
@@ -468,7 +471,7 @@ function App(): JSX.Element {
                             )
                           }
                         >
-                          <X class="button__icon" />
+                          <Icon icon="x" class="button__icon" />
                         </IconButton>
                       </div>
                     )}
@@ -492,7 +495,7 @@ function App(): JSX.Element {
                     void runStateUpdate(window.ipc.environment.clearQuests())
                   }
                 >
-                  <Trash2 class="button__icon" />
+                  <Icon icon="trash_2" class="button__icon" />
                   Clear
                 </Button>
               }
@@ -541,7 +544,7 @@ function App(): JSX.Element {
                   aria-label="Add quest"
                   disabled={!questInput().trim()}
                 >
-                  <Plus class="button__icon" />
+                  <Icon icon="plus" class="button__icon" />
                 </IconButton>
               </form>
 
@@ -605,7 +608,7 @@ function App(): JSX.Element {
                             )
                           }
                         >
-                          <X class="button__icon" />
+                          <Icon icon="x" class="button__icon" />
                         </IconButton>
                       </div>
                     )}
@@ -627,7 +630,7 @@ function App(): JSX.Element {
                     disabled={fetchingBoosts()}
                     onClick={() => void fetchBoosts()}
                   >
-                    <Download class="button__icon" />
+                    <Icon icon="download" class="button__icon" />
                     Fetch
                   </Button>
                   <Button
@@ -640,7 +643,7 @@ function App(): JSX.Element {
                       void runStateUpdate(window.ipc.environment.clearBoosts())
                     }
                   >
-                    <Trash2 class="button__icon" />
+                    <Icon icon="trash_2" class="button__icon" />
                     Clear
                   </Button>
                 </div>
@@ -664,7 +667,7 @@ function App(): JSX.Element {
                   aria-label="Add boost"
                   disabled={!boostInput().trim()}
                 >
-                  <Plus class="button__icon" />
+                  <Icon icon="plus" class="button__icon" />
                 </IconButton>
               </form>
 
@@ -689,7 +692,7 @@ function App(): JSX.Element {
                             )
                           }
                         >
-                          <X class="button__icon" />
+                          <Icon icon="x" class="button__icon" />
                         </IconButton>
                       </div>
                     )}

--- a/app/src/renderer/windows/follower/App.tsx
+++ b/app/src/renderer/windows/follower/App.tsx
@@ -2,6 +2,7 @@
 import "../../polyfills";
 import "./style.css";
 import {
+  Icon,
   AppShell,
   AppShellBody,
   AppShellHeader,
@@ -28,14 +29,6 @@ import {
   TooltipTrigger,
   type IconButtonProps,
 } from "@vexed/ui";
-import {
-  HelpCircle,
-  Play,
-  SlidersHorizontal,
-  Square,
-  UserRound,
-  X,
-} from "lucide-solid";
 import {
   For,
   Show,
@@ -120,7 +113,7 @@ function LabelHelp(props: {
             <IconButton
               {...(triggerProps({
                 "aria-label": `${props.label} help`,
-                children: <HelpCircle class="button__icon" />,
+                children: <Icon icon="help_circle" class="button__icon" />,
                 class: "follower-help-button",
                 size: "icon-xs",
                 type: "button",
@@ -398,9 +391,9 @@ function App(): JSX.Element {
             onClick={toggle}
           >
             {running() ? (
-              <Square class="button__icon" />
+              <Icon icon="square" class="button__icon" />
             ) : (
-              <Play class="button__icon" />
+              <Icon icon="play" class="button__icon" />
             )}
             {running() ? "Stop" : "Start"}
           </Button>
@@ -418,7 +411,7 @@ function App(): JSX.Element {
                 variant="ghost"
                 onClick={() => setDismissedIssue(true)}
               >
-                <X class="button__icon" />
+                <Icon icon="x" class="button__icon" />
               </IconButton>
             </div>
           </Show>
@@ -448,7 +441,7 @@ function App(): JSX.Element {
                         disabled={running()}
                         onClick={() => void fillMe()}
                       >
-                        <UserRound class="button__icon" />
+                        <Icon icon="user_round" class="button__icon" />
                         Me
                       </Button>
                     </div>
@@ -566,7 +559,7 @@ function App(): JSX.Element {
                         tooltip="Configure skill profiles"
                         onClick={() => void openSkills()}
                       >
-                        <SlidersHorizontal class="button__icon" />
+                        <Icon icon="sliders_horizontal" class="button__icon" />
                       </TooltipIconButton>
                     </div>
                     <Select

--- a/app/src/renderer/windows/game/TopNav.tsx
+++ b/app/src/renderer/windows/game/TopNav.tsx
@@ -12,13 +12,13 @@ import {
   type JSX,
   type Setter,
 } from "solid-js";
-import { ChevronDown, CircleAlert, Clock, LoaderCircle } from "lucide-solid";
 import { formatOptionalHotkeyDisplay } from "@vexed/shared/hotkeyDisplay";
 import type {
   CombatProfile,
   CombatProfileAutoAttackMode,
 } from "../../../shared/combat-profiles";
 import {
+  Icon,
   Button,
   type ButtonProps,
   Input,
@@ -817,13 +817,22 @@ export function TopNav(props: TopNavProps): JSX.Element {
               >
                 <Switch>
                   <Match when={autoReloginTriggerStatusKind() === "waiting"}>
-                    <Clock class="game-topnav__status-icon game-topnav__delay-icon" />
+                    <Icon
+                      icon="clock"
+                      class="game-topnav__status-icon game-topnav__delay-icon"
+                    />
                   </Match>
                   <Match when={autoReloginTriggerStatusKind() === "retrying"}>
-                    <LoaderCircle class="game-topnav__status-icon game-topnav__retry-spinner" />
+                    <Icon
+                      icon="loader_circle"
+                      class="game-topnav__status-icon game-topnav__retry-spinner"
+                    />
                   </Match>
                   <Match when={autoReloginTriggerStatusKind() === "alert"}>
-                    <CircleAlert class="game-topnav__status-icon game-topnav__alert-icon" />
+                    <Icon
+                      icon="circle_alert"
+                      class="game-topnav__status-icon game-topnav__alert-icon"
+                    />
                   </Match>
                 </Switch>
               </span>
@@ -846,7 +855,8 @@ export function TopNav(props: TopNavProps): JSX.Element {
                 <div class="game-menu__status game-menu__status--relogin">
                   <Show when={props.autoReloginToggling()}>
                     <span class="game-menu__status-row">
-                      <LoaderCircle
+                      <Icon
+                        icon="loader_circle"
                         aria-hidden="true"
                         class="game-menu__status-icon game-menu__status-icon--spin"
                       />
@@ -857,7 +867,8 @@ export function TopNav(props: TopNavProps): JSX.Element {
                   </Show>
                   <Show when={props.autoReloginAttempting()}>
                     <span class="game-menu__status-row">
-                      <LoaderCircle
+                      <Icon
+                        icon="loader_circle"
                         aria-hidden="true"
                         class="game-menu__status-icon game-menu__status-icon--spin"
                       />
@@ -867,7 +878,8 @@ export function TopNav(props: TopNavProps): JSX.Element {
                   <Show when={props.autoReloginLastError()}>
                     {(error) => (
                       <span class="game-menu__status-row game-menu__error">
-                        <CircleAlert
+                        <Icon
+                          icon="circle_alert"
                           aria-hidden="true"
                           class="game-menu__status-icon"
                         />
@@ -1056,7 +1068,8 @@ export function TopNav(props: TopNavProps): JSX.Element {
               <span class="game-topnav__combat-label">
                 {props.autoAttackConfiguredProfileLabel()}
               </span>
-              <ChevronDown
+              <Icon
+                icon="chevron_down"
                 aria-hidden="true"
                 class="game-topnav__select-chevron"
               />
@@ -1144,7 +1157,8 @@ export function TopNav(props: TopNavProps): JSX.Element {
               <span class="game-topnav__select-label">
                 {props.selectedPad() || "Pad"}
               </span>
-              <ChevronDown
+              <Icon
+                icon="chevron_down"
                 aria-hidden="true"
                 class="game-topnav__select-chevron"
               />
@@ -1193,7 +1207,8 @@ export function TopNav(props: TopNavProps): JSX.Element {
               <span class="game-topnav__select-label">
                 {props.selectedCell() || "Cell"}
               </span>
-              <ChevronDown
+              <Icon
+                icon="chevron_down"
                 aria-hidden="true"
                 class="game-topnav__select-chevron"
               />

--- a/app/src/renderer/windows/packets/App.tsx
+++ b/app/src/renderer/windows/packets/App.tsx
@@ -3,6 +3,7 @@ import "../../polyfills";
 import "./style.css";
 import { createHotkey } from "@tanstack/solid-hotkeys";
 import {
+  Icon,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -46,20 +47,6 @@ import {
   TooltipTrigger,
   type IconButtonProps,
 } from "@vexed/ui";
-import {
-  ArrowDown,
-  ArrowUp,
-  Check,
-  Copy,
-  Download,
-  HelpCircle,
-  Play,
-  Plus,
-  Search,
-  Square,
-  Trash2,
-  X,
-} from "lucide-solid";
 import {
   For,
   Show,
@@ -364,7 +351,7 @@ function PacketSenderLabelHelp(): JSX.Element {
             <Button
               {...(triggerProps({
                 "aria-label": "Packet placeholders",
-                children: <HelpCircle class="button__icon" />,
+                children: <Icon icon="help_circle" class="button__icon" />,
                 class: "packets-placeholder-help-button",
                 size: "icon-sm",
                 type: "button",
@@ -1075,7 +1062,7 @@ function App(): JSX.Element {
                 copiedPacketId() === props.entry.id,
             }}
           >
-            <Check aria-hidden="true" />
+            <Icon icon="check" aria-hidden="true" />
           </span>
         </button>
         <TooltipIconButton
@@ -1098,10 +1085,10 @@ function App(): JSX.Element {
           }
         >
           <span class="packets-log-row__queue-icon packets-log-row__queue-icon--plus">
-            <Plus class="button__icon" />
+            <Icon icon="plus" class="button__icon" />
           </span>
           <span class="packets-log-row__queue-icon packets-log-row__queue-icon--check">
-            <Check class="button__icon" />
+            <Icon icon="check" class="button__icon" />
           </span>
         </TooltipIconButton>
       </div>
@@ -1184,10 +1171,10 @@ function App(): JSX.Element {
                     class="packets-copy-button__icon-stack"
                   >
                     <span class="packets-copy-button__icon packets-copy-button__icon--copy">
-                      <Copy class="button__icon" />
+                      <Icon icon="copy" class="button__icon" />
                     </span>
                     <span class="packets-copy-button__icon packets-copy-button__icon--check">
-                      <Check class="button__icon" />
+                      <Icon icon="check" class="button__icon" />
                     </span>
                   </span>
                   <span
@@ -1210,7 +1197,7 @@ function App(): JSX.Element {
                   type="button"
                   variant="outline"
                 >
-                  <Download class="button__icon" />
+                  <Icon icon="download" class="button__icon" />
                   <span class="packets-header__button-label">Export</span>
                 </Button>
                 <Button
@@ -1223,9 +1210,9 @@ function App(): JSX.Element {
                   variant={captureRunning() ? "destructive-outline" : "default"}
                 >
                   {captureRunning() ? (
-                    <Square class="button__icon" />
+                    <Icon icon="square" class="button__icon" />
                   ) : (
-                    <Play class="button__icon" />
+                    <Icon icon="play" class="button__icon" />
                   )}
                   <span class="packets-header__button-label">
                     {captureRunning() ? "Stop capture" : "Start capture"}
@@ -1246,9 +1233,9 @@ function App(): JSX.Element {
                   variant={queueRunning() ? "destructive-outline" : "default"}
                 >
                   {queueRunning() ? (
-                    <Square class="button__icon" />
+                    <Icon icon="square" class="button__icon" />
                   ) : (
-                    <Play class="button__icon" />
+                    <Icon icon="play" class="button__icon" />
                   )}
                   <span class="packets-header__button-label">
                     {queueRunning() ? "Stop queue" : "Start queue"}
@@ -1279,7 +1266,7 @@ function App(): JSX.Element {
                   type="button"
                   variant="ghost"
                 >
-                  <X class="button__icon" />
+                  <Icon icon="x" class="button__icon" />
                 </IconButton>
               </div>
             </Show>
@@ -1290,7 +1277,7 @@ function App(): JSX.Element {
                   <div class="packets-log-tools">
                     <InputGroup class="packets-search">
                       <InputGroupAddon>
-                        <Search aria-hidden="true" />
+                        <Icon icon="search" aria-hidden="true" />
                       </InputGroupAddon>
                       <InputGroupInput
                         ref={(element) => {
@@ -1366,7 +1353,7 @@ function App(): JSX.Element {
                         type="button"
                         variant="destructive-outline"
                       >
-                        <Trash2 class="button__icon" />
+                        <Icon icon="trash_2" class="button__icon" />
                         Clear
                       </Button>
                     </div>
@@ -1531,7 +1518,7 @@ function App(): JSX.Element {
                             type="button"
                             variant="outline"
                           >
-                            <Plus class="button__icon" />
+                            <Icon icon="plus" class="button__icon" />
                             Add to queue
                           </Button>
                         </div>
@@ -1607,7 +1594,7 @@ function App(): JSX.Element {
                               onClick={() => moveQueuePacket(-1)}
                               tooltip="Move up"
                             >
-                              <ArrowUp class="button__icon" />
+                              <Icon icon="arrow_up" class="button__icon" />
                             </TooltipIconButton>
                             <TooltipIconButton
                               aria-label="Move packet down"
@@ -1617,7 +1604,7 @@ function App(): JSX.Element {
                               onClick={() => moveQueuePacket(1)}
                               tooltip="Move down"
                             >
-                              <ArrowDown class="button__icon" />
+                              <Icon icon="arrow_down" class="button__icon" />
                             </TooltipIconButton>
                           </div>
                           <div class="packets-queue__actions-group">
@@ -1629,7 +1616,7 @@ function App(): JSX.Element {
                               onClick={removeQueuePacket}
                               tooltip="Remove"
                             >
-                              <Trash2 class="button__icon" />
+                              <Icon icon="trash_2" class="button__icon" />
                             </TooltipIconButton>
                             <Button
                               disabled={queue().length === 0 || queueRunning()}

--- a/app/src/renderer/windows/settings/App.tsx
+++ b/app/src/renderer/windows/settings/App.tsx
@@ -6,6 +6,7 @@ import {
   formatHotkeyDisplayParts as displayHotkeyParts,
 } from "@vexed/shared/hotkeyDisplay";
 import {
+  Icon,
   Alert,
   AlertDialog,
   AlertDialogAction,
@@ -40,7 +41,6 @@ import {
   TooltipTrigger,
   type ButtonProps,
 } from "@vexed/ui";
-import { CircleAlert, RotateCcw, X } from "lucide-solid";
 import {
   For,
   Show,
@@ -240,7 +240,11 @@ function SettingsErrorNotice(props: {
       variant="error"
     >
       <AlertDescription class="settings-error__message">
-        <CircleAlert aria-hidden="true" class="settings-error__icon" />
+        <Icon
+          icon="circle_alert"
+          aria-hidden="true"
+          class="settings-error__icon"
+        />
         {props.message}
       </AlertDescription>
     </Alert>
@@ -271,7 +275,9 @@ function ResetButton(props: {
                     {...(dialogTriggerProps(
                       tooltipTriggerProps({
                         "aria-label": props.label,
-                        children: <RotateCcw class="button__icon" />,
+                        children: (
+                          <Icon icon="rotate_ccw" class="button__icon" />
+                        ),
                         class: "reset-settings-button",
                         size: "icon-sm",
                         type: "button",
@@ -368,7 +374,7 @@ function HotkeyConflictPill(props: {
               "aria-label": `${label()}: ${props.conflicts.join(", ")}`,
               children: (
                 <>
-                  <CircleAlert class="button__icon" />
+                  <Icon icon="circle_alert" class="button__icon" />
                   {count()}
                 </>
               ),
@@ -765,7 +771,7 @@ function HotkeySettingsSection(props: {
                       onClick={() => void commitBinding(command.id, null)}
                       tooltip="Restore default shortcut"
                     >
-                      <RotateCcw class="button__icon" />
+                      <Icon icon="rotate_ccw" class="button__icon" />
                     </HotkeyIconButton>
                   </Show>
                   <KbdGroup
@@ -814,7 +820,7 @@ function HotkeySettingsSection(props: {
                   onClick={() => void commitBinding(command.id, "")}
                   tooltip="Clear shortcut"
                 >
-                  <X class="button__icon" />
+                  <Icon icon="x" class="button__icon" />
                 </HotkeyIconButton>
               </div>
             </div>

--- a/app/src/renderer/windows/skills/App.tsx
+++ b/app/src/renderer/windows/skills/App.tsx
@@ -2,6 +2,7 @@
 import "../../polyfills";
 import "./style.css";
 import {
+  Icon,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -35,7 +36,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@vexed/ui";
-import { HelpCircle, Save, X } from "lucide-solid";
 import {
   For,
   Index,
@@ -173,7 +173,7 @@ function SkillsLabelHelp(props: {
             <Button
               {...(triggerProps({
                 "aria-label": `${props.label} help`,
-                children: <HelpCircle class="button__icon" />,
+                children: <Icon icon="help_circle" class="button__icon" />,
                 class: "skills-help-button",
                 size: "icon-sm",
                 type: "button",
@@ -519,7 +519,7 @@ function App(): JSX.Element {
             size="sm"
             onClick={() => void saveSelected()}
           >
-            <Save class="button__icon" />
+            <Icon icon="save" class="button__icon" />
             Save
           </Button>
         </AppShellHeaderRight>
@@ -759,7 +759,7 @@ function App(): JSX.Element {
                             variant="ghost"
                             onClick={() => removeAnimationTrigger(triggerIndex)}
                           >
-                            <X class="button__icon" />
+                            <Icon icon="x" class="button__icon" />
                           </Button>
                         </div>
                       )}
@@ -826,7 +826,7 @@ function App(): JSX.Element {
                             variant="ghost"
                             onClick={() => removeStep(stepIndex)}
                           >
-                            <X class="button__icon" />
+                            <Icon icon="x" class="button__icon" />
                           </Button>
                         </div>
                         <div class="skills-rules">
@@ -969,7 +969,7 @@ function App(): JSX.Element {
                                       removeCondition(stepIndex, conditionIndex)
                                     }
                                   >
-                                    <X class="button__icon" />
+                                    <Icon icon="x" class="button__icon" />
                                   </Button>
                                 </div>
                               )}

--- a/packages/ui/demo/App.tsx
+++ b/packages/ui/demo/App.tsx
@@ -3,6 +3,7 @@ import "./demo.css";
 import { createEffect, createSignal, For } from "solid-js";
 import { render } from "solid-js/web";
 import {
+  Icon,
   AppShell,
   AppShellBody,
   AppShellHeader,
@@ -126,17 +127,6 @@ import {
   type EmptyMediaVariant,
   type IconButtonSize,
 } from "@vexed/ui";
-import {
-  Check,
-  Copy,
-  Inbox,
-  Pause,
-  Play,
-  Search,
-  Settings,
-  ShieldAlert,
-  X,
-} from "lucide-solid";
 
 const badgeSizes = [
   "sm",
@@ -310,7 +300,7 @@ function DemoApp() {
                               size={size}
                               variant={variant}
                             >
-                              <Settings class="button__icon" />
+                              <Icon icon="settings" class="button__icon" />
                             </IconButton>
                           )}
                         </For>
@@ -327,11 +317,11 @@ function DemoApp() {
                   Disabled
                 </Button>
                 <Button size="sm">
-                  <Play class="button__icon" />
+                  <Icon icon="play" class="button__icon" />
                   With icon
                 </Button>
                 <Button size="xl" variant="destructive-outline">
-                  <Copy class="button__icon" />
+                  <Icon icon="copy" class="button__icon" />
                   Review
                 </Button>
                 <Button as="a" href="#" variant="link">
@@ -692,7 +682,7 @@ function DemoApp() {
                       <span class="demo-matrix__label">input group {size}</span>
                       <InputGroup size={size}>
                         <InputGroupAddon>
-                          <Search />
+                          <Icon icon="search" />
                           <InputGroupText>/join</InputGroupText>
                         </InputGroupAddon>
                         <InputGroupInput placeholder="battleon" />
@@ -901,11 +891,11 @@ function DemoApp() {
                           keywords={["find", "lookup"]}
                         >
                           <span>Search records</span>
-                          <Search class="button__icon" />
+                          <Icon icon="search" class="button__icon" />
                         </CommandItem>
                         <CommandItem value="guard">
                           <span>Enable guard rails</span>
-                          <ShieldAlert class="button__icon" />
+                          <Icon icon="shield_alert" class="button__icon" />
                         </CommandItem>
                         <CommandLinkItem href="#" value="docs">
                           <span>Open docs</span>
@@ -936,7 +926,7 @@ function DemoApp() {
                     <Empty>
                       <EmptyHeader>
                         <EmptyMedia variant={variant}>
-                          <Inbox class="button__icon" />
+                          <Icon icon="inbox" class="button__icon" />
                         </EmptyMedia>
                         <EmptyTitle>{variant} media</EmptyTitle>
                         <EmptyDescription>
@@ -981,7 +971,7 @@ function DemoApp() {
               </div>
               <div class="demo-row">
                 <Badge as="button" variant="outline">
-                  <Check />
+                  <Icon icon="check" />
                   Button
                 </Badge>
                 <Badge as="a" href="#" variant="secondary">
@@ -991,7 +981,7 @@ function DemoApp() {
                   Disabled
                 </Badge>
                 <Badge variant="info">
-                  <Settings />
+                  <Icon icon="settings" />
                   Icon
                 </Badge>
               </div>
@@ -1050,15 +1040,15 @@ function DemoApp() {
             <CardContent class="demo-stack demo-custom-theme">
               <div class="demo-row">
                 <Button>
-                  <Check class="button__icon" />
+                  <Icon icon="check" class="button__icon" />
                   Custom primary
                 </Button>
                 <Button variant="outline">
-                  <Pause class="button__icon" />
+                  <Icon icon="pause" class="button__icon" />
                   Pause
                 </Button>
                 <IconButton aria-label="Close" variant="ghost">
-                  <X class="button__icon" />
+                  <Icon icon="x" class="button__icon" />
                 </IconButton>
               </div>
               <Input fullWidth placeholder="Custom themed input" />
@@ -1081,7 +1071,7 @@ function DemoApp() {
                   </AppShellHeaderLeft>
                   <AppShellHeaderRight>
                     <Button size="sm" variant="outline">
-                      <Search class="button__icon" />
+                      <Icon icon="search" class="button__icon" />
                       Search
                     </Button>
                     <IconButton
@@ -1089,7 +1079,7 @@ function DemoApp() {
                       size="icon-sm"
                       variant="ghost"
                     >
-                      <Settings class="button__icon" />
+                      <Icon icon="settings" class="button__icon" />
                     </IconButton>
                   </AppShellHeaderRight>
                 </AppShellHeader>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,7 @@
     "clean": "rm -rf dist dist-demo",
     "build": "tsx scripts/build.ts",
     "postinstall": "tsx scripts/build.ts",
+    "icon:print": "tsx scripts/print-lucide-icon.ts",
     "demo": "vite --config vite.demo.config.ts --host 127.0.0.1",
     "demo:build": "vite build --config vite.demo.config.ts",
     "demo:electron11": "pnpm --dir ../../app dev:ui:electron11",
@@ -50,8 +51,7 @@
     "@ark-ui/solid": "^5.36.2",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "clsx": "^2.1.1",
-    "lucide-solid": "^1.14.0"
+    "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",

--- a/packages/ui/scripts/build.ts
+++ b/packages/ui/scripts/build.ts
@@ -50,7 +50,6 @@ async function main(): Promise<void> {
       "@ark-ui/solid",
       "@ark-ui/solid/*",
       "clsx",
-      "lucide-solid",
       "solid-js",
       "solid-js/web",
     ],

--- a/packages/ui/scripts/print-lucide-icon.ts
+++ b/packages/ui/scripts/print-lucide-icon.ts
@@ -1,0 +1,93 @@
+const lucideVersion = "1.14.0";
+const supportedElementNames = new Set([
+  "circle",
+  "line",
+  "path",
+  "polyline",
+  "rect",
+]);
+
+function toIconKey(name: string): string {
+  return name.trim().toLowerCase().replace(/-/g, "_");
+}
+
+function parseAttributes(source: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrPattern = /([a-zA-Z][\w:-]*)="([^"]*)"/g;
+
+  for (const match of source.matchAll(attrPattern)) {
+    const [, name, value] = match;
+    if (name === undefined || value === undefined) continue;
+    attrs[name] = value;
+  }
+
+  return attrs;
+}
+
+function formatAttrs(attrs: Record<string, string>): string {
+  const entries = Object.entries(attrs);
+  if (entries.length === 0) return "{}";
+
+  return `{ ${entries
+    .map(([name, value]) => `${JSON.stringify(name)}: ${JSON.stringify(value)}`)
+    .join(", ")} }`;
+}
+
+function parseIconNodes(svg: string): string {
+  const nodePattern = /<(circle|line|path|polyline|rect)\b([^>]*)\/?>/g;
+  const nodes: string[] = [];
+
+  for (const match of svg.matchAll(nodePattern)) {
+    const [, elementName, attrSource] = match;
+    if (
+      elementName === undefined ||
+      attrSource === undefined ||
+      !supportedElementNames.has(elementName)
+    ) {
+      continue;
+    }
+
+    nodes.push(
+      `    [${JSON.stringify(elementName)}, ${formatAttrs(parseAttributes(attrSource))}],`,
+    );
+  }
+
+  if (nodes.length === 0) {
+    throw new Error("No supported SVG child nodes found.");
+  }
+
+  return nodes.join("\n");
+}
+
+async function fetchIconSvg(name: string): Promise<string> {
+  const response = await fetch(
+    `https://unpkg.com/lucide-static@${lucideVersion}/icons/${name}.svg`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${name}.svg from Lucide ${lucideVersion}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return response.text();
+}
+
+async function main(): Promise<void> {
+  const iconNames = process.argv.slice(2);
+  if (iconNames.length === 0) {
+    throw new Error(
+      "Usage: pnpm --dir packages/ui icon:print <lucide-icon-name> [...names]",
+    );
+  }
+
+  for (const name of iconNames) {
+    const svg = await fetchIconSvg(name);
+    console.log(`  ${toIconKey(name)}: [`);
+    console.log(parseIconNodes(svg));
+    console.log("  ],");
+  }
+}
+
+await main();
+
+export {};

--- a/packages/ui/src/components/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox.tsx
@@ -1,5 +1,5 @@
+import { Icon } from "./Icon";
 import { splitProps, type JSX } from "solid-js";
-import { Check } from "lucide-solid";
 import { cn } from "../lib/cn";
 import { isAriaInvalid } from "../lib/domState";
 
@@ -49,7 +49,7 @@ export function Checkbox(props: CheckboxProps): JSX.Element {
         type="checkbox"
       />
       <span aria-hidden="true" class="checkbox__control">
-        <Check class="checkbox__icon" />
+        <Icon icon="check" class="checkbox__icon" />
       </span>
       {local.children && <span class="checkbox__label">{local.children}</span>}
     </label>

--- a/packages/ui/src/components/Combobox.tsx
+++ b/packages/ui/src/components/Combobox.tsx
@@ -1,9 +1,9 @@
+import { Icon } from "./Icon";
 import {
   Combobox as ComboboxPrimitive,
   createListCollection,
   type CollectionItem,
 } from "@ark-ui/solid/combobox";
-import { Check, ChevronsUpDown, X } from "lucide-solid";
 import {
   createContext,
   createEffect,
@@ -165,7 +165,7 @@ export function ComboboxInput(props: ComboboxInputProps): JSX.Element {
             />
             {showClear() && (
               <ComboboxClear class="combobox__clear" {...local.clearProps}>
-                <X />
+                <Icon icon="x" />
               </ComboboxClear>
             )}
             {local.showTrigger !== false && (
@@ -173,7 +173,7 @@ export function ComboboxInput(props: ComboboxInputProps): JSX.Element {
                 class="combobox__trigger"
                 {...local.triggerProps}
               >
-                <ChevronsUpDown />
+                <Icon icon="chevrons_up_down" />
               </ComboboxTrigger>
             )}
           </ComboboxPrimitive.Control>
@@ -277,7 +277,7 @@ export function ComboboxItem(props: ComboboxItemProps): JSX.Element {
       item={item()}
     >
       <ComboboxPrimitive.ItemIndicator class="combobox__item-indicator">
-        <Check />
+        <Icon icon="check" />
       </ComboboxPrimitive.ItemIndicator>
       <ComboboxPrimitive.ItemText class="combobox__item-text">
         {local.children ?? item().label}

--- a/packages/ui/src/components/Command.tsx
+++ b/packages/ui/src/components/Command.tsx
@@ -1,4 +1,4 @@
-import { Search } from "lucide-solid";
+import { Icon } from "./Icon";
 import {
   createContext,
   createEffect,
@@ -215,7 +215,7 @@ export function CommandInput(props: CommandInputProps): JSX.Element {
   const context = useContext(CommandContext);
   return (
     <div class="command__input-wrap" data-slot="command-input-wrap">
-      <Search aria-hidden="true" class="command__input-icon" />
+      <Icon icon="search" aria-hidden="true" class="command__input-icon" />
       <input
         {...rest}
         aria-activedescendant={

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -1,5 +1,5 @@
+import { Icon } from "./Icon";
 import { Dialog as DialogPrimitive } from "@ark-ui/solid/dialog";
-import { X } from "lucide-solid";
 import {
   Show,
   createContext,
@@ -224,7 +224,7 @@ export function DialogContent(props: DialogContentProps): JSX.Element {
                     size="icon-sm"
                     {...local.closeProps}
                   >
-                    <X class="button__icon" />
+                    <Icon icon="x" class="button__icon" />
                   </DialogClose>
                 )}
               </DialogPrimitive.Content>

--- a/packages/ui/src/components/Icon.tsx
+++ b/packages/ui/src/components/Icon.tsx
@@ -1,0 +1,416 @@
+import { For, Show, splitProps, type JSX } from "solid-js";
+import { Dynamic } from "solid-js/web";
+
+type IconElementName = "circle" | "line" | "path" | "polyline" | "rect";
+type IconNode = readonly [
+  elementName: IconElementName,
+  attrs: Record<string, string>,
+][];
+
+type IconSize = "xs" | "sm" | "md" | "lg" | "xl" | number | string;
+
+const sizeTokens = {
+  xs: 12,
+  sm: 14,
+  md: 16,
+  lg: 20,
+  xl: 24,
+} as const;
+
+const defaultSize = 24;
+const defaultStrokeWidth = 2;
+
+// Lucide icon node data, copied from Lucide v1.14.0 (ISC license).
+// To add another icon, run `pnpm --dir packages/ui icon:print <lucide-icon-name>`
+// and paste the generated entry into this map.
+const icons = {
+  arrow_down: [
+    ["path", { d: "M12 5v14", key: "s699le" }],
+    ["path", { d: "m19 12-7 7-7-7", key: "1idqje" }],
+  ],
+  arrow_up: [
+    ["path", { d: "m5 12 7-7 7 7", key: "hav0vg" }],
+    ["path", { d: "M12 19V5", key: "x0mq9r" }],
+  ],
+  check: [["path", { d: "M20 6 9 17l-5-5", key: "1gmf2c" }]],
+  chevron_down: [["path", { d: "m6 9 6 6 6-6", key: "qrunsl" }]],
+  chevron_right: [["path", { d: "m9 18 6-6-6-6", key: "mthhwq" }]],
+  chevrons_up_down: [
+    ["path", { d: "m7 15 5 5 5-5", key: "1hf1tw" }],
+    ["path", { d: "m7 9 5-5 5 5", key: "sgt6xg" }],
+  ],
+  circle_alert: [
+    ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
+    ["line", { x1: "12", x2: "12", y1: "8", y2: "12", key: "1pkeuh" }],
+    ["line", { x1: "12", x2: "12.01", y1: "16", y2: "16", key: "4dfq90" }],
+  ],
+  circle_check: [
+    ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
+    ["path", { d: "m9 12 2 2 4-4", key: "dzmm74" }],
+  ],
+  circle_question_mark: [
+    ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
+    ["path", { d: "M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3", key: "1u773s" }],
+    ["path", { d: "M12 17h.01", key: "p32p05" }],
+  ],
+  clock: [
+    ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
+    ["path", { d: "M12 6v6l4 2", key: "mmk7yg" }],
+  ],
+  copy: [
+    [
+      "rect",
+      {
+        width: "14",
+        height: "14",
+        x: "8",
+        y: "8",
+        rx: "2",
+        ry: "2",
+        key: "17jyea",
+      },
+    ],
+    [
+      "path",
+      {
+        d: "M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2",
+        key: "zix9uf",
+      },
+    ],
+  ],
+  download: [
+    ["path", { d: "M12 15V3", key: "m9g1x1" }],
+    ["path", { d: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4", key: "ih7n3h" }],
+    ["path", { d: "m7 10 5 5 5-5", key: "brsn70" }],
+  ],
+  eye: [
+    [
+      "path",
+      {
+        d: "M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0",
+        key: "1nclc0",
+      },
+    ],
+    ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }],
+  ],
+  eye_off: [
+    [
+      "path",
+      {
+        d: "M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49",
+        key: "ct8e1f",
+      },
+    ],
+    ["path", { d: "M14.084 14.158a3 3 0 0 1-4.242-4.242", key: "151rxh" }],
+    [
+      "path",
+      {
+        d: "M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143",
+        key: "13bj9a",
+      },
+    ],
+    ["path", { d: "m2 2 20 20", key: "1ooewy" }],
+  ],
+  folder_open: [
+    [
+      "path",
+      {
+        d: "m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2",
+        key: "usdka0",
+      },
+    ],
+  ],
+  help_circle: [
+    ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
+    ["path", { d: "M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3", key: "1u773s" }],
+    ["path", { d: "M12 17h.01", key: "p32p05" }],
+  ],
+  inbox: [
+    [
+      "polyline",
+      { points: "22 12 16 12 14 15 10 15 8 12 2 12", key: "o97t9d" },
+    ],
+    [
+      "path",
+      {
+        d: "M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z",
+        key: "oot6mr",
+      },
+    ],
+  ],
+  info: [
+    ["circle", { cx: "12", cy: "12", r: "10", key: "1mglay" }],
+    ["path", { d: "M12 16v-4", key: "1dtifu" }],
+    ["path", { d: "M12 8h.01", key: "e9boi3" }],
+  ],
+  loader_circle: [
+    ["path", { d: "M21 12a9 9 0 1 1-6.219-8.56", key: "13zald" }],
+  ],
+  pause: [
+    [
+      "rect",
+      { x: "14", y: "3", width: "5", height: "18", rx: "1", key: "kaeet6" },
+    ],
+    [
+      "rect",
+      { x: "5", y: "3", width: "5", height: "18", rx: "1", key: "1wsw3u" },
+    ],
+  ],
+  pencil: [
+    [
+      "path",
+      {
+        d: "M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z",
+        key: "1a8usu",
+      },
+    ],
+    ["path", { d: "m15 5 4 4", key: "1mk7zo" }],
+  ],
+  play: [
+    [
+      "path",
+      {
+        d: "M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z",
+        key: "10ikf1",
+      },
+    ],
+  ],
+  plus: [
+    ["path", { d: "M5 12h14", key: "1ays0h" }],
+    ["path", { d: "M12 5v14", key: "s699le" }],
+  ],
+  refresh_cw: [
+    [
+      "path",
+      {
+        d: "M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8",
+        key: "v9h5vc",
+      },
+    ],
+    ["path", { d: "M21 3v5h-5", key: "1q7to0" }],
+    [
+      "path",
+      {
+        d: "M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16",
+        key: "3uifl3",
+      },
+    ],
+    ["path", { d: "M8 16H3v5", key: "1cv678" }],
+  ],
+  rotate_ccw: [
+    [
+      "path",
+      { d: "M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8", key: "1357e3" },
+    ],
+    ["path", { d: "M3 3v5h5", key: "1xhq8a" }],
+  ],
+  save: [
+    [
+      "path",
+      {
+        d: "M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z",
+        key: "1c8476",
+      },
+    ],
+    ["path", { d: "M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7", key: "1ydtos" }],
+    ["path", { d: "M7 3v4a1 1 0 0 0 1 1h7", key: "t51u73" }],
+  ],
+  search: [
+    ["path", { d: "m21 21-4.34-4.34", key: "14j7rj" }],
+    ["circle", { cx: "11", cy: "11", r: "8", key: "4ej97u" }],
+  ],
+  settings: [
+    [
+      "path",
+      {
+        d: "M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915",
+        key: "1i5ecw",
+      },
+    ],
+    ["circle", { cx: "12", cy: "12", r: "3", key: "1v7zrd" }],
+  ],
+  share_2: [
+    ["circle", { cx: "18", cy: "5", r: "3", key: "gq8acd" }],
+    ["circle", { cx: "6", cy: "12", r: "3", key: "w7nqdw" }],
+    ["circle", { cx: "18", cy: "19", r: "3", key: "1xt0gg" }],
+    [
+      "line",
+      { x1: "8.59", x2: "15.42", y1: "13.51", y2: "17.49", key: "47mynk" },
+    ],
+    [
+      "line",
+      { x1: "15.41", x2: "8.59", y1: "6.51", y2: "10.49", key: "1n3mei" },
+    ],
+  ],
+  shield_alert: [
+    [
+      "path",
+      {
+        d: "M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z",
+        key: "oel41y",
+      },
+    ],
+    ["path", { d: "M12 8v4", key: "1got3b" }],
+    ["path", { d: "M12 16h.01", key: "1drbdi" }],
+  ],
+  sliders_horizontal: [
+    ["path", { d: "M10 5H3", key: "1qgfaw" }],
+    ["path", { d: "M12 19H3", key: "yhmn1j" }],
+    ["path", { d: "M14 3v4", key: "1sua03" }],
+    ["path", { d: "M16 17v4", key: "1q0r14" }],
+    ["path", { d: "M21 12h-9", key: "1o4lsq" }],
+    ["path", { d: "M21 19h-5", key: "1rlt1p" }],
+    ["path", { d: "M21 5h-7", key: "1oszz2" }],
+    ["path", { d: "M8 10v4", key: "tgpxqk" }],
+    ["path", { d: "M8 12H3", key: "a7s4jb" }],
+  ],
+  square: [
+    [
+      "rect",
+      { width: "18", height: "18", x: "3", y: "3", rx: "2", key: "afitv7" },
+    ],
+  ],
+  trash_2: [
+    ["path", { d: "M10 11v6", key: "nco0om" }],
+    ["path", { d: "M14 11v6", key: "outv1u" }],
+    ["path", { d: "M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6", key: "miytrc" }],
+    ["path", { d: "M3 6h18", key: "d0wm0j" }],
+    ["path", { d: "M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2", key: "e791ji" }],
+  ],
+  triangle_alert: [
+    [
+      "path",
+      {
+        d: "m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3",
+        key: "wmoenq",
+      },
+    ],
+    ["path", { d: "M12 9v4", key: "juzpu7" }],
+    ["path", { d: "M12 17h.01", key: "p32p05" }],
+  ],
+  user_plus: [
+    ["path", { d: "M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2", key: "1yyitq" }],
+    ["circle", { cx: "9", cy: "7", r: "4", key: "nufk8" }],
+    ["line", { x1: "19", x2: "19", y1: "8", y2: "14", key: "1bvyxn" }],
+    ["line", { x1: "22", x2: "16", y1: "11", y2: "11", key: "1shjgl" }],
+  ],
+  user_round: [
+    ["circle", { cx: "12", cy: "8", r: "5", key: "1hypcn" }],
+    ["path", { d: "M20 21a8 8 0 0 0-16 0", key: "rfgkzh" }],
+  ],
+  users: [
+    ["path", { d: "M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2", key: "1yyitq" }],
+    ["path", { d: "M16 3.128a4 4 0 0 1 0 7.744", key: "16gr8j" }],
+    ["path", { d: "M22 21v-2a4 4 0 0 0-3-3.87", key: "kshegd" }],
+    ["circle", { cx: "9", cy: "7", r: "4", key: "nufk8" }],
+  ],
+  x: [
+    ["path", { d: "M18 6 6 18", key: "1bl5f8" }],
+    ["path", { d: "m6 6 12 12", key: "d8bk6v" }],
+  ],
+} as const satisfies Record<string, IconNode>;
+
+export type IconName = keyof typeof icons;
+
+export type IconProps = Omit<
+  JSX.SvgSVGAttributes<SVGSVGElement>,
+  "color" | "strokeWidth"
+> & {
+  readonly absoluteStrokeWidth?: boolean;
+  readonly color?: string;
+  readonly icon: IconName;
+  readonly size?: IconSize;
+  readonly strokeWidth?: number | string;
+  readonly title?: string;
+};
+
+function resolveSize(size: IconSize | undefined): number | string {
+  if (size === undefined) return defaultSize;
+  if (size in sizeTokens) return sizeTokens[size as keyof typeof sizeTokens];
+  return size;
+}
+
+function resolveStrokeWidth(
+  size: number | string,
+  strokeWidth: number | string,
+  absoluteStrokeWidth: boolean | undefined,
+): number | string {
+  if (absoluteStrokeWidth !== true) return strokeWidth;
+
+  const numericSize = Number(size);
+  const numericStrokeWidth = Number(strokeWidth);
+  if (
+    !Number.isFinite(numericSize) ||
+    numericSize <= 0 ||
+    !Number.isFinite(numericStrokeWidth)
+  ) {
+    return strokeWidth;
+  }
+
+  return (numericStrokeWidth * defaultSize) / numericSize;
+}
+
+function hasA11yProp(props: Record<string, unknown>): boolean {
+  if (props["role"] !== undefined) return true;
+
+  for (const prop in props) {
+    if (prop.startsWith("aria-")) return true;
+  }
+
+  return false;
+}
+
+function svgElementAttrs(
+  attrs: Record<string, string>,
+): Record<string, string> {
+  const svgAttrs = { ...attrs };
+  delete svgAttrs["key"];
+  return svgAttrs;
+}
+
+export function Icon(props: IconProps): JSX.Element {
+  const [local, rest] = splitProps(props, [
+    "absoluteStrokeWidth",
+    "children",
+    "color",
+    "icon",
+    "size",
+    "strokeWidth",
+    "title",
+  ]);
+  const size = () => resolveSize(local.size);
+  const strokeWidth = () =>
+    resolveStrokeWidth(
+      size(),
+      local.strokeWidth ?? defaultStrokeWidth,
+      local.absoluteStrokeWidth,
+    );
+  const ariaHidden = () =>
+    local.title || hasA11yProp(rest as Record<string, unknown>)
+      ? undefined
+      : "true";
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size()}
+      height={size()}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={local.color ?? "currentColor"}
+      stroke-width={strokeWidth()}
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden={ariaHidden()}
+      {...rest}
+    >
+      <Show when={local.title}>{(title) => <title>{title()}</title>}</Show>
+      <For each={icons[local.icon]}>
+        {([elementName, attrs]) => (
+          <Dynamic component={elementName} {...svgElementAttrs(attrs)} />
+        )}
+      </For>
+      {local.children}
+    </svg>
+  );
+}

--- a/packages/ui/src/components/Menu.tsx
+++ b/packages/ui/src/components/Menu.tsx
@@ -1,5 +1,5 @@
+import { Icon } from "./Icon";
 import { Menu as MenuPrimitive } from "@ark-ui/solid/menu";
-import { Check, ChevronRight } from "lucide-solid";
 import { splitProps, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import { cn } from "../lib/cn";
@@ -177,7 +177,7 @@ export function MenuCheckboxItem(props: MenuCheckboxItemProps): JSX.Element {
     >
       {local.children}
       <MenuPrimitive.ItemIndicator class="menu__item-indicator">
-        <Check />
+        <Icon icon="check" />
       </MenuPrimitive.ItemIndicator>
     </MenuPrimitive.CheckboxItem>
   );
@@ -241,7 +241,7 @@ export function MenuSubTrigger(props: MenuSubTriggerProps): JSX.Element {
       data-slot="menu-sub-trigger"
     >
       {local.children}
-      <ChevronRight class="menu__sub-icon" />
+      <Icon icon="chevron_right" class="menu__sub-icon" />
     </MenuPrimitive.TriggerItem>
   );
 }

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -1,9 +1,9 @@
+import { Icon } from "./Icon";
 import {
   createListCollection,
   Select as SelectPrimitive,
   type CollectionItem,
 } from "@ark-ui/solid/select";
-import { Check, ChevronsUpDown } from "lucide-solid";
 import {
   createContext,
   createMemo,
@@ -101,7 +101,7 @@ export function SelectButton(props: SelectButtonProps): JSX.Element {
       type={rest.type ?? "button"}
     >
       <span class="select__value">{local.children}</span>
-      <ChevronsUpDown class="select__icon" />
+      <Icon icon="chevrons_up_down" class="select__icon" />
     </button>
   );
 }
@@ -122,7 +122,7 @@ export function SelectTrigger(props: SelectTriggerProps): JSX.Element {
       data-slot="select-trigger"
     >
       {local.children}
-      <ChevronsUpDown class="select__icon" />
+      <Icon icon="chevrons_up_down" class="select__icon" />
     </SelectPrimitive.Trigger>
   );
 }
@@ -239,7 +239,7 @@ export function SelectItem(props: SelectItemProps): JSX.Element {
       item={item()}
     >
       <SelectPrimitive.ItemIndicator class="select__item-indicator">
-        <Check />
+        <Icon icon="check" />
       </SelectPrimitive.ItemIndicator>
       <SelectPrimitive.ItemText class="select__item-text">
         {local.children ?? item().label}

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -1,3 +1,4 @@
+import { Icon } from "./Icon";
 import {
   createEffect,
   createSignal,
@@ -8,7 +9,6 @@ import {
   type Accessor,
   type JSX,
 } from "solid-js";
-import { CircleAlert, CircleCheck, Info, TriangleAlert, X } from "lucide-solid";
 import { cn } from "../lib/cn";
 
 export type ToastVariant = "default" | "error" | "info" | "success" | "warning";
@@ -103,19 +103,19 @@ const DEFAULT_REMOVE_DELAY = 180;
 
 const defaultToastIcon = (variant: ToastVariant): JSX.Element | null => {
   if (variant === "success") {
-    return <CircleCheck aria-hidden="true" />;
+    return <Icon icon="circle_check" aria-hidden="true" />;
   }
 
   if (variant === "info") {
-    return <Info aria-hidden="true" />;
+    return <Icon icon="info" aria-hidden="true" />;
   }
 
   if (variant === "warning") {
-    return <TriangleAlert aria-hidden="true" />;
+    return <Icon icon="triangle_alert" aria-hidden="true" />;
   }
 
   if (variant === "error") {
-    return <CircleAlert aria-hidden="true" />;
+    return <Icon icon="circle_alert" aria-hidden="true" />;
   }
 
   return null;
@@ -355,7 +355,7 @@ export function ToastBanner(props: ToastBannerProps): JSX.Element {
           onClick={close}
           type="button"
         >
-          <X aria-hidden="true" />
+          <Icon icon="x" aria-hidden="true" />
         </button>
       </Show>
     </div>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -187,6 +187,7 @@ export {
   type IconButtonProps,
   type IconButtonSize,
 } from "./components/IconButton";
+export { Icon, type IconName, type IconProps } from "./components/Icon";
 export { Input, type InputProps } from "./components/Input";
 export {
   InputGroup,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,9 +66,6 @@ importers:
       effect:
         specifier: 4.0.0-beta.43
         version: 4.0.0-beta.43
-      lucide-solid:
-        specifier: ^1.14.0
-        version: 1.14.0(solid-js@1.9.12)
       solid-js:
         specifier: ^1.9.12
         version: 1.9.12
@@ -201,9 +198,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      lucide-solid:
-        specifier: ^1.14.0
-        version: 1.14.0(solid-js@1.9.12)
       solid-js:
         specifier: ^1.9.12
         version: 1.9.12
@@ -3844,11 +3838,6 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
-
-  lucide-solid@1.14.0:
-    resolution: {integrity: sha512-OeuC91agcJS3CyneSo96VpdkUAQdQO8c8r0QO5/FIkGnlfJ7Gd0fw3Z6CcdKnG94P0Ydwt+He2ar3oeTzbuNnw==}
-    peerDependencies:
-      solid-js: ^1.4.7
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -9999,10 +9988,6 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
-
-  lucide-solid@1.14.0(solid-js@1.9.12):
-    dependencies:
-      solid-js: 1.9.12
 
   lunr@2.3.9: {}
 


### PR DESCRIPTION
## Summary
- add a dependency-free Icon component exported by @vexed/ui
- replace app and UI lucide-solid imports with the shared Icon component
- remove lucide-solid from app/UI dependencies and add an icon:print helper for future additions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal icon rendering system across the application for improved performance and maintainability. Updated icon implementations in account manager, environment, followers, game navigation, packet inspector, settings, and skills modules. All user interface icons maintain consistent appearance and functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->