### PR TITLE
fix: stabilize scripted combat and map transitions

### DIFF
--- a/app/src/renderer/windows/game/flash/Layers/Combat.test.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Combat.test.ts
@@ -975,3 +975,119 @@ test("kill restores the starting combat cell and pad after respawn", async () =>
     calls.filter((call) => call === "combat.attackMonsterById:7"),
   ).toHaveLength(2);
 });
+
+test("kill switches to a respawned priority target before waiting on skill readiness", async () => {
+  const calls: string[] = [];
+  const avatar = new Avatar(avatarData());
+  const boss = new Monster(
+    monsterData({
+      monMapId: 7,
+      strMonName: "Nulgath the Archfiend",
+    }),
+  );
+  const blade = new Monster(
+    monsterData({
+      intHP: 0,
+      intState: EntityState.Dead,
+      monMapId: 8,
+      strMonName: "Overfiend Blade",
+    }),
+  );
+
+  const world = makeKillWorld(avatar, boss);
+  const twoMonsterWorld = {
+    ...world,
+    monsters: {
+      ...world.monsters,
+      getAll: () =>
+        Effect.succeed(
+          new Collection([
+            [boss.monMapId, boss],
+            [blade.monMapId, blade],
+          ]),
+        ),
+      get: (monMapId: number) =>
+        Effect.succeed(
+          monMapId === boss.monMapId
+            ? Option.some(boss)
+            : monMapId === blade.monMapId
+              ? Option.some(blade)
+              : Option.none(),
+        ),
+    },
+  } satisfies WorldShape;
+
+  const bridge: BridgeShape = {
+    call<K extends keyof Window["swf"]>(
+      path: K,
+      args?: Parameters<Window["swf"][K]>,
+    ) {
+      if (path === "combat.attackMonsterById") {
+        const monMapId = Number(args?.[0]);
+        calls.push(`combat.attackMonsterById:${monMapId}`);
+
+        if (monMapId === boss.monMapId) {
+          blade.data.intHP = blade.data.intHPMax;
+          blade.data.intState = EntityState.Idle;
+        } else if (monMapId === blade.monMapId) {
+          boss.data.intHP = 0;
+          boss.data.intState = EntityState.Dead;
+        }
+
+        return Effect.void as Effect.Effect<ReturnType<Window["swf"][K]>>;
+      }
+
+      if (path === "combat.getTarget") {
+        calls.push("combat.getTarget");
+        return Effect.succeed(null) as Effect.Effect<
+          ReturnType<Window["swf"][K]>
+        >;
+      }
+
+      if (path === "combat.getSkillCooldownRemaining") {
+        calls.push("combat.getSkillCooldownRemaining");
+        return Effect.succeed(0) as Effect.Effect<ReturnType<Window["swf"][K]>>;
+      }
+
+      if (path === "combat.useSkill") {
+        calls.push(`combat.useSkill:${String(args?.[0])}`);
+        return Effect.void as Effect.Effect<ReturnType<Window["swf"][K]>>;
+      }
+
+      if (
+        path === "combat.cancelAutoAttack" ||
+        path === "combat.cancelTarget"
+      ) {
+        calls.push(path);
+        return Effect.void as Effect.Effect<ReturnType<Window["swf"][K]>>;
+      }
+
+      throw new Error(`unexpected bridge call: ${String(path)}`);
+    },
+    callGameFunction() {
+      return Effect.void;
+    },
+    onConnection() {
+      return Effect.succeed(() => undefined);
+    },
+  };
+
+  await withCombat(
+    bridge,
+    (combat) =>
+      combat.kill("Nulgath the Archfiend", {
+        killPriority: ["Overfiend Blade"],
+        skillDelay: 0,
+        skillSet: [1],
+        skillWait: true,
+      }),
+    { world: twoMonsterWorld },
+  );
+
+  expect(calls.indexOf("combat.attackMonsterById:7")).toBeLessThan(
+    calls.indexOf("combat.attackMonsterById:8"),
+  );
+  expect(calls.indexOf("combat.useSkill:1")).toBeGreaterThan(
+    calls.indexOf("combat.attackMonsterById:8"),
+  );
+});

