### PR TITLE
feat: add fast travels

### DIFF
--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -26,6 +26,7 @@ import { MainIpcLive } from "./ipc/MainIpc";
 import { Persistence, PersistenceLive } from "./persistence/Persistence";
 import { AccountManagerRepositoryLive } from "./persistence/accounts/AccountRepository";
 import { CombatProfileRepositoryLive } from "./persistence/combatProfiles/CombatProfileRepository";
+import { FastTravelRepositoryLive } from "./persistence/fastTravels/FastTravelRepository";
 import {
   makeElectronWindowRuntime,
   makeWindowService,
@@ -164,6 +165,7 @@ const settingsLayer = SettingsServiceLive.pipe(
 const persistedDocumentsLayer = Layer.mergeAll(
   AccountManagerRepositoryLive,
   CombatProfileRepositoryLive,
+  FastTravelRepositoryLive,
   WorkspaceFilesLive,
 ).pipe(Layer.provideMerge(observabilityLayer));
 const windowLayer = Layer.effect(WindowService)(

--- a/app/src/main/ipc/MainIpcHandlers.ts
+++ b/app/src/main/ipc/MainIpcHandlers.ts
@@ -4,6 +4,7 @@ import { registerAccountManagerIpcHandlers } from "./methods/accounts";
 import { registerArmyIpcHandlers } from "./methods/army";
 import { registerCombatProfilesIpcHandlers } from "./methods/combatProfiles";
 import { registerEnvironmentIpcHandlers } from "./methods/environment";
+import { registerFastTravelsIpcHandlers } from "./methods/fastTravels";
 import { registerFollowerIpcHandlers } from "./methods/follower";
 import { registerObservabilityIpcHandlers } from "./methods/observability";
 import { registerPacketsIpcHandlers } from "./methods/packets";
@@ -14,6 +15,7 @@ import { registerWindowIpcHandlers } from "./methods/window";
 import { AccountManagerRepository } from "../persistence/accounts/AccountRepository";
 import { Observability } from "../app/MainObservability";
 import { CombatProfileRepository } from "../persistence/combatProfiles/CombatProfileRepository";
+import { FastTravelRepository } from "../persistence/fastTravels/FastTravelRepository";
 import { MainIpc } from "./MainIpc";
 import { SettingsService } from "../settings/SettingsService";
 import { UpdateChecker } from "../updates/Updates";
@@ -27,6 +29,7 @@ export const installMainIpcHandlers = (
   never,
   | AccountManagerRepository
   | CombatProfileRepository
+  | FastTravelRepository
   | MainIpc
   | Observability
   | Scope.Scope
@@ -45,6 +48,7 @@ export const installMainIpcHandlers = (
     yield* registerUpdatesIpcHandlers();
     yield* registerWindowIpcHandlers();
     yield* registerEnvironmentIpcHandlers(runWindowEffect);
+    yield* registerFastTravelsIpcHandlers(runWindowEffect);
     yield* registerFollowerIpcHandlers(runWindowEffect);
     yield* registerPacketsIpcHandlers(runWindowEffect);
   });

--- a/app/src/main/ipc/methods/fastTravels.ts
+++ b/app/src/main/ipc/methods/fastTravels.ts
@@ -1,0 +1,237 @@
+import { BrowserWindow, type IpcMainInvokeEvent } from "electron";
+import { Effect, Scope } from "effect";
+import {
+  addFastTravel,
+  deleteFastTravel,
+  normalizeFastTravelDraft,
+  normalizeFastTravelWarpPayload,
+  updateFastTravel,
+  type FastTravel,
+  type FastTravelDraft,
+  type FastTravelWarpPayload,
+} from "../../../shared/fast-travels";
+import {
+  FastTravelsIpcChannels,
+  type FastTravelsRequestMessage,
+  type FastTravelsResponseMessage,
+} from "../../../shared/ipc";
+import { makeRandomId } from "../../../shared/random-id";
+import {
+  FastTravelRepository,
+  type FastTravelRepositoryShape,
+} from "../../persistence/fastTravels/FastTravelRepository";
+import {
+  WindowManagerError,
+  WindowService,
+  type WindowEffectRunner,
+} from "../../window/WindowService";
+import { MainIpc } from "../MainIpc";
+
+const FAST_TRAVELS_REQUEST_TIMEOUT_MS = 5_000;
+
+const pendingRequests = new Map<
+  string,
+  {
+    readonly resolve: () => void;
+    readonly reject: (error: Error) => void;
+    readonly timeout: ReturnType<typeof setTimeout>;
+  }
+>();
+
+const getSenderWindowId = (event: IpcMainInvokeEvent): number | undefined =>
+  BrowserWindow.fromWebContents(event.sender)?.id;
+
+const requestErrorMessage = (cause: unknown): string =>
+  cause instanceof Error && cause.message !== ""
+    ? cause.message
+    : "Fast travel request failed";
+
+const senderGameWindowId = (
+  event: IpcMainInvokeEvent,
+): Effect.Effect<number, WindowManagerError, WindowService> =>
+  Effect.gen(function* () {
+    const senderWindowId = getSenderWindowId(event);
+    if (senderWindowId === undefined) {
+      return yield* new WindowManagerError({
+        message: "Missing sender window",
+      });
+    }
+
+    const windows = yield* WindowService;
+    const gameWindowId = yield* windows.getGameWindowId(senderWindowId);
+    if (gameWindowId === undefined) {
+      return yield* new WindowManagerError({
+        message: "Missing parent game window",
+      });
+    }
+
+    return gameWindowId;
+  });
+
+const broadcastChanged = (locations: readonly FastTravel[]): void => {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) {
+      continue;
+    }
+
+    win.webContents.send(FastTravelsIpcChannels.changed, locations);
+  }
+};
+
+const publishLocations = (
+  repository: FastTravelRepositoryShape,
+  locations: readonly FastTravel[],
+) =>
+  repository
+    .set(locations)
+    .pipe(
+      Effect.tap((normalized) =>
+        Effect.sync(() => broadcastChanged(normalized)),
+      ),
+    );
+
+const requestGameFastTravel = (
+  gameWindow: BrowserWindow,
+  payload: FastTravelWarpPayload,
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const requestId = makeRandomId();
+    const timeout = setTimeout(() => {
+      pendingRequests.delete(requestId);
+      reject(new Error("Fast travel did not respond"));
+    }, FAST_TRAVELS_REQUEST_TIMEOUT_MS);
+
+    pendingRequests.set(requestId, { resolve, reject, timeout });
+
+    const request: FastTravelsRequestMessage = {
+      requestId,
+      kind: "warp",
+      payload,
+    };
+
+    try {
+      gameWindow.webContents.send(FastTravelsIpcChannels.request, request);
+    } catch (cause) {
+      pendingRequests.delete(requestId);
+      clearTimeout(timeout);
+      reject(
+        cause instanceof Error
+          ? cause
+          : new Error("Fast travel request failed"),
+      );
+    }
+  });
+
+const sendFastTravelRequest = (
+  event: IpcMainInvokeEvent,
+  payload: FastTravelWarpPayload,
+): Effect.Effect<void, WindowManagerError, WindowService> =>
+  Effect.gen(function* () {
+    const gameWindowId = yield* senderGameWindowId(event);
+    const windows = yield* WindowService;
+    const gameWindow = yield* windows.getGameWindow(gameWindowId);
+    if (!gameWindow) {
+      return yield* new WindowManagerError({
+        message: "Missing parent game window",
+      });
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => requestGameFastTravel(gameWindow, payload),
+      catch: (cause) =>
+        new WindowManagerError({
+          message: requestErrorMessage(cause),
+          cause,
+        }),
+    });
+  });
+
+export const registerFastTravelsIpcHandlers = (
+  runWindowEffect: WindowEffectRunner,
+): Effect.Effect<void, never, FastTravelRepository | MainIpc | Scope.Scope> =>
+  Effect.gen(function* () {
+    const ipc = yield* MainIpc;
+    const run = <A>(
+      effect: Effect.Effect<A, WindowManagerError, WindowService>,
+    ) => Effect.promise(() => runWindowEffect(effect));
+
+    yield* ipc.on(FastTravelsIpcChannels.response, (_event, response) =>
+      Effect.sync(() => {
+        const fastTravelResponse = response as FastTravelsResponseMessage;
+        if (typeof fastTravelResponse?.requestId !== "string") {
+          return;
+        }
+
+        const pending = pendingRequests.get(fastTravelResponse.requestId);
+        if (!pending) {
+          return;
+        }
+
+        pendingRequests.delete(fastTravelResponse.requestId);
+        clearTimeout(pending.timeout);
+
+        if (fastTravelResponse.ok) {
+          pending.resolve();
+        } else {
+          pending.reject(
+            new Error(fastTravelResponse.error || "Fast travel request failed"),
+          );
+        }
+      }),
+    );
+
+    yield* ipc.handle(FastTravelsIpcChannels.getAll, () =>
+      Effect.gen(function* () {
+        const repository = yield* FastTravelRepository;
+        return yield* repository.get;
+      }),
+    );
+
+    yield* ipc.handle(FastTravelsIpcChannels.create, (_event, draft) =>
+      Effect.gen(function* () {
+        const repository = yield* FastTravelRepository;
+        const current = yield* repository.get;
+        return yield* publishLocations(
+          repository,
+          addFastTravel(
+            current,
+            normalizeFastTravelDraft(draft as FastTravelDraft),
+          ),
+        );
+      }),
+    );
+
+    yield* ipc.handle(
+      FastTravelsIpcChannels.update,
+      (_event, originalName, draft) =>
+        Effect.gen(function* () {
+          const repository = yield* FastTravelRepository;
+          const current = yield* repository.get;
+          return yield* publishLocations(
+            repository,
+            updateFastTravel(
+              current,
+              typeof originalName === "string" ? originalName : "",
+              normalizeFastTravelDraft(draft as FastTravelDraft),
+            ),
+          );
+        }),
+    );
+
+    yield* ipc.handle(FastTravelsIpcChannels.delete, (_event, name) =>
+      Effect.gen(function* () {
+        const repository = yield* FastTravelRepository;
+        const current = yield* repository.get;
+        return yield* publishLocations(
+          repository,
+          deleteFastTravel(current, typeof name === "string" ? name : ""),
+        );
+      }),
+    );
+
+    yield* ipc.handle(FastTravelsIpcChannels.warp, (event, payload) =>
+      run(
+        sendFastTravelRequest(event, normalizeFastTravelWarpPayload(payload)),
+      ),
+    );
+  });

