### PR TITLE
fix(topnav): organize windows menu sections

### DIFF
--- a/app/src/renderer/windows/game/style.css
+++ b/app/src/renderer/windows/game/style.css
@@ -366,7 +366,7 @@
 }
 
 .game-menu--mega {
-    min-width: min(30rem, calc(100vw - 1rem));
+    min-width: min(42rem, calc(100vw - 1rem));
 }
 
 .game-menu--scripts {
@@ -463,7 +463,7 @@
 .game-menu__mega-grid {
     display: grid;
     gap: 0.375rem;
-    grid-template-columns: repeat(2, minmax(12rem, 1fr));
+    grid-template-columns: repeat(3, minmax(9rem, 1fr));
 }
 
 .game-menu__group {

--- a/app/src/shared/windows.ts
+++ b/app/src/shared/windows.ts
@@ -66,7 +66,7 @@ export const appWindowGroups: readonly WindowGroup[] = [
 
 export const gameWindowGroups: readonly WindowGroup[] = [
   {
-    name: "Tools",
+    name: "Application",
     items: [
       {
         id: WindowIds.Skills,
@@ -81,6 +81,11 @@ export const gameWindowGroups: readonly WindowGroup[] = [
           minHeight: 500,
         },
       },
+    ],
+  },
+  {
+    name: "Tools",
+    items: [
       {
         id: WindowIds.Environment,
         label: "Environment",


### PR DESCRIPTION
## Summary

- move Skills into a new first Application section in the Windows menu
- keep Tools focused on gameplay helper windows
- render the Windows mega menu as three columns so sections align in one row