### PR TITLE
fix(docs): contain overscroll in docs UI

### DIFF
--- a/docs/src/components/Search.astro
+++ b/docs/src/components/Search.astro
@@ -305,6 +305,7 @@ if (project.trailingSlash === 'never') dataAttributes['data-strip-trailing-slash
     .dialog-frame {
         position: relative;
         overflow: auto;
+        overscroll-behavior: contain;
         flex-direction: column;
         flex-grow: 1;
         gap: 1rem;

--- a/docs/src/components/Sidebar.astro
+++ b/docs/src/components/Sidebar.astro
@@ -249,6 +249,7 @@ const { sidebar } = Astro.locals.starlightRoute;
         display: flex;
         overflow-x: hidden;
         overflow-y: auto;
+        overscroll-behavior-y: contain;
         scrollbar-width: none;
         flex: 1;
         min-height: 0;

--- a/docs/src/components/parts/Drawer.astro
+++ b/docs/src/components/parts/Drawer.astro
@@ -151,6 +151,7 @@ const currentPath = Astro.url.pathname;
     .body {
         height: 100%;
         overflow-y: auto;
+        overscroll-behavior-y: contain;
         padding: 1.5rem;
     }
 

--- a/docs/src/styles/base.css
+++ b/docs/src/styles/base.css
@@ -61,6 +61,7 @@
         overflow-y: scroll;
         scrollbar-gutter: stable;
         background: var(--background);
+        overscroll-behavior-y: none;
     }
 
     /* ::view-transition-old(root),
@@ -116,6 +117,7 @@
     body {
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
+        overscroll-behavior-y: none;
     }
 
     :is(


### PR DESCRIPTION
## Summary
- Disable vertical overscroll on the docs page root to prevent edge bounce at the top and bottom of long pages.
- Contain scroll momentum inside nested docs panels such as the sidebar, mobile drawer, and search dialog.

## Root Cause
Trackpad and wheel momentum could continue past the scroll boundary and propagate into the page viewport, making the docs layout bob when scrolling beyond the first or last scroll position.

## Impact
Scrolling now stops predictably at content boundaries while preserving normal scrolling inside the docs navigation and modal panels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined scroll behavior across dialog, sidebar, and drawer components to contain scroll effects within these interactive elements and eliminate unwanted scroll chaining between components.
  * Disabled vertical overscroll behavior at the page level to deliver a smoother, more polished scrolling experience throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->