### PR TITLE
fix: normalize form control rendering

### DIFF
--- a/app/src/renderer/windows/account-manager/style.css
+++ b/app/src/renderer/windows/account-manager/style.css
@@ -252,10 +252,9 @@
   font-weight: 400;
   height: calc(var(--control-height-lg) - 2px);
   justify-content: flex-start;
-  line-height: 1.25;
+  line-height: 1.5;
   max-width: 100%;
   min-width: 0;
-  overflow: hidden;
   padding-left: 0.75rem;
   padding-right: 0.75rem;
   width: 100%;
@@ -264,6 +263,7 @@
 .account-manager__script-display .button__content {
   flex: 1 1 auto;
   justify-content: flex-start;
+  line-height: 1.5;
   max-width: 100%;
   min-width: 0;
   overflow: hidden;

--- a/app/src/renderer/windows/loader-grabber/App.tsx
+++ b/app/src/renderer/windows/loader-grabber/App.tsx
@@ -655,7 +655,7 @@ function App(): JSX.Element {
                     disabled={!grabbedData()}
                     onInput={(event) => setSearch(event.currentTarget.value)}
                     placeholder="Search results..."
-                    type="search"
+                    type="text"
                     value={search()}
                   />
                   <InputGroupAddon


### PR DESCRIPTION
## Summary

- Normalize account manager script button line-height so clipped content renders consistently.
- Use a text input for loader grabber filtering to avoid browser search-control rendering differences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text line spacing in the account manager script display for improved readability
  * Adjusted search input field styling in the data grabber panel

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->