### PR TITLE
fix: reduce electron artifact size

### DIFF
--- a/app/electron-builder.json
+++ b/app/electron-builder.json
@@ -6,8 +6,8 @@
   "directories": {
     "output": "build"
   },
+  "files": ["dist/**/*", "package.json", "!node_modules/**/*"],
   "mac": {
-    "files": ["dist/**/*"],
     "extraResources": [
       {
         "from": "../assets",
@@ -24,7 +24,6 @@
     "artifactName": "${productName}-${os}.${ext}"
   },
   "win": {
-    "files": ["dist/**/*"],
     "extraResources": [
       {
         "from": "../assets",
@@ -41,7 +40,6 @@
     "artifactName": "${productName}-${os}.${ext}"
   },
   "linux": {
-    "files": ["dist/**/*"],
     "extraResources": [
       {
         "from": "../assets",

--- a/app/esbuild.config.js
+++ b/app/esbuild.config.js
@@ -3,6 +3,7 @@ const {
   appendFileSync,
   copyFileSync,
   mkdirSync,
+  rmSync,
   unwatchFile,
   watchFile,
 } = require("fs");
@@ -316,7 +317,16 @@ function copyRendererHtml({ notify = false } = {}) {
   }
 }
 
+function cleanProductionOutput() {
+  if (!isProduction || isWatch) {
+    return;
+  }
+
+  rmSync("dist", { recursive: true, force: true });
+}
+
 async function buildOnce() {
+  cleanProductionOutput();
   await build(createMainBuildOptions());
   await build(createPreloadBuildOptions());
   copyRendererHtml();


### PR DESCRIPTION
## Summary
- package only the compiled Electron app payload instead of copying production node_modules
- clean production dist output before compiling to avoid stale source maps in artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined packaging configuration to ensure proper inclusion of application files and exclusion of dependencies across macOS, Windows, and Linux deployments.
  * Enhanced production build process with automatic cleanup of previous build artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->