--- a/app/src/main/ipc/methods/fastTravels.ts
+++ b/app/src/main/ipc/methods/fastTravels.ts
@@ -74,7 +74,11 @@ const broadcastChanged = (locations: readonly FastTravel[]): void => {
       continue;
     }
 
-    win.webContents.send(FastTravelsIpcChannels.changed, locations);
+    try {
+      win.webContents.send(FastTravelsIpcChannels.changed, locations);
+    } catch {
+      // Window teardown can race the destroyed checks; broadcasts are best effort.
+    }
   }
 };
 
@@ -170,12 +174,20 @@ export const registerFastTravelsIpcHandlers = (
         pendingRequests.delete(fastTravelResponse.requestId);
         clearTimeout(pending.timeout);
 
+        if (typeof fastTravelResponse.ok !== "boolean") {
+          pending.reject(new Error("Invalid fast travel response"));
+          return;
+        }
+
         if (fastTravelResponse.ok) {
           pending.resolve();
         } else {
-          pending.reject(
-            new Error(fastTravelResponse.error || "Fast travel request failed"),
-          );
+          const message =
+            typeof fastTravelResponse.error === "string" &&
+            fastTravelResponse.error !== ""
+              ? fastTravelResponse.error
+              : "Fast travel request failed";
+          pending.reject(new Error(message));
         }
       }),
     );

--- a/app/src/main/persistence/fastTravels/FastTravelRepository.test.ts
+++ b/app/src/main/persistence/fastTravels/FastTravelRepository.test.ts
@@ -1,0 +1,176 @@
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_FAST_TRAVELS } from "../../../shared/fast-travels";
+import { MainEnvironmentLive } from "../../app/MainEnvironment";
+import {
+  Observability,
+  type ObservabilityShape,
+} from "../../app/MainObservability";
+import { PersistenceLive } from "../Persistence";
+import {
+  FAST_TRAVELS_STORAGE_FILE,
+  FastTravelRepository,
+  FastTravelRepositoryLive,
+  type FastTravelRepositoryShape,
+} from "./FastTravelRepository";
+
+const observability: ObservabilityShape = {
+  runId: "test",
+  logPath: "/tmp/vexed-test.ndjson",
+  write: () =>
+    Effect.succeed({
+      id: 0,
+      runId: "test",
+      timestamp: "2026-05-22T00:00:00.000Z",
+      level: "info",
+      source: "main",
+      component: "test",
+      message: "test",
+    }),
+  debug: () =>
+    Effect.succeed({
+      id: 0,
+      runId: "test",
+      timestamp: "2026-05-22T00:00:00.000Z",
+      level: "debug",
+      source: "main",
+      component: "test",
+      message: "test",
+    }),
+  info: () =>
+    Effect.succeed({
+      id: 0,
+      runId: "test",
+      timestamp: "2026-05-22T00:00:00.000Z",
+      level: "info",
+      source: "main",
+      component: "test",
+      message: "test",
+    }),
+  warn: () =>
+    Effect.succeed({
+      id: 0,
+      runId: "test",
+      timestamp: "2026-05-22T00:00:00.000Z",
+      level: "warn",
+      source: "main",
+      component: "test",
+      message: "test",
+    }),
+  error: () =>
+    Effect.succeed({
+      id: 0,
+      runId: "test",
+      timestamp: "2026-05-22T00:00:00.000Z",
+      level: "error",
+      source: "main",
+      component: "test",
+      message: "test",
+    }),
+  snapshot: Effect.succeed({
+    runId: "test",
+    logPath: "/tmp/vexed-test.ndjson",
+    records: [],
+  }),
+  installProcessHooks: Effect.void,
+  observeWindow: () => Effect.void,
+};
+
+const makeLayer = (dir: string) =>
+  FastTravelRepositoryLive.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        MainEnvironmentLive({
+          appDataDir: dir,
+          workspaceDir: join(dir, "workspace"),
+          assetsDir: join(dir, "assets"),
+          rendererDir: join(dir, "renderer"),
+          preloadPath: join(dir, "preload.js"),
+          isDev: false,
+          isDarwin: true,
+          isWin: false,
+          isLinux: false,
+        }),
+        PersistenceLive,
+        Layer.succeed(Observability)(observability),
+      ),
+    ),
+  );
+
+const runWithRepository = <A>(
+  dir: string,
+  effect: (repository: FastTravelRepositoryShape) => Effect.Effect<A, unknown>,
+) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const repository = yield* FastTravelRepository;
+      return yield* effect(repository);
+    }).pipe(Effect.provide(makeLayer(dir))),
+  );
+
+describe("FastTravelRepository", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await mkdtemp(join(tmpdir(), "vexed-fast-travels-"));
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  it("returns defaults for missing storage without writing on read", async () => {
+    const locations = await runWithRepository(
+      testDir,
+      (repository) => repository.get,
+    );
+
+    expect(locations).toEqual(DEFAULT_FAST_TRAVELS);
+    expect(locations).not.toBe(DEFAULT_FAST_TRAVELS);
+
+    await expect(
+      readFile(join(testDir, FAST_TRAVELS_STORAGE_FILE), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("quarantines malformed storage and writes defaults", async () => {
+    const path = join(testDir, FAST_TRAVELS_STORAGE_FILE);
+    await writeFile(path, "{ nope", "utf8");
+
+    await expect(
+      runWithRepository(testDir, (repository) => repository.get),
+    ).resolves.toEqual(DEFAULT_FAST_TRAVELS);
+
+    await expect(readFile(path, "utf8")).resolves.toBe(
+      `${JSON.stringify(DEFAULT_FAST_TRAVELS, null, 2)}\n`,
+    );
+    const files = await readdir(testDir);
+    expect(
+      files.some((file) =>
+        file.startsWith(`${FAST_TRAVELS_STORAGE_FILE}.corrupt-`),
+      ),
+    ).toBe(true);
+  });
+
+  it("normalizes and persists updates", async () => {
+    const path = join(testDir, FAST_TRAVELS_STORAGE_FILE);
+    const locations = await runWithRepository(testDir, (repository) =>
+      repository.update(() => [
+        { name: " Home ", map: "Battleon" },
+        { name: "home", map: "ignored" },
+        { name: "Boss", map: "Escherion", cell: " Boss " },
+      ]),
+    );
+
+    expect(locations).toEqual([
+      { name: "Home", map: "battleon" },
+      { name: "Boss", map: "escherion", cell: "Boss" },
+    ]);
+    await expect(readFile(path, "utf8")).resolves.toBe(
+      `${JSON.stringify(locations, null, 2)}\n`,
+    );
+  });
+});

--- a/app/src/main/persistence/fastTravels/FastTravelRepository.ts
+++ b/app/src/main/persistence/fastTravels/FastTravelRepository.ts
@@ -59,29 +59,32 @@ export const FastTravelRepositoryLive = Layer.effect(FastTravelRepository)(
       return normalizeFastTravels(result.value);
     });
 
-    const get = SynchronizedRef.updateAndGetEffect(ref, (current) =>
-      current === null ? load : Effect.succeed(current),
-    ).pipe(Effect.map((locations) => locations ?? defaults()));
+    const get = SynchronizedRef.modifyEffect(ref, (current) =>
+      (current === null ? load : Effect.succeed(current)).pipe(
+        Effect.map((locations) => [locations, locations] as const),
+      ),
+    );
 
     const set = (locations: readonly FastTravel[]) =>
-      Effect.gen(function* () {
-        const normalized = normalizeFastTravels(locations);
-        yield* persistence.writeJson(path, normalized);
-        yield* SynchronizedRef.set(ref, normalized);
-        return normalized;
-      });
+      SynchronizedRef.modifyEffect(ref, () =>
+        Effect.gen(function* () {
+          const normalized = normalizeFastTravels(locations);
+          yield* persistence.writeJson(path, normalized);
+          return [normalized, normalized] as const;
+        }),
+      );
 
     const update = (
       f: (locations: readonly FastTravel[]) => readonly FastTravel[],
     ) =>
-      SynchronizedRef.updateAndGetEffect(ref, (current) =>
+      SynchronizedRef.modifyEffect(ref, (current) =>
         Effect.gen(function* () {
           const base = current ?? (yield* load);
           const normalized = normalizeFastTravels(f(base));
           yield* persistence.writeJson(path, normalized);
-          return normalized;
+          return [normalized, normalized] as const;
         }),
-      ).pipe(Effect.map((locations) => locations ?? defaults()));
+      );
 
     return { path, get, set, update };
   }),

--- a/app/src/main/persistence/fastTravels/FastTravelRepository.ts
+++ b/app/src/main/persistence/fastTravels/FastTravelRepository.ts
@@ -1,0 +1,88 @@
+import { Effect, Layer, ServiceMap, SynchronizedRef } from "effect";
+import {
+  cloneDefaultFastTravels,
+  normalizeFastTravels,
+  type FastTravel,
+} from "../../../shared/fast-travels";
+import { MainEnvironment } from "../../app/MainEnvironment";
+import { Observability } from "../../app/MainObservability";
+import { Persistence, type PersistenceError } from "../Persistence";
+
+export const FAST_TRAVELS_STORAGE_FILE = "fast-travels.json";
+
+export interface FastTravelRepositoryShape {
+  readonly path: string;
+  readonly get: Effect.Effect<readonly FastTravel[], PersistenceError>;
+  readonly set: (
+    locations: readonly FastTravel[],
+  ) => Effect.Effect<readonly FastTravel[], PersistenceError>;
+  readonly update: (
+    f: (locations: readonly FastTravel[]) => readonly FastTravel[],
+  ) => Effect.Effect<readonly FastTravel[], PersistenceError>;
+}
+
+export class FastTravelRepository extends ServiceMap.Service<
+  FastTravelRepository,
+  FastTravelRepositoryShape
+>()("main/FastTravelRepository") {}
+
+export const FastTravelRepositoryLive = Layer.effect(FastTravelRepository)(
+  Effect.gen(function* () {
+    const env = yield* MainEnvironment;
+    const persistence = yield* Persistence;
+    const observability = yield* Observability;
+    const path = env.appDataPath(FAST_TRAVELS_STORAGE_FILE);
+    const ref = yield* SynchronizedRef.make<readonly FastTravel[] | null>(null);
+    const defaults = (): readonly FastTravel[] => cloneDefaultFastTravels();
+
+    const load = Effect.gen(function* () {
+      const result = yield* persistence.readJson(path);
+      if (result.status === "missing") {
+        return defaults();
+      }
+
+      if (result.status === "malformed") {
+        const quarantinePath = yield* persistence.quarantineMalformed(
+          path,
+          result.error.message,
+        );
+        yield* observability.warn(
+          "fast-travels",
+          "Malformed fast travel storage file",
+          { path, quarantinePath, error: result.error },
+        );
+        const fallback = defaults();
+        yield* persistence.writeJson(path, fallback);
+        return fallback;
+      }
+
+      return normalizeFastTravels(result.value);
+    });
+
+    const get = SynchronizedRef.updateAndGetEffect(ref, (current) =>
+      current === null ? load : Effect.succeed(current),
+    ).pipe(Effect.map((locations) => locations ?? defaults()));
+
+    const set = (locations: readonly FastTravel[]) =>
+      Effect.gen(function* () {
+        const normalized = normalizeFastTravels(locations);
+        yield* persistence.writeJson(path, normalized);
+        yield* SynchronizedRef.set(ref, normalized);
+        return normalized;
+      });
+
+    const update = (
+      f: (locations: readonly FastTravel[]) => readonly FastTravel[],
+    ) =>
+      SynchronizedRef.updateAndGetEffect(ref, (current) =>
+        Effect.gen(function* () {
+          const base = current ?? (yield* load);
+          const normalized = normalizeFastTravels(f(base));
+          yield* persistence.writeJson(path, normalized);
+          return normalized;
+        }),
+      ).pipe(Effect.map((locations) => locations ?? defaults()));
+
+    return { path, get, set, update };
+  }),
+);

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -8,6 +8,7 @@ import {
   ArmyIpcChannels,
   CombatProfilesIpcChannels,
   EnvironmentIpcChannels,
+  FastTravelsIpcChannels,
   FollowerIpcChannels,
   ObservabilityIpcChannels,
   PacketsIpcChannels,
@@ -38,6 +39,11 @@ import {
   type EnvironmentItemRules,
   type EnvironmentQuestAutoRegisterOptions,
   type EnvironmentState,
+  type FastTravel,
+  type FastTravelDraft,
+  type FastTravelsRequestMessage,
+  type FastTravelsResponseMessage,
+  type FastTravelWarpPayload,
   type FollowerRequestMessage,
   type FollowerResponseMessage,
   type FollowerStartPayload,
@@ -104,6 +110,9 @@ const followerStopRequestListeners = new Set<
 >();
 const packetRequestListeners = new Set<
   (request: PacketsRequestMessage) => void
+>();
+const fastTravelRequestListeners = new Set<
+  (request: FastTravelsRequestMessage) => void
 >();
 
 const latestEnvironmentFetchBoostsListener = ():
@@ -268,6 +277,15 @@ ipcRenderer.on(
   PacketsIpcChannels.request,
   (_event, request: PacketsRequestMessage) => {
     for (const listener of packetRequestListeners) {
+      listener(request);
+    }
+  },
+);
+
+ipcRenderer.on(
+  FastTravelsIpcChannels.request,
+  (_event, request: FastTravelsRequestMessage) => {
+    for (const listener of fastTravelRequestListeners) {
       listener(request);
     }
   },
@@ -578,6 +596,62 @@ const bridge: AppBridge = {
       return () => {
         environmentFetchBoostsListeners.delete(listener);
       };
+    },
+  },
+  fastTravels: {
+    getAll: async () => {
+      return (await ipcRenderer.invoke(
+        FastTravelsIpcChannels.getAll,
+      )) as readonly FastTravel[];
+    },
+    create: async (draft: FastTravelDraft) => {
+      return (await ipcRenderer.invoke(
+        FastTravelsIpcChannels.create,
+        draft,
+      )) as readonly FastTravel[];
+    },
+    update: async (originalName: string, draft: FastTravelDraft) => {
+      return (await ipcRenderer.invoke(
+        FastTravelsIpcChannels.update,
+        originalName,
+        draft,
+      )) as readonly FastTravel[];
+    },
+    delete: async (name: string) => {
+      return (await ipcRenderer.invoke(
+        FastTravelsIpcChannels.delete,
+        name,
+      )) as readonly FastTravel[];
+    },
+    warp: async (payload: FastTravelWarpPayload) => {
+      await ipcRenderer.invoke(FastTravelsIpcChannels.warp, payload);
+    },
+    onChanged: (listener) => {
+      const subscription = (
+        _event: unknown,
+        locations: readonly FastTravel[],
+      ) => {
+        listener(locations);
+      };
+
+      ipcRenderer.on(FastTravelsIpcChannels.changed, subscription);
+
+      return () => {
+        ipcRenderer.removeListener(
+          FastTravelsIpcChannels.changed,
+          subscription,
+        );
+      };
+    },
+    onRequest: (listener) => {
+      fastTravelRequestListeners.add(listener);
+
+      return () => {
+        fastTravelRequestListeners.delete(listener);
+      };
+    },
+    respond: async (response: FastTravelsResponseMessage) => {
+      ipcRenderer.send(FastTravelsIpcChannels.response, response);
     },
   },
   follower: {

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -285,6 +285,15 @@ ipcRenderer.on(
 ipcRenderer.on(
   FastTravelsIpcChannels.request,
   (_event, request: FastTravelsRequestMessage) => {
+    if (fastTravelRequestListeners.size === 0) {
+      ipcRenderer.send(FastTravelsIpcChannels.response, {
+        error: "Fast travel is not available in this game window",
+        ok: false,
+        requestId: request.requestId,
+      } satisfies FastTravelsResponseMessage);
+      return;
+    }
+
     for (const listener of fastTravelRequestListeners) {
       listener(request);
     }

--- a/app/src/renderer/windows/fast-travels/App.tsx
+++ b/app/src/renderer/windows/fast-travels/App.tsx
@@ -356,7 +356,7 @@ function App(): JSX.Element {
           : "Failed to add location.",
       );
       setDialogError(message);
-      if (message.toLowerCase().includes("exists")) {
+      if (cause instanceof FastTravelDuplicateNameError) {
         setFieldError("name");
       }
     } finally {

--- a/app/src/renderer/windows/fast-travels/App.tsx
+++ b/app/src/renderer/windows/fast-travels/App.tsx
@@ -1,5 +1,779 @@
 /* @refresh reload */
-import { WindowIds } from "../../../shared/windows";
-import { mountWindowApp } from "../windowApp";
+import "../../polyfills";
+import "./style.css";
+import { createHotkey } from "@tanstack/solid-hotkeys";
+import {
+  Icon,
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AppShell,
+  AppShellBody,
+  AppShellHeader,
+  AppShellHeaderLeft,
+  AppShellHeaderRight,
+  AppShellTitle,
+  Button,
+  Card,
+  CardContent,
+  CardFrame,
+  CardFrameHeader,
+  CardFrameTitle,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  IconButton,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Kbd,
+  Label,
+  Spinner,
+  Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  type IconButtonProps,
+} from "@vexed/ui";
+import {
+  For,
+  Show,
+  createEffect,
+  createMemo,
+  createSignal,
+  onCleanup,
+  onMount,
+  type JSX,
+} from "solid-js";
+import {
+  MAX_FAST_TRAVEL_ROOM_NUMBER,
+  FastTravelDuplicateNameError,
+  FastTravelNotFoundError,
+  FastTravelValidationError,
+  normalizeFastTravelDraft,
+  normalizeFastTravelRoomNumber,
+  sameFastTravelName,
+  type FastTravel,
+  type FastTravelDraft,
+} from "../../../shared/fast-travels";
+import { mountWindow } from "../mount";
 
-mountWindowApp(WindowIds.FastTravels);
+interface FastTravelFormState {
+  readonly name: string;
+  readonly map: string;
+  readonly cell: string;
+  readonly pad: string;
+}
+
+interface SaveOptions {
+  readonly closeAfterSave: boolean;
+}
+
+type FastTravelFieldError = "name" | "map";
+type DialogMode = "create" | "edit";
+
+const emptyForm = (): FastTravelFormState => ({
+  name: "",
+  map: "",
+  cell: "",
+  pad: "",
+});
+
+const toForm = (location: FastTravel): FastTravelFormState => ({
+  name: location.name,
+  map: location.map,
+  cell: location.cell ?? "",
+  pad: location.pad ?? "",
+});
+
+const operationErrorMessage = (cause: unknown, fallback: string): string => {
+  if (cause instanceof FastTravelDuplicateNameError) {
+    return "A location with this name already exists.";
+  }
+  if (cause instanceof FastTravelNotFoundError) {
+    return "Location not found. It may have been deleted.";
+  }
+  if (cause instanceof FastTravelValidationError) {
+    return cause.message;
+  }
+  if (cause instanceof Error && cause.message !== "") {
+    return cause.message;
+  }
+  return fallback;
+};
+
+const locationSubtitle = (location: FastTravel): string => {
+  const parts = [location.map];
+  if (location.cell) {
+    parts.push(location.cell);
+  }
+  if (location.pad) {
+    parts.push(location.pad);
+  }
+  return parts.join(" / ");
+};
+
+function TooltipIconButton(props: {
+  readonly "aria-label": string;
+  readonly class?: string;
+  readonly children: JSX.Element;
+  readonly disabled?: boolean;
+  readonly tooltip: string;
+  readonly onClick: JSX.EventHandler<HTMLButtonElement, MouseEvent>;
+}): JSX.Element {
+  return (
+    <Tooltip closeDelay={0} openDelay={200} positioning={{ placement: "top" }}>
+      <TooltipTrigger
+        asChild={(triggerProps) => (
+          <IconButton
+            {...(triggerProps({
+              "aria-label": props["aria-label"],
+              children: props.children,
+              class: props.class,
+              disabled: props.disabled,
+              size: "icon",
+              type: "button",
+              variant: "ghost",
+              onClick: props.onClick,
+            } as IconButtonProps) as IconButtonProps)}
+          />
+        )}
+      />
+      <TooltipContent>{props.tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}
+
+function FormField(props: {
+  readonly children: JSX.Element;
+  readonly error?: boolean;
+  readonly for: string;
+  readonly label: string;
+  readonly optional?: boolean;
+}): JSX.Element {
+  return (
+    <div class="fast-travels-form__field">
+      <Label for={props.for}>
+        {props.label}
+        <Show when={props.optional}>
+          <span class="fast-travels-form__optional">Optional</span>
+        </Show>
+      </Label>
+      <div data-invalid={props.error ? "" : undefined}>{props.children}</div>
+    </div>
+  );
+}
+
+function App(): JSX.Element {
+  const [locations, setLocations] = createSignal<readonly FastTravel[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal("");
+  const [searchQuery, setSearchQuery] = createSignal("");
+  const [useRoomNumber, setUseRoomNumber] = createSignal(false);
+  const [roomNumber, setRoomNumber] = createSignal(
+    String(MAX_FAST_TRAVEL_ROOM_NUMBER),
+  );
+  const [warpingName, setWarpingName] = createSignal<string | null>(null);
+  const [dialogOpen, setDialogOpen] = createSignal(false);
+  const [dialogMode, setDialogMode] = createSignal<DialogMode>("create");
+  const [editingOriginalName, setEditingOriginalName] = createSignal("");
+  const [form, setForm] = createSignal<FastTravelFormState>(emptyForm());
+  const [fieldError, setFieldError] = createSignal<FastTravelFieldError | null>(
+    null,
+  );
+  const [dialogError, setDialogError] = createSignal("");
+  const [saving, setSaving] = createSignal(false);
+  const [pendingDelete, setPendingDelete] = createSignal<FastTravel | null>(
+    null,
+  );
+  const [deleting, setDeleting] = createSignal(false);
+  let searchInput: HTMLInputElement | undefined;
+  let nameInput: HTMLInputElement | undefined;
+
+  const filteredLocations = createMemo(() => {
+    const query = searchQuery().trim().toLowerCase();
+    if (query === "") {
+      return locations();
+    }
+
+    return locations().filter((location) => {
+      const haystack = [
+        location.name,
+        location.map,
+        location.cell ?? "",
+        location.pad ?? "",
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  });
+
+  const normalizedRoomNumber = createMemo(
+    () =>
+      normalizeFastTravelRoomNumber(roomNumber()) ??
+      MAX_FAST_TRAVEL_ROOM_NUMBER,
+  );
+  const formSubmittable = createMemo(
+    () => form().name.trim() !== "" && form().map.trim() !== "",
+  );
+
+  createHotkey(
+    "/",
+    (event) => {
+      if (event.repeat || dialogOpen() || pendingDelete() !== null) {
+        return;
+      }
+
+      searchInput?.focus();
+      searchInput?.select();
+    },
+    {
+      eventType: "keydown",
+      conflictBehavior: "replace",
+      ignoreInputs: true,
+    },
+  );
+
+  createEffect(() => {
+    if (dialogOpen()) {
+      window.requestAnimationFrame(() => {
+        nameInput?.focus();
+      });
+    }
+  });
+
+  const setFormField = (
+    field: keyof FastTravelFormState,
+    value: string,
+  ): void => {
+    setForm((current) => ({ ...current, [field]: value }));
+    setDialogError("");
+    if (fieldError() === field) {
+      setFieldError(null);
+    }
+  };
+
+  const openCreateDialog = (): void => {
+    setDialogMode("create");
+    setEditingOriginalName("");
+    setForm(emptyForm());
+    setFieldError(null);
+    setDialogError("");
+    setDialogOpen(true);
+  };
+
+  const openEditDialog = (location: FastTravel): void => {
+    setDialogMode("edit");
+    setEditingOriginalName(location.name);
+    setForm(toForm(location));
+    setFieldError(null);
+    setDialogError("");
+    setDialogOpen(true);
+  };
+
+  const closeDialog = (): void => {
+    if (saving()) {
+      return;
+    }
+
+    setDialogOpen(false);
+    setFieldError(null);
+    setDialogError("");
+  };
+
+  const normalizeForm = (): FastTravelDraft | null => {
+    try {
+      return normalizeFastTravelDraft(form());
+    } catch (cause) {
+      if (cause instanceof FastTravelValidationError) {
+        setFieldError(cause.field);
+        setDialogError(cause.message);
+      } else {
+        setDialogError("Location details are invalid.");
+      }
+      return null;
+    }
+  };
+
+  const duplicateNameInCurrentList = (draft: FastTravelDraft): boolean => {
+    const originalName = editingOriginalName();
+    return locations().some(
+      (location) =>
+        sameFastTravelName(location.name, draft.name) &&
+        (dialogMode() !== "edit" ||
+          !sameFastTravelName(location.name, originalName)),
+    );
+  };
+
+  const saveLocation = async (options: SaveOptions): Promise<void> => {
+    if (saving() || !formSubmittable()) {
+      return;
+    }
+
+    const draft = normalizeForm();
+    if (!draft) {
+      return;
+    }
+
+    if (duplicateNameInCurrentList(draft)) {
+      setFieldError("name");
+      setDialogError("A location with this name already exists.");
+      return;
+    }
+
+    setSaving(true);
+    setFieldError(null);
+    setDialogError("");
+    try {
+      const nextLocations =
+        dialogMode() === "edit"
+          ? await window.ipc.fastTravels.update(editingOriginalName(), draft)
+          : await window.ipc.fastTravels.create(draft);
+      setLocations(nextLocations);
+      if (options.closeAfterSave || dialogMode() === "edit") {
+        setDialogOpen(false);
+      } else {
+        setForm(emptyForm());
+        window.requestAnimationFrame(() => {
+          nameInput?.focus();
+        });
+      }
+    } catch (cause) {
+      const message = operationErrorMessage(
+        cause,
+        dialogMode() === "edit"
+          ? "Failed to update location."
+          : "Failed to add location.",
+      );
+      setDialogError(message);
+      if (message.toLowerCase().includes("exists")) {
+        setFieldError("name");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteLocation = async (): Promise<void> => {
+    const location = pendingDelete();
+    if (!location) {
+      return;
+    }
+
+    setDeleting(true);
+    setError("");
+    try {
+      const nextLocations = await window.ipc.fastTravels.delete(location.name);
+      setLocations(nextLocations);
+      setPendingDelete(null);
+    } catch (cause) {
+      setError(operationErrorMessage(cause, "Failed to delete location."));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const warpToLocation = async (location: FastTravel): Promise<void> => {
+    if (warpingName() !== null) {
+      return;
+    }
+
+    setWarpingName(location.name);
+    setError("");
+    try {
+      await window.ipc.fastTravels.warp({
+        location,
+        ...(useRoomNumber() ? { roomNumber: normalizedRoomNumber() } : {}),
+      });
+    } catch (cause) {
+      setError(operationErrorMessage(cause, "Fast travel failed."));
+    } finally {
+      setWarpingName(null);
+    }
+  };
+
+  onMount(() => {
+    const unsubscribe = window.ipc.fastTravels.onChanged(setLocations);
+    void window.ipc.fastTravels
+      .getAll()
+      .then(setLocations)
+      .catch((cause) => {
+        console.error("Failed to load fast travels:", cause);
+        setError(operationErrorMessage(cause, "Failed to load locations."));
+      })
+      .finally(() => setLoading(false));
+
+    onCleanup(unsubscribe);
+  });
+
+  return (
+    <AppShell class="fast-travels-app">
+      <AppShellHeader class="fast-travels-header">
+        <AppShellHeaderLeft>
+          <AppShellTitle>Fast Travels</AppShellTitle>
+        </AppShellHeaderLeft>
+        <AppShellHeaderRight class="fast-travels-header__actions">
+          <Button size="sm" type="button" onClick={openCreateDialog}>
+            <Icon icon="plus" class="button__icon" />
+            Add Location
+          </Button>
+        </AppShellHeaderRight>
+      </AppShellHeader>
+
+      <AppShellBody class="fast-travels-body">
+        <div class="fast-travels-shell">
+          <Show when={error()}>
+            {(message) => (
+              <Alert class="fast-travels-error" variant="error">
+                <AlertDescription class="fast-travels-error__message">
+                  <Icon icon="circle_alert" aria-hidden="true" />
+                  {message()}
+                </AlertDescription>
+              </Alert>
+            )}
+          </Show>
+
+          <div class="fast-travels-toolbar">
+            <InputGroup class="fast-travels-search">
+              <InputGroupAddon>
+                <Icon icon="search" aria-hidden="true" />
+              </InputGroupAddon>
+              <InputGroupInput
+                ref={(element) => {
+                  searchInput = element;
+                }}
+                type="text"
+                value={searchQuery()}
+                placeholder="Search locations..."
+                spellcheck={false}
+                onInput={(event) => setSearchQuery(event.currentTarget.value)}
+              />
+              <InputGroupAddon
+                align="inline-end"
+                class="fast-travels-search__shortcut"
+              >
+                <Kbd>/</Kbd>
+              </InputGroupAddon>
+            </InputGroup>
+
+            <div
+              class="fast-travels-room"
+              data-enabled={useRoomNumber() ? "true" : "false"}
+            >
+              <Switch
+                aria-label="Use room number"
+                class="fast-travels-room__switch"
+                size="sm"
+                checked={useRoomNumber()}
+                onChange={(event) =>
+                  setUseRoomNumber(event.currentTarget.checked)
+                }
+              >
+                Use room number
+              </Switch>
+              <Input
+                class="fast-travels-room__input"
+                type="number"
+                min="1"
+                max={String(MAX_FAST_TRAVEL_ROOM_NUMBER)}
+                value={roomNumber()}
+                disabled={!useRoomNumber()}
+                aria-label="Room number"
+                onInput={(event) => setRoomNumber(event.currentTarget.value)}
+                onBlur={() => setRoomNumber(String(normalizedRoomNumber()))}
+              />
+            </div>
+          </div>
+
+          <CardFrame class="fast-travels-panel">
+            <CardFrameHeader class="fast-travels-panel__header">
+              <div class="fast-travels-panel__title-group">
+                <CardFrameTitle class="fast-travels-panel__title">
+                  Locations
+                </CardFrameTitle>
+              </div>
+            </CardFrameHeader>
+            <Card class="fast-travels-panel__body">
+              <CardContent class="fast-travels-list">
+                <Show
+                  when={!loading()}
+                  fallback={
+                    <div class="fast-travels-empty">
+                      <Spinner size="lg" />
+                      <span>Loading locations...</span>
+                    </div>
+                  }
+                >
+                  <Show
+                    when={filteredLocations().length > 0}
+                    fallback={
+                      <div class="fast-travels-empty">
+                        {searchQuery().trim()
+                          ? "No matching locations"
+                          : "No saved locations"}
+                      </div>
+                    }
+                  >
+                    <div class="fast-travels-grid">
+                      <For each={filteredLocations()}>
+                        {(location) => {
+                          const busy = () => warpingName() !== null;
+                          const thisLocationBusy = () =>
+                            warpingName() !== null &&
+                            sameFastTravelName(
+                              warpingName() ?? "",
+                              location.name,
+                            );
+
+                          return (
+                            <div
+                              class="fast-travels-location"
+                              aria-disabled={busy() ? "true" : undefined}
+                            >
+                              <button
+                                class="fast-travels-location__warp"
+                                type="button"
+                                disabled={busy()}
+                                aria-label={`Warp to ${location.name}`}
+                                onClick={() => void warpToLocation(location)}
+                              >
+                                <div class="fast-travels-location__main">
+                                  <div class="fast-travels-location__name">
+                                    {location.name}
+                                  </div>
+                                  <div class="fast-travels-location__meta">
+                                    {locationSubtitle(location)}
+                                  </div>
+                                </div>
+                                <span
+                                  class="fast-travels-location__warp-affordance"
+                                  aria-hidden="true"
+                                >
+                                  <Show
+                                    when={thisLocationBusy()}
+                                    fallback={
+                                      <>
+                                        <Icon icon="play" />
+                                        <span>Warp</span>
+                                      </>
+                                    }
+                                  >
+                                    <Spinner size="sm" />
+                                  </Show>
+                                </span>
+                              </button>
+                              <div class="fast-travels-location__actions">
+                                <TooltipIconButton
+                                  aria-label={`Edit ${location.name}`}
+                                  tooltip="Edit"
+                                  disabled={busy()}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    openEditDialog(location);
+                                  }}
+                                >
+                                  <Icon icon="pencil" class="button__icon" />
+                                </TooltipIconButton>
+                                <TooltipIconButton
+                                  aria-label={`Delete ${location.name}`}
+                                  class="fast-travels-location__delete"
+                                  tooltip="Delete"
+                                  disabled={busy()}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setPendingDelete(location);
+                                  }}
+                                >
+                                  <Icon icon="trash_2" class="button__icon" />
+                                </TooltipIconButton>
+                              </div>
+                            </div>
+                          );
+                        }}
+                      </For>
+                    </div>
+                  </Show>
+                </Show>
+              </CardContent>
+            </Card>
+          </CardFrame>
+        </div>
+      </AppShellBody>
+
+      <Dialog
+        open={dialogOpen()}
+        onOpenChange={(details) => {
+          if (details.open) {
+            setDialogOpen(true);
+          } else {
+            closeDialog();
+          }
+        }}
+      >
+        <DialogContent class="fast-travels-dialog">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogMode() === "edit" ? "Edit Location" : "Add Location"}
+            </DialogTitle>
+          </DialogHeader>
+          <form
+            class="fast-travels-form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void saveLocation({ closeAfterSave: true });
+            }}
+          >
+            <Show when={dialogError()}>
+              {(message) => (
+                <Alert class="fast-travels-dialog__error" variant="error">
+                  <AlertDescription class="fast-travels-error__message">
+                    <Icon icon="circle_alert" aria-hidden="true" />
+                    {message()}
+                  </AlertDescription>
+                </Alert>
+              )}
+            </Show>
+
+            <div class="fast-travels-form__grid">
+              <FormField
+                for="fast-travel-name"
+                label="Name"
+                error={fieldError() === "name"}
+              >
+                <Input
+                  id="fast-travel-name"
+                  ref={(element) => {
+                    nameInput = element;
+                  }}
+                  fullWidth
+                  value={form().name}
+                  invalid={fieldError() === "name"}
+                  disabled={saving()}
+                  placeholder="Escherion"
+                  onInput={(event) =>
+                    setFormField("name", event.currentTarget.value)
+                  }
+                />
+              </FormField>
+
+              <FormField
+                for="fast-travel-map"
+                label="Map"
+                error={fieldError() === "map"}
+              >
+                <Input
+                  id="fast-travel-map"
+                  fullWidth
+                  value={form().map}
+                  invalid={fieldError() === "map"}
+                  disabled={saving()}
+                  placeholder="escherion"
+                  onInput={(event) =>
+                    setFormField("map", event.currentTarget.value)
+                  }
+                />
+              </FormField>
+
+              <FormField for="fast-travel-cell" label="Cell" optional>
+                <Input
+                  id="fast-travel-cell"
+                  fullWidth
+                  value={form().cell}
+                  disabled={saving()}
+                  placeholder="Boss"
+                  onInput={(event) =>
+                    setFormField("cell", event.currentTarget.value)
+                  }
+                />
+              </FormField>
+
+              <FormField for="fast-travel-pad" label="Pad" optional>
+                <Input
+                  id="fast-travel-pad"
+                  fullWidth
+                  value={form().pad}
+                  disabled={saving()}
+                  placeholder="Left"
+                  onInput={(event) =>
+                    setFormField("pad", event.currentTarget.value)
+                  }
+                />
+              </FormField>
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={saving()}
+                onClick={closeDialog}
+              >
+                Cancel
+              </Button>
+              <Show when={dialogMode() === "create"}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  loading={saving()}
+                  disabled={!formSubmittable()}
+                  onClick={() => void saveLocation({ closeAfterSave: false })}
+                >
+                  Add Another
+                </Button>
+              </Show>
+              <Button
+                type="submit"
+                loading={saving()}
+                disabled={!formSubmittable()}
+              >
+                {dialogMode() === "edit" ? "Update" : "Add Location"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog
+        open={pendingDelete() !== null}
+        onOpenChange={(details) => {
+          if (!details.open && !deleting()) {
+            setPendingDelete(null);
+          }
+        }}
+      >
+        <AlertDialogContent class="fast-travels-dialog">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Location</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete {pendingDelete()?.name ?? "this location"} from Fast
+              Travels?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting()}>Cancel</AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deleting()}
+              onClick={() => void deleteLocation()}
+            >
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AppShell>
+  );
+}
+
+mountWindow(() => <App />);

--- a/app/src/renderer/windows/fast-travels/style.css
+++ b/app/src/renderer/windows/fast-travels/style.css
@@ -1,0 +1,450 @@
+.fast-travels-app {
+  --fast-travels-gap: 0.75rem;
+  --fast-travels-row-min: 4.5rem;
+}
+
+.fast-travels-header .app-shell__header-layout {
+  align-items: center;
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
+}
+
+.fast-travels-header__actions {
+  justify-self: end;
+  min-width: 0;
+}
+
+.fast-travels-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: clamp(0.75rem, 1.5vw, 1rem);
+}
+
+.fast-travels-shell {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--fast-travels-gap);
+  min-height: 0;
+  min-width: 0;
+  padding-bottom: 0.75rem;
+}
+
+.fast-travels-error.alert,
+.fast-travels-dialog__error.alert {
+  border-radius: var(--radius-md);
+  color: rgb(var(--destructive));
+  padding: 0.625rem 0.75rem;
+}
+
+.fast-travels-error__message.alert__description {
+  align-items: flex-start;
+  color: inherit;
+  display: flex;
+  font-size: var(--text-sm);
+  gap: 0.5rem;
+  line-height: 1.35;
+  min-width: 0;
+}
+
+.fast-travels-error__message svg {
+  flex: 0 0 auto;
+  height: 1rem;
+  margin-top: 0.0625rem;
+  width: 1rem;
+}
+
+.fast-travels-toolbar {
+  display: grid;
+  gap: 0.625rem;
+  grid-template-columns: minmax(0, 1fr);
+  min-width: 0;
+}
+
+.fast-travels-search {
+  min-width: 0;
+}
+
+.fast-travels-search svg {
+  height: 1rem;
+  opacity: 0.72;
+  width: 1rem;
+}
+
+.fast-travels-search__shortcut {
+  padding-left: 0.25rem !important;
+  padding-right: 0.5rem !important;
+}
+
+.fast-travels-room {
+  align-items: center;
+  display: flex;
+  gap: 0.625rem;
+  min-height: var(--control-height-lg);
+  min-width: 0;
+}
+
+.fast-travels-room__switch {
+  flex: 0 1 auto;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  min-height: 2.5rem;
+  min-width: 0;
+}
+
+.fast-travels-room__switch .switch__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fast-travels-room__input {
+  flex: 0 0 7.25rem;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+  text-align: right;
+  transition:
+    background-color var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    opacity var(--duration-fast) ease;
+  width: 7.25rem;
+}
+
+.fast-travels-room__input[type="number"]::-webkit-inner-spin-button,
+.fast-travels-room__input[type="number"]::-webkit-outer-spin-button {
+  margin-left: 0.25rem;
+  opacity: 0.9;
+}
+
+.fast-travels-room__input:disabled {
+  color: rgb(var(--muted-foreground));
+  opacity: 1;
+}
+
+.fast-travels-room[data-enabled="false"] .fast-travels-room__input {
+  background: rgb(var(--muted) / 0.24);
+  border-color: rgb(var(--border) / 0.72);
+}
+
+.fast-travels-panel {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  max-height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.fast-travels-panel__header {
+  align-items: center;
+  padding: 0.375rem 0.375rem 0.375rem 0.75rem !important;
+}
+
+.fast-travels-panel__title-group {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.fast-travels-panel__title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  letter-spacing: 0;
+}
+
+.fast-travels-panel__body {
+  border: 0;
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  flex: 1 1 0%;
+  margin: 0 -1px 0;
+  min-height: 0;
+  min-width: 0;
+}
+
+.fast-travels-list.card__content {
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+  padding: 0.75rem;
+}
+
+.fast-travels-grid {
+  display: grid;
+  gap: 0.625rem;
+  grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
+  min-width: 0;
+}
+
+.fast-travels-location {
+  align-items: center;
+  background: rgb(var(--card));
+  border-radius: var(--radius-md);
+  box-shadow:
+    inset 0 0 0 1px rgb(var(--border) / 0.72),
+    var(--shadow-xs);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: var(--fast-travels-row-min);
+  min-width: 0;
+  overflow: hidden;
+}
+
+.fast-travels-location[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.fast-travels-location__warp {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: var(--cursor-interactive);
+  display: grid;
+  gap: 0.625rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: var(--fast-travels-row-min);
+  min-width: 0;
+  padding: 0.75rem;
+  text-align: left;
+  transition: background-color var(--duration-fast) ease;
+}
+
+.fast-travels-location__warp:disabled {
+  cursor: not-allowed;
+}
+
+.fast-travels-location__warp:not(:disabled):hover,
+.fast-travels-location__warp:not(:disabled):focus-visible {
+  background: rgb(var(--muted) / 0.38);
+}
+
+.fast-travels-location__warp:not(:disabled):active {
+  background: rgb(var(--muted) / 0.58);
+}
+
+.fast-travels-location__warp:focus-visible {
+  outline: 2px solid rgb(var(--ring));
+  outline-offset: -2px;
+}
+
+.fast-travels-location__main {
+  min-width: 0;
+}
+
+.fast-travels-location__name {
+  color: rgb(var(--foreground));
+  font-size: var(--text-sm);
+  font-weight: 650;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fast-travels-location__meta {
+  color: rgb(var(--muted-foreground));
+  font-size: var(--text-xs);
+  line-height: 1.35;
+  margin-top: 0.1875rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fast-travels-location__warp-affordance {
+  align-items: center;
+  background: rgb(var(--primary) / 0.1);
+  border-radius: var(--radius-sm);
+  box-shadow: inset 0 0 0 1px rgb(var(--primary) / 0.22);
+  color: rgb(var(--primary));
+  display: inline-flex;
+  font-size: var(--text-xs);
+  font-weight: 650;
+  gap: 0.3125rem;
+  height: var(--control-height-md);
+  justify-content: center;
+  min-width: 4rem;
+  opacity: 1;
+  padding: 0 0.5rem;
+  transition:
+    background-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    opacity var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+  white-space: nowrap;
+}
+
+.fast-travels-location__warp-affordance svg {
+  height: 0.875rem;
+  width: 0.875rem;
+}
+
+.fast-travels-location__warp-affordance span {
+  line-height: 1;
+}
+
+.fast-travels-location__warp:not(:disabled):hover
+  .fast-travels-location__warp-affordance,
+.fast-travels-location__warp:not(:disabled):focus-visible
+  .fast-travels-location__warp-affordance {
+  background: rgb(var(--primary));
+  box-shadow: none;
+  color: rgb(var(--primary-foreground));
+  opacity: 1;
+}
+
+.fast-travels-location__warp:not(:disabled):active
+  .fast-travels-location__warp-affordance {
+  transform: scale(0.96);
+}
+
+.fast-travels-location__actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.375rem;
+  padding-right: 0.75rem;
+}
+
+.fast-travels-location__actions .button__icon {
+  height: 1.125rem;
+  width: 1.125rem;
+}
+
+.fast-travels-location__delete.button:not(:disabled):hover {
+  background: rgb(var(--destructive) / 0.1);
+  color: rgb(var(--destructive));
+}
+
+.fast-travels-empty {
+  align-items: center;
+  color: rgb(var(--muted-foreground));
+  display: flex;
+  flex-direction: column;
+  font-size: var(--text-sm);
+  gap: 0.625rem;
+  height: 100%;
+  justify-content: center;
+  min-height: 12rem;
+  text-align: center;
+}
+
+.fast-travels-dialog {
+  max-width: min(92vw, 28rem);
+}
+
+.fast-travels-dialog .dialog__header {
+  padding: 1.5rem 1.5rem 1rem;
+}
+
+.fast-travels-dialog .dialog__close {
+  border-radius: var(--radius-sm);
+  height: var(--control-height-sm);
+  right: 0.625rem;
+  top: 0.625rem;
+  width: var(--control-height-sm);
+}
+
+.fast-travels-dialog .dialog__close .button__icon {
+  height: 1rem;
+  margin: 0;
+  opacity: 0.92;
+  width: 1rem;
+}
+
+.fast-travels-dialog .dialog__title {
+  font-size: var(--text-xl);
+  text-wrap: balance;
+}
+
+.fast-travels-dialog .dialog__footer {
+  padding: 1rem 1.5rem;
+}
+
+.fast-travels-dialog .dialog__footer > .button {
+  min-height: var(--control-height-md);
+}
+
+.fast-travels-form {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.fast-travels-form__grid {
+  display: grid;
+  gap: 0.875rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 0 1.5rem 1.25rem;
+}
+
+.fast-travels-form__field {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.fast-travels-form__field:first-child,
+.fast-travels-form__field:nth-child(2) {
+  grid-column: 1 / -1;
+}
+
+.fast-travels-form__field .label {
+  align-items: center;
+  color: rgb(var(--foreground));
+  display: flex;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  gap: 0.5rem;
+  line-height: 1.2;
+}
+
+.fast-travels-form__optional {
+  color: rgb(var(--muted-foreground));
+  font-size: var(--text-xs);
+  font-weight: 400;
+}
+
+.fast-travels-dialog__error {
+  margin: 0 1.5rem 1rem;
+}
+
+@media (max-width: 40rem) {
+  .fast-travels-form__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .fast-travels-room {
+    max-width: 100%;
+  }
+
+  .fast-travels-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 28rem) {
+  .fast-travels-room {
+    align-self: flex-start;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    max-width: 100%;
+  }
+
+  .fast-travels-room__switch {
+    min-height: 2rem;
+  }
+}

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -850,6 +850,7 @@ export default function App(props: {
     | ReturnType<typeof installPacketsBridge>
     | undefined;
   let autoAttackToggleInFlight = false;
+  let fastTravelRequestChain = Promise.resolve();
   let cleanedUp = false;
   const accountLaunchFibers = new Set<Fiber.Fiber<void, unknown>>();
   const assignDisposer =
@@ -1924,20 +1925,38 @@ export default function App(props: {
       }),
     );
 
-  const handleFastTravelRequest = (
+  const respondFastTravel = (
+    requestId: string,
+    response:
+      | { readonly ok: true }
+      | { readonly ok: false; readonly error: string },
+  ) =>
+    window.ipc.fastTravels.respond({
+      requestId,
+      ...response,
+    });
+
+  const runFastTravelRequest = async (
     request: FastTravelsRequestMessage,
-  ): void => {
+  ): Promise<void> => {
+    if (cleanedUp) {
+      await respondFastTravel(request.requestId, {
+        ok: false,
+        error: "Game window is shutting down",
+      });
+      return;
+    }
+
     if (request.kind !== "warp") {
-      void window.ipc.fastTravels.respond({
-        requestId: request.requestId,
+      await respondFastTravel(request.requestId, {
         ok: false,
         error: `Unsupported fast travel request: ${String(request.kind)}`,
       });
       return;
     }
 
-    void runtime
-      .runPromise(
+    try {
+      await runtime.runPromise(
         Effect.gen(function* () {
           const player = yield* Player;
           const ready = yield* player.isReady();
@@ -1952,25 +1971,32 @@ export default function App(props: {
             location.pad,
           );
         }),
-      )
-      .then(() =>
-        window.ipc.fastTravels.respond({
-          requestId: request.requestId,
-          ok: true,
-        }),
-      )
-      .catch((error: unknown) => {
-        console.error("Fast travel request failed:", error);
-        const message =
-          error instanceof Error && error.message !== ""
-            ? error.message
-            : "Fast travel failed";
-        void window.ipc.fastTravels.respond({
-          requestId: request.requestId,
-          ok: false,
-          error: message,
-        });
+      );
+      await respondFastTravel(request.requestId, { ok: true });
+    } catch (error: unknown) {
+      console.error("Fast travel request failed:", error);
+      const message =
+        error instanceof Error && error.message !== ""
+          ? error.message
+          : "Fast travel failed";
+      await respondFastTravel(request.requestId, {
+        ok: false,
+        error: message,
       });
+    }
+  };
+
+  const handleFastTravelRequest = (
+    request: FastTravelsRequestMessage,
+  ): void => {
+    fastTravelRequestChain = fastTravelRequestChain
+      .catch((error: unknown) => {
+        console.error("Fast travel request chain failed:", error);
+      })
+      .then(() => runFastTravelRequest(request));
+    void fastTravelRequestChain.catch((error: unknown) => {
+      console.error("Fast travel request handling failed:", error);
+    });
   };
 
   onMount(() => {

--- a/app/src/renderer/windows/game/App.tsx
+++ b/app/src/renderer/windows/game/App.tsx
@@ -30,9 +30,11 @@ import {
 } from "../../../shared/combat-profiles";
 import type {
   AccountGameLaunchPayload,
+  FastTravelsRequestMessage,
   FollowerStartPayload,
   ScriptExecutePayload,
 } from "../../../shared/ipc";
+import { fastTravelMapTarget } from "../../../shared/fast-travels";
 import type { WindowId } from "../../../shared/windows";
 import { runtime } from "./Runtime";
 import { installPacketsBridge } from "./packetsBridge";
@@ -1922,6 +1924,55 @@ export default function App(props: {
       }),
     );
 
+  const handleFastTravelRequest = (
+    request: FastTravelsRequestMessage,
+  ): void => {
+    if (request.kind !== "warp") {
+      void window.ipc.fastTravels.respond({
+        requestId: request.requestId,
+        ok: false,
+        error: `Unsupported fast travel request: ${String(request.kind)}`,
+      });
+      return;
+    }
+
+    void runtime
+      .runPromise(
+        Effect.gen(function* () {
+          const player = yield* Player;
+          const ready = yield* player.isReady();
+          if (!ready) {
+            throw new Error("Player is not ready");
+          }
+
+          const { location } = request.payload;
+          yield* player.joinMap(
+            fastTravelMapTarget(request.payload),
+            location.cell,
+            location.pad,
+          );
+        }),
+      )
+      .then(() =>
+        window.ipc.fastTravels.respond({
+          requestId: request.requestId,
+          ok: true,
+        }),
+      )
+      .catch((error: unknown) => {
+        console.error("Fast travel request failed:", error);
+        const message =
+          error instanceof Error && error.message !== ""
+            ? error.message
+            : "Fast travel failed";
+        void window.ipc.fastTravels.respond({
+          requestId: request.requestId,
+          ok: false,
+          error: message,
+        });
+      });
+  };
+
   onMount(() => {
     const unsubscribeAppSettings =
       window.ipc.settings.onChanged(applyAppSettings);
@@ -1957,6 +2008,9 @@ export default function App(props: {
       window.ipc.follower.onStartRequest(startFollower);
     const unsubscribeFollowerStop =
       window.ipc.follower.onStopRequest(stopFollower);
+    const unsubscribeFastTravels = window.ipc.fastTravels.onRequest(
+      handleFastTravelRequest,
+    );
     const packetsBridge = installPacketsBridge(runtime);
     packetsBridgeController = packetsBridge;
     let followerStateDisposer: (() => void) | undefined;
@@ -2091,6 +2145,7 @@ export default function App(props: {
       unsubscribeFollowerMe();
       unsubscribeFollowerStart();
       unsubscribeFollowerStop();
+      unsubscribeFastTravels();
       packetsBridge.dispose();
       packetsBridgeController = undefined;
       followerStateDisposer?.();

--- a/app/src/shared/fast-travels.test.ts
+++ b/app/src/shared/fast-travels.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_FAST_TRAVELS,
+  FastTravelDuplicateNameError,
+  FastTravelNotFoundError,
+  FastTravelValidationError,
+  addFastTravel,
+  deleteFastTravel,
+  fastTravelMapTarget,
+  normalizeFastTravelDraft,
+  normalizeFastTravelRoomNumber,
+  normalizeFastTravelWarpPayload,
+  normalizeFastTravels,
+  updateFastTravel,
+  type FastTravel,
+} from "./fast-travels";
+
+describe("fast travel helpers", () => {
+  it("normalizes drafts", () => {
+    expect(
+      normalizeFastTravelDraft({
+        name: "  Escherion  ",
+        map: "  Escherion ",
+        cell: " Boss ",
+        pad: " Left ",
+      }),
+    ).toEqual({
+      name: "Escherion",
+      map: "escherion",
+      cell: "Boss",
+      pad: "Left",
+    });
+
+    expect(
+      normalizeFastTravelDraft({
+        name: "Home",
+        map: "Battleon",
+        cell: " ",
+        pad: "",
+      }),
+    ).toEqual({ name: "Home", map: "battleon" });
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() =>
+      normalizeFastTravelDraft({ name: "", map: "battleon" }),
+    ).toThrow(FastTravelValidationError);
+    expect(() => normalizeFastTravelDraft({ name: "Home", map: "" })).toThrow(
+      FastTravelValidationError,
+    );
+  });
+
+  it("normalizes stored lists and dedupes names case-insensitively", () => {
+    expect(
+      normalizeFastTravels([
+        { name: "Home", map: "Battleon" },
+        { name: "home", map: "ignored" },
+        { name: "Boss", map: "escherion", cell: "Boss" },
+        { nope: true },
+      ]),
+    ).toEqual([
+      { name: "Home", map: "battleon" },
+      { name: "Boss", map: "escherion", cell: "Boss" },
+    ]);
+
+    expect(normalizeFastTravels([])).toEqual([]);
+    expect(normalizeFastTravels("nope")).toEqual(DEFAULT_FAST_TRAVELS);
+  });
+
+  it("adds, updates, and deletes locations predictably", () => {
+    const initial: readonly FastTravel[] = [
+      { name: "Home", map: "battleon" },
+      { name: "Boss", map: "escherion" },
+    ];
+
+    expect(addFastTravel(initial, { name: "Dage", map: "Underworld" })).toEqual(
+      [
+        { name: "Home", map: "battleon" },
+        { name: "Boss", map: "escherion" },
+        { name: "Dage", map: "underworld" },
+      ],
+    );
+    expect(() =>
+      addFastTravel(initial, { name: "home", map: "other" }),
+    ).toThrow(FastTravelDuplicateNameError);
+
+    expect(
+      updateFastTravel(initial, "home", {
+        name: "Spawn",
+        map: "Battleon",
+      }),
+    ).toEqual([
+      { name: "Spawn", map: "battleon" },
+      { name: "Boss", map: "escherion" },
+    ]);
+    expect(() =>
+      updateFastTravel(initial, "missing", { name: "Other", map: "other" }),
+    ).toThrow(FastTravelNotFoundError);
+    expect(() =>
+      updateFastTravel(initial, "home", { name: "boss", map: "other" }),
+    ).toThrow(FastTravelDuplicateNameError);
+
+    expect(deleteFastTravel(initial, "BOSS")).toEqual([
+      { name: "Home", map: "battleon" },
+    ]);
+    expect(() => deleteFastTravel(initial, "missing")).toThrow(
+      FastTravelNotFoundError,
+    );
+  });
+
+  it("normalizes room numbers and warp targets", () => {
+    expect(normalizeFastTravelRoomNumber("12")).toBe(12);
+    expect(normalizeFastTravelRoomNumber(0)).toBe(1);
+    expect(normalizeFastTravelRoomNumber(500_000)).toBe(100_000);
+    expect(normalizeFastTravelRoomNumber("nope")).toBeUndefined();
+
+    expect(
+      fastTravelMapTarget(
+        normalizeFastTravelWarpPayload({
+          location: { name: "Home", map: "Battleon" },
+          roomNumber: 123,
+        }),
+      ),
+    ).toBe("battleon-123");
+    expect(
+      fastTravelMapTarget({
+        location: { name: "Home", map: "battleon" },
+      }),
+    ).toBe("battleon");
+  });
+});

--- a/app/src/shared/fast-travels.ts
+++ b/app/src/shared/fast-travels.ts
@@ -1,0 +1,293 @@
+export interface FastTravel {
+  readonly name: string;
+  readonly map: string;
+  readonly cell?: string;
+  readonly pad?: string;
+}
+
+export interface FastTravelDraft {
+  readonly name: string;
+  readonly map: string;
+  readonly cell?: string;
+  readonly pad?: string;
+}
+
+export interface FastTravelWarpPayload {
+  readonly location: FastTravel;
+  readonly roomNumber?: number;
+}
+
+export const MIN_FAST_TRAVEL_ROOM_NUMBER = 1;
+export const MAX_FAST_TRAVEL_ROOM_NUMBER = 100_000;
+
+export const DEFAULT_FAST_TRAVELS: readonly FastTravel[] = [
+  { name: "Oblivion", map: "tercessuinotlim", cell: "Enter", pad: "Spawn" },
+  {
+    name: "Twins",
+    map: "tercessuinotlim",
+    cell: "Twins",
+    pad: "Left",
+  },
+  {
+    name: "VHL/Taro/Zee",
+    map: "tercessuinotlim",
+    cell: "Taro",
+    pad: "Left",
+  },
+  {
+    name: "Swindle",
+    map: "tercessuinotlim",
+    cell: "Swindle",
+    pad: "Left",
+  },
+  {
+    name: "Nulgath/Skew",
+    map: "tercessuinotlim",
+    cell: "Boss2",
+    pad: "Right",
+  },
+  {
+    name: "Polish",
+    map: "tercessuinotlim",
+    cell: "m12",
+    pad: "Top",
+  },
+  {
+    name: "Carnage/Ninja",
+    map: "tercessuinotlim",
+    cell: "m4",
+    pad: "Top",
+  },
+  {
+    name: "Binky",
+    map: "doomvault",
+    cell: "r5",
+    pad: "Left",
+  },
+  {
+    name: "Dage",
+    map: "underworld",
+    cell: "s1",
+    pad: "Left",
+  },
+  {
+    name: "Escherion",
+    map: "escherion",
+    cell: "Boss",
+    pad: "Left",
+  },
+];
+
+export class FastTravelValidationError extends Error {
+  constructor(
+    message: string,
+    readonly field: "name" | "map",
+  ) {
+    super(message);
+    this.name = "FastTravelValidationError";
+  }
+}
+
+export class FastTravelDuplicateNameError extends Error {
+  constructor(readonly locationName: string) {
+    super(`Fast travel location already exists: ${locationName}`);
+    this.name = "FastTravelDuplicateNameError";
+  }
+}
+
+export class FastTravelNotFoundError extends Error {
+  constructor(readonly locationName: string) {
+    super(`Fast travel location not found: ${locationName}`);
+    this.name = "FastTravelNotFoundError";
+  }
+}
+
+const normalizeKey = (value: string): string => value.trim().toLowerCase();
+
+const optionalTrimmed = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : undefined;
+
+export const sameFastTravelName = (left: string, right: string): boolean =>
+  normalizeKey(left) === normalizeKey(right);
+
+export const cloneDefaultFastTravels = (): FastTravel[] =>
+  DEFAULT_FAST_TRAVELS.map((location) => ({ ...location }));
+
+export const normalizeFastTravelDraft = (draft: unknown): FastTravel => {
+  const record =
+    typeof draft === "object" && draft !== null
+      ? (draft as Partial<FastTravelDraft>)
+      : {};
+  const name = typeof record.name === "string" ? record.name.trim() : "";
+  if (name === "") {
+    throw new FastTravelValidationError("Location name is required", "name");
+  }
+
+  const map =
+    typeof record.map === "string" ? record.map.trim().toLowerCase() : "";
+  if (map === "") {
+    throw new FastTravelValidationError("Map is required", "map");
+  }
+
+  const cell = optionalTrimmed(record.cell);
+  const pad = optionalTrimmed(record.pad);
+
+  return {
+    name,
+    map,
+    ...(cell === undefined ? {} : { cell }),
+    ...(pad === undefined ? {} : { pad }),
+  };
+};
+
+export const normalizeFastTravels = (value: unknown): FastTravel[] => {
+  if (!Array.isArray(value)) {
+    return cloneDefaultFastTravels();
+  }
+
+  const locations: FastTravel[] = [];
+  const names = new Set<string>();
+
+  for (const item of value) {
+    if (typeof item !== "object" || item === null) {
+      continue;
+    }
+
+    const record = item as Partial<FastTravel>;
+    if (typeof record.name !== "string" || typeof record.map !== "string") {
+      continue;
+    }
+
+    let location: FastTravel;
+    try {
+      location = normalizeFastTravelDraft({
+        name: record.name,
+        map: record.map,
+        ...(typeof record.cell === "string" ? { cell: record.cell } : {}),
+        ...(typeof record.pad === "string" ? { pad: record.pad } : {}),
+      });
+    } catch {
+      continue;
+    }
+
+    const key = normalizeKey(location.name);
+    if (names.has(key)) {
+      continue;
+    }
+
+    names.add(key);
+    locations.push(location);
+  }
+
+  return locations;
+};
+
+export const addFastTravel = (
+  locations: readonly FastTravel[],
+  draft: FastTravelDraft,
+): FastTravel[] => {
+  const location = normalizeFastTravelDraft(draft);
+  if (
+    locations.some((candidate) =>
+      sameFastTravelName(candidate.name, location.name),
+    )
+  ) {
+    throw new FastTravelDuplicateNameError(location.name);
+  }
+
+  return [...locations, location];
+};
+
+export const updateFastTravel = (
+  locations: readonly FastTravel[],
+  originalName: string,
+  draft: FastTravelDraft,
+): FastTravel[] => {
+  const index = locations.findIndex((location) =>
+    sameFastTravelName(location.name, originalName),
+  );
+  if (index === -1) {
+    throw new FastTravelNotFoundError(originalName);
+  }
+
+  const location = normalizeFastTravelDraft(draft);
+  const duplicate = locations.some(
+    (candidate, candidateIndex) =>
+      candidateIndex !== index &&
+      sameFastTravelName(candidate.name, location.name),
+  );
+  if (duplicate) {
+    throw new FastTravelDuplicateNameError(location.name);
+  }
+
+  return locations.map((candidate, candidateIndex) =>
+    candidateIndex === index ? location : candidate,
+  );
+};
+
+export const deleteFastTravel = (
+  locations: readonly FastTravel[],
+  name: string,
+): FastTravel[] => {
+  const next = locations.filter(
+    (location) => !sameFastTravelName(location.name, name),
+  );
+  if (next.length === locations.length) {
+    throw new FastTravelNotFoundError(name);
+  }
+
+  return next;
+};
+
+export const normalizeFastTravelRoomNumber = (
+  value: unknown,
+): number | undefined => {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim() !== ""
+        ? Number(value)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed)) {
+    return undefined;
+  }
+
+  const room = Math.trunc(parsed);
+  return Math.min(
+    MAX_FAST_TRAVEL_ROOM_NUMBER,
+    Math.max(MIN_FAST_TRAVEL_ROOM_NUMBER, room),
+  );
+};
+
+export const normalizeFastTravelWarpPayload = (
+  payload: unknown,
+): FastTravelWarpPayload => {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("Fast travel payload is required");
+  }
+
+  const record = payload as {
+    readonly location?: FastTravelDraft;
+    readonly roomNumber?: unknown;
+  };
+
+  const roomNumber = normalizeFastTravelRoomNumber(record.roomNumber);
+
+  return {
+    location: normalizeFastTravelDraft(
+      record.location ?? {
+        name: "",
+        map: "",
+      },
+    ),
+    ...(roomNumber === undefined ? {} : { roomNumber }),
+  };
+};
+
+export const fastTravelMapTarget = (payload: FastTravelWarpPayload): string => {
+  const roomNumber = normalizeFastTravelRoomNumber(payload.roomNumber);
+  return roomNumber === undefined
+    ? payload.location.map
+    : `${payload.location.map}-${roomNumber}`;
+};

--- a/app/src/shared/ipc.ts
+++ b/app/src/shared/ipc.ts
@@ -19,6 +19,11 @@ import type {
   EnvironmentQuestAutoRegisterOptions,
   EnvironmentState,
 } from "./environment";
+import type {
+  FastTravel,
+  FastTravelDraft,
+  FastTravelWarpPayload,
+} from "./fast-travels";
 import type { FollowerStartPayload, FollowerState } from "./follower";
 import type {
   PacketCapturedPayload,
@@ -85,6 +90,12 @@ export type {
   EnvironmentQuestAutoRegisterOptions,
   EnvironmentState,
 } from "./environment";
+
+export type {
+  FastTravel,
+  FastTravelDraft,
+  FastTravelWarpPayload,
+} from "./fast-travels";
 
 export type {
   FollowerConfig,
@@ -183,6 +194,17 @@ export const EnvironmentIpcChannels = {
   changed: "environment:changed",
 } as const;
 
+export const FastTravelsIpcChannels = {
+  getAll: "fast-travels:get-all",
+  create: "fast-travels:create",
+  update: "fast-travels:update",
+  delete: "fast-travels:delete",
+  warp: "fast-travels:warp",
+  changed: "fast-travels:changed",
+  request: "fast-travels:request",
+  response: "fast-travels:response",
+} as const;
+
 export const CombatProfilesIpcChannels = {
   getState: "combat-profiles:get-state",
   saveProfile: "combat-profiles:save-profile",
@@ -236,6 +258,8 @@ export type PacketsRequestKind =
   | "startQueue"
   | "stopQueue";
 
+export type FastTravelsRequestKind = "warp";
+
 export interface FollowerRequestMessage {
   readonly requestId: string;
   readonly kind: FollowerRequestKind;
@@ -261,6 +285,23 @@ export interface PacketsRequestMessage {
 }
 
 export type PacketsResponseMessage =
+  | {
+      readonly requestId: string;
+      readonly ok: true;
+    }
+  | {
+      readonly error: string;
+      readonly ok: false;
+      readonly requestId: string;
+    };
+
+export interface FastTravelsRequestMessage {
+  readonly requestId: string;
+  readonly kind: FastTravelsRequestKind;
+  readonly payload: FastTravelWarpPayload;
+}
+
+export type FastTravelsResponseMessage =
   | {
       readonly requestId: string;
       readonly ok: true;
@@ -716,6 +757,56 @@ export interface EnvironmentBridge {
   ): () => void;
 }
 
+export interface FastTravelsInvokeChannels {
+  readonly [FastTravelsIpcChannels.getAll]: IpcInvokeDefinition<
+    [],
+    readonly FastTravel[]
+  >;
+  readonly [FastTravelsIpcChannels.create]: IpcInvokeDefinition<
+    [draft: FastTravelDraft],
+    readonly FastTravel[]
+  >;
+  readonly [FastTravelsIpcChannels.update]: IpcInvokeDefinition<
+    [originalName: string, draft: FastTravelDraft],
+    readonly FastTravel[]
+  >;
+  readonly [FastTravelsIpcChannels.delete]: IpcInvokeDefinition<
+    [name: string],
+    readonly FastTravel[]
+  >;
+  readonly [FastTravelsIpcChannels.warp]: IpcInvokeDefinition<
+    [payload: FastTravelWarpPayload],
+    void
+  >;
+}
+
+export interface FastTravelsRendererEventChannels {
+  readonly [FastTravelsIpcChannels.changed]: [locations: readonly FastTravel[]];
+  readonly [FastTravelsIpcChannels.request]: [
+    request: FastTravelsRequestMessage,
+  ];
+}
+
+export interface FastTravelsMainEventChannels {
+  readonly [FastTravelsIpcChannels.response]: [
+    response: FastTravelsResponseMessage,
+  ];
+}
+
+export interface FastTravelsBridge {
+  getAll(): Promise<readonly FastTravel[]>;
+  create(draft: FastTravelDraft): Promise<readonly FastTravel[]>;
+  update(
+    originalName: string,
+    draft: FastTravelDraft,
+  ): Promise<readonly FastTravel[]>;
+  delete(name: string): Promise<readonly FastTravel[]>;
+  warp(payload: FastTravelWarpPayload): Promise<void>;
+  onChanged(listener: (locations: readonly FastTravel[]) => void): () => void;
+  onRequest(listener: (request: FastTravelsRequestMessage) => void): () => void;
+  respond(response: FastTravelsResponseMessage): Promise<void>;
+}
+
 export interface CombatProfilesInvokeChannels {
   readonly [CombatProfilesIpcChannels.getState]: IpcInvokeDefinition<
     [],
@@ -864,6 +955,7 @@ export interface AppBridge {
   readonly army: ArmyBridge;
   readonly combatProfiles: CombatProfilesBridge;
   readonly environment: EnvironmentBridge;
+  readonly fastTravels: FastTravelsBridge;
   readonly follower: FollowerBridge;
   readonly observability: ObservabilityBridge;
   readonly packets: PacketsBridge;


### PR DESCRIPTION
## Summary
- add persisted fast-travel locations with defaults and validation
- wire fast-travels IPC between the window, main process, preload bridge, and game runtime
- replace the placeholder fast-travels window with a searchable Solid UI for adding, editing, deleting, and warping to locations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Fast Travels feature enabling players to save frequently visited game locations and warp to them instantly. Supports creating, editing, and deleting saved locations with optional room number customization. Search functionality accessible via "/" keyboard shortcut. All saved locations persist across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->