--- a/app/src/renderer/windows/game/flash/Layers/Combat.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Combat.ts
@@ -15,6 +15,7 @@ import { expiresAtMs as antiCounterExpiresAtMs } from "../antiCounter";
 const DEFAULT_SKILL_ROTATION: readonly Skill[] = [1, 2, 3, 4];
 const DEFAULT_SKILL_DELAY_MS = 150;
 const ANTI_COUNTER_WAIT_MS = 50;
+const KILL_TARGET_RECHECK_MS = 50;
 const SKILL_READY_CONFIRMATION_DELAY_MS = 150;
 
 type ResolvedKillTarget =
@@ -945,6 +946,58 @@ const make = Effect.gen(function* () {
           return undefined;
         });
 
+      const isSelectedAttackCurrent = (monMapId: number) =>
+        Effect.gen(function* () {
+          const nextAttack = yield* resolveNextAttack();
+          return (
+            nextAttack?.kind === "attack" && nextAttack.monMapId === monMapId
+          );
+        });
+
+      const waitForSelectedSkillReady = (idx: number, monMapId: number) =>
+        Effect.gen(function* () {
+          while (true) {
+            if (!(yield* isSelectedAttackCurrent(monMapId))) {
+              return false;
+            }
+
+            const cooldown = yield* getSkillCooldownRemaining(idx);
+            if (cooldown > 0) {
+              yield* Effect.sleep(
+                `${Math.min(cooldown, KILL_TARGET_RECHECK_MS)} millis`,
+              );
+              continue;
+            }
+
+            let confirmationRemaining = SKILL_READY_CONFIRMATION_DELAY_MS;
+            while (confirmationRemaining > 0) {
+              if (!(yield* isSelectedAttackCurrent(monMapId))) {
+                return false;
+              }
+
+              const confirmationDelay = Math.min(
+                confirmationRemaining,
+                KILL_TARGET_RECHECK_MS,
+              );
+              yield* Effect.sleep(`${confirmationDelay} millis`);
+              confirmationRemaining -= confirmationDelay;
+            }
+
+            if (!(yield* isSelectedAttackCurrent(monMapId))) {
+              return false;
+            }
+
+            const confirmedCooldown = yield* getSkillCooldownRemaining(idx);
+            if (confirmedCooldown === 0) {
+              return true;
+            }
+
+            yield* Effect.sleep(
+              `${Math.min(confirmedCooldown, KILL_TARGET_RECHECK_MS)} millis`,
+            );
+          }
+        });
+
       let didKillTarget = false;
       let targetMonMapId =
         resolvedTarget.kind === "monMapId"
@@ -1007,7 +1060,15 @@ const make = Effect.gen(function* () {
             skillIndex += 1;
 
             if (skill !== undefined) {
-              yield* useSkill(skill, false, normalizedKillOptions.skillWait);
+              const idx = Number.parseInt(String(skill), 10);
+              const shouldUseSkill =
+                !normalizedKillOptions.skillWait ||
+                (isValidSkillIndex(idx) &&
+                  (yield* waitForSelectedSkillReady(idx, nextAttack.monMapId)));
+
+              if (shouldUseSkill) {
+                yield* useSkill(skill, false, false);
+              }
             }
           }
         } else if (nextAttack?.kind === "blocked") {

--- a/app/src/renderer/windows/game/scripting/recipes.ts
+++ b/app/src/renderer/windows/game/scripting/recipes.ts
@@ -440,6 +440,17 @@ const goToHouse = (
     yield* deps.combat.exit();
     yield* deps.world.map.waitForGameAction("tfer");
     yield* deps.packet.sendServer(`%xt%zm%house%1%${playerName}%`);
+    yield* waitFor(
+      Effect.gen(function* () {
+        if (!(yield* deps.world.map.isLoaded())) return false;
+
+        const mapName = yield* deps.world.map.getName();
+        if (!equalsIgnoreCase(mapName, "house")) return false;
+
+        return yield* deps.player.isReady();
+      }),
+      { timeout: "5 seconds" },
+    );
   });
 
 const beep = (


### PR DESCRIPTION
## Summary
- re-check kill target priority while waiting for skill readiness
- add a map transition grace period before the next scripted action
- cover priority retargeting with a combat regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for combat kill behavior with priority targeting.

* **Bug Fixes**
  * Improved skill timing during kill flow with periodic target verification.
  * Added stabilization delay when joining maps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->