### PR TITLE
fix(environment): skip unavailable quest accepts

### DIFF
--- a/app/src/renderer/windows/game/environment/Layers/Environment.test.ts
+++ b/app/src/renderer/windows/game/environment/Layers/Environment.test.ts
@@ -1,0 +1,318 @@
+import { Collection } from "@vexed/collection";
+import { Quest, type QuestInfo } from "@vexed/game";
+import {
+  createEmptyEnvironmentState,
+  type EnvironmentState,
+} from "../../../../../shared/environment";
+import { Effect, Layer, Logger } from "effect";
+import { describe, expect, test } from "vitest";
+import { Drops, type DropsShape } from "../../flash/Services/Drops";
+import { Inventory, type InventoryShape } from "../../flash/Services/Inventory";
+import { Player, type PlayerShape } from "../../flash/Services/Player";
+import { Quests, type QuestsShape } from "../../flash/Services/Quests";
+import { Jobs, type JobsShape } from "../../jobs/Services/Jobs";
+import { Environment, type EnvironmentShape } from "../Services/Environment";
+import { EnvironmentLive } from "./Environment";
+
+const QUEST_JOB_KEY = "environment/quests";
+
+const questInfo = (questId: number): QuestInfo =>
+  ({
+    QuestID: String(questId),
+    RequiredItems: [],
+    Rewards: [],
+    oItems: {},
+    oRewards: {},
+    reward: [],
+    sName: `Quest ${questId}`,
+  }) as unknown as QuestInfo;
+
+interface EnvironmentHarness {
+  readonly acceptedQuestIds: readonly number[];
+  readonly logs: readonly unknown[];
+  readonly runQuestCycle: () => Effect.Effect<void, unknown>;
+  readonly setAvailableResults: (results: readonly boolean[]) => void;
+  readonly setInProgress: (value: boolean) => void;
+}
+
+const withEnvironment = (
+  body: (
+    environment: EnvironmentShape,
+    harness: EnvironmentHarness,
+  ) => Effect.Effect<void, unknown>,
+) => {
+  const acceptedQuestIds: number[] = [];
+  const logs: unknown[] = [];
+  const periodicTasks = new Map<string, Effect.Effect<void, unknown>>();
+  let availableResults: boolean[] = [];
+  let inProgress = false;
+  let state: EnvironmentState = {
+    ...createEmptyEnvironmentState(),
+    questIds: [609],
+  };
+
+  const questTree = new Collection<number, Quest>();
+  questTree.set(609, new Quest(questInfo(609)));
+
+  const previousWindow = globalThis.window;
+  const hadWindow = "window" in globalThis;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      ipc: {
+        environment: {
+          addBoost: async () => state,
+          addItem: async () => state,
+          addQuest: async (questId: number | string) => {
+            const normalizedQuestId = Number(questId);
+            state = {
+              ...state,
+              questIds: Array.from(
+                new Set([...state.questIds, normalizedQuestId]),
+              ),
+            };
+            return state;
+          },
+          clear: async () => {
+            state = createEmptyEnvironmentState();
+            return state;
+          },
+          clearBoosts: async () => state,
+          clearItems: async () => state,
+          clearQuestReward: async () => state,
+          clearQuests: async () => {
+            state = { ...state, questIds: [], questRewards: {} };
+            return state;
+          },
+          getState: async () => state,
+          onChanged: () => () => undefined,
+          onFetchBoostsRequest: () => () => undefined,
+          removeBoost: async () => state,
+          removeItem: async () => state,
+          removeQuest: async (questId: number | string) => {
+            const normalizedQuestId = Number(questId);
+            state = {
+              ...state,
+              questIds: state.questIds.filter((id) => id !== normalizedQuestId),
+            };
+            return state;
+          },
+          setItemRules: async () => state,
+          setQuestAutoRegister: async () => state,
+          setQuestReward: async () => state,
+          syncToAll: async () => state,
+        },
+      },
+    },
+  });
+
+  const drops = {
+    acceptDrop: () => Effect.void,
+    containsDrop: () => Effect.succeed(false),
+    getDrops: () => Effect.succeed([]),
+    isUsingCustomDrops: () => Effect.succeed(false),
+    rejectDrop: () => Effect.succeed(false),
+    toggleUi: () => Effect.void,
+  } satisfies DropsShape;
+
+  const inventory = {
+    contains: () => Effect.succeed(false),
+    equip: () => Effect.succeed(false),
+    getAvailableSlots: () => Effect.succeed(0),
+    getItem: () => Effect.succeed(null),
+    getItems: () => Effect.succeed([]),
+    getSlots: () => Effect.succeed(0),
+    getUsedSlots: () => Effect.succeed(0),
+  } satisfies InventoryShape;
+
+  const jobs = {
+    getRunningKeys: () => Effect.succeed(Array.from(periodicTasks.keys())),
+    isRunning: (key: string) => Effect.succeed(periodicTasks.has(key)),
+    start: () => Effect.succeed(true),
+    startPeriodic: (key, _interval, task) =>
+      Effect.sync(() => {
+        periodicTasks.set(key, task);
+        return true;
+      }),
+    startPeriodicJob: (definition) =>
+      Effect.sync(() => {
+        periodicTasks.set(definition.key, definition.task);
+        return true;
+      }),
+    stop: (key: string) =>
+      Effect.sync(() => {
+        const hadTask = periodicTasks.has(key);
+        periodicTasks.delete(key);
+        return hadTask;
+      }),
+    stopAll: () =>
+      Effect.sync(() => {
+        periodicTasks.clear();
+      }),
+  } satisfies JobsShape;
+
+  const player = {
+    hasActiveBoost: () => Effect.succeed(true),
+    useBoost: () => Effect.succeed(false),
+  } as unknown as PlayerShape;
+
+  const quests = {
+    abandon: () => Effect.void,
+    accept: (questId: number) =>
+      Effect.sync(() => {
+        acceptedQuestIds.push(questId);
+      }),
+    canComplete: () => Effect.succeed(false),
+    complete: () => Effect.void,
+    getAccepted: () => Effect.succeed([]),
+    getMaxTurnIns: () => Effect.succeed(1),
+    getTree: () => Effect.succeed(questTree),
+    has: (questId: number) => Effect.succeed(questTree.has(questId)),
+    isAvailable: () =>
+      Effect.sync(() => availableResults.shift() ?? false),
+    isInProgress: () => Effect.succeed(inProgress),
+    load: () => Effect.void,
+    loadMany: () => Effect.void,
+    onLoaded: () => Effect.succeed(() => undefined),
+  } satisfies QuestsShape;
+
+  const testLogger = Logger.make<unknown, void>((options) => {
+    if (Array.isArray(options.message)) {
+      logs.push(...options.message);
+      return;
+    }
+
+    logs.push(options.message);
+  });
+
+  const harness: EnvironmentHarness = {
+    acceptedQuestIds,
+    logs,
+    runQuestCycle: () =>
+      periodicTasks.get(QUEST_JOB_KEY) ?? Effect.void.pipe(Effect.asVoid),
+    setAvailableResults(results) {
+      availableResults = [...results];
+    },
+    setInProgress(value) {
+      inProgress = value;
+    },
+  };
+
+  const TestLive = Layer.merge(
+    Logger.layer([testLogger]),
+    EnvironmentLive.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.succeed(Drops)(drops),
+          Layer.succeed(Inventory)(inventory),
+          Layer.succeed(Jobs)(jobs),
+          Layer.succeed(Player)(player),
+          Layer.succeed(Quests)(quests),
+        ),
+      ),
+    ),
+  );
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const environment = yield* Environment;
+        yield* environment.addQuest(609);
+        yield* body(environment, harness);
+      }),
+    ).pipe(
+      Effect.provide(TestLive),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (hadWindow) {
+            Object.defineProperty(globalThis, "window", {
+              configurable: true,
+              value: previousWindow,
+            });
+          } else {
+            Reflect.deleteProperty(globalThis, "window");
+          }
+        }),
+      ),
+    ),
+  );
+};
+
+describe("environment quest automation", () => {
+  test("skips accept when a quest becomes unavailable before mutation", async () => {
+    await withEnvironment((_environment, harness) =>
+      Effect.gen(function* () {
+        harness.setAvailableResults([true, false]);
+
+        yield* harness.runQuestCycle();
+
+        expect(harness.acceptedQuestIds).toEqual([]);
+        expect(harness.logs).toEqual([
+          {
+            message: "environment quest is unavailable; skipping accept",
+            questId: 609,
+          },
+        ]);
+      }),
+    );
+  });
+
+  test("warns once per unavailable period and resets when the quest is actionable", async () => {
+    await withEnvironment((_environment, harness) =>
+      Effect.gen(function* () {
+        harness.setAvailableResults([false]);
+        yield* harness.runQuestCycle();
+
+        harness.setAvailableResults([false]);
+        yield* harness.runQuestCycle();
+
+        harness.setInProgress(true);
+        yield* harness.runQuestCycle();
+
+        harness.setInProgress(false);
+        harness.setAvailableResults([false]);
+        yield* harness.runQuestCycle();
+
+        expect(harness.acceptedQuestIds).toEqual([]);
+        expect(harness.logs).toEqual([
+          {
+            message: "environment quest is unavailable; skipping accept",
+            questId: 609,
+          },
+          {
+            message: "environment quest is unavailable; skipping accept",
+            questId: 609,
+          },
+        ]);
+      }),
+    );
+  });
+
+  test("warns again when an unavailable quest is removed and re-added", async () => {
+    await withEnvironment((environment, harness) =>
+      Effect.gen(function* () {
+        harness.setAvailableResults([false]);
+        yield* harness.runQuestCycle();
+
+        yield* environment.removeQuest(609);
+        yield* environment.addQuest(609);
+
+        harness.setAvailableResults([false]);
+        yield* harness.runQuestCycle();
+
+        expect(harness.acceptedQuestIds).toEqual([]);
+        expect(harness.logs).toEqual([
+          {
+            message: "environment quest is unavailable; skipping accept",
+            questId: 609,
+          },
+          {
+            message: "environment quest is unavailable; skipping accept",
+            questId: 609,
+          },
+        ]);
+      }),
+    );
+  });
+});

--- a/app/src/renderer/windows/game/environment/Layers/Environment.ts
+++ b/app/src/renderer/windows/game/environment/Layers/Environment.ts
@@ -83,10 +83,26 @@ const make = Effect.gen(function* () {
     new Set(),
   );
   const lastQuestMutationAtRef = yield* Ref.make(0);
+  const unavailableQuestWarningsRef = yield* Ref.make<ReadonlySet<number>>(
+    new Set(),
+  );
   const questMutationSemaphore = yield* Semaphore.make(1);
 
   const setState = (state: EnvironmentState) =>
-    Ref.set(stateRef, normalizeEnvironmentState(state));
+    Effect.gen(function* () {
+      const normalizedState = normalizeEnvironmentState(state);
+      yield* Ref.set(stateRef, normalizedState);
+      yield* Ref.update(unavailableQuestWarningsRef, (questIds) => {
+        const activeQuestIds = new Set(normalizedState.questIds);
+        const next = new Set<number>();
+        for (const questId of questIds) {
+          if (activeQuestIds.has(questId)) {
+            next.add(questId);
+          }
+        }
+        return next;
+      });
+    });
 
   const invokeState = (
     invoke: () => Promise<EnvironmentState>,
@@ -323,6 +339,42 @@ const make = Effect.gen(function* () {
       }
     });
 
+  const warnQuestUnavailableOnce = (questId: number) =>
+    Effect.gen(function* () {
+      const shouldWarn = yield* Ref.modify(
+        unavailableQuestWarningsRef,
+        (questIds) => {
+          if (questIds.has(questId)) {
+            return [false, questIds] as const;
+          }
+
+          const next = new Set(questIds);
+          next.add(questId);
+          return [true, next] as const;
+        },
+      );
+
+      if (!shouldWarn) {
+        return;
+      }
+
+      yield* Effect.logWarning({
+        message: "environment quest is unavailable; skipping accept",
+        questId,
+      });
+    });
+
+  const clearQuestUnavailableWarning = (questId: number) =>
+    Ref.update(unavailableQuestWarningsRef, (questIds) => {
+      if (!questIds.has(questId)) {
+        return questIds;
+      }
+
+      const next = new Set(questIds);
+      next.delete(questId);
+      return next;
+    });
+
   const determineQuestAutomationIntent = (
     state: EnvironmentState,
     questId: number,
@@ -353,6 +405,12 @@ const make = Effect.gen(function* () {
         : yield* quests
             .isAvailable(questId)
             .pipe(Effect.catchCause(() => Effect.succeed(false)));
+
+      if (inProgress || available) {
+        yield* clearQuestUnavailableWarning(questId);
+      } else {
+        yield* warnQuestUnavailableOnce(questId);
+      }
 
       const rewardItemId = state.questRewards[questId];
       return createQuestAutomationIntent({
@@ -417,48 +475,67 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      yield* questMutationSemaphore.withPermits(1)(
-        Effect.gen(function* () {
-          const beforeDelay = Date.now();
-          const lastMutationAt = yield* Ref.get(lastQuestMutationAtRef);
-          const delayMs = getQuestMutationDelayMs(
-            lastMutationAt,
-            beforeDelay,
-            QUEST_MUTATION_DELAY_MS,
-          );
-          if (delayMs > 0) {
-            yield* Effect.sleep(`${delayMs} millis`);
+      yield* Effect.gen(function* () {
+        if (intent.action === "accept") {
+          const available = yield* quests
+            .isAvailable(intent.questId)
+            .pipe(Effect.catchCause(() => Effect.succeed(false)));
+
+          if (!available) {
+            yield* warnQuestUnavailableOnce(intent.questId);
+            return;
           }
 
-          const startedAt = Date.now();
-          yield* Ref.set(lastQuestMutationAtRef, startedAt);
+          yield* clearQuestUnavailableWarning(intent.questId);
+        }
 
-          const effect =
-            intent.action === "accept"
-              ? quests.accept(intent.questId, true)
-              : quests.complete(intent.questId, undefined, intent.rewardItemId);
+        yield* questMutationSemaphore.withPermits(1)(
+          Effect.gen(function* () {
+            const beforeDelay = Date.now();
+            const lastMutationAt = yield* Ref.get(lastQuestMutationAtRef);
+            const delayMs = getQuestMutationDelayMs(
+              lastMutationAt,
+              beforeDelay,
+              QUEST_MUTATION_DELAY_MS,
+            );
+            if (delayMs > 0) {
+              yield* Effect.sleep(`${delayMs} millis`);
+            }
 
-          const completed = yield* effect.pipe(
-            Effect.timeoutOption(QUEST_ACTION_TIMEOUT),
-            Effect.map(Option.isSome),
-            Effect.catchCause((cause) =>
-              Effect.logError({
-                message: "environment quest mutation failed",
-                questId: intent.questId,
-                action: intent.action,
-                cause,
-              }).pipe(Effect.as(false)),
-            ),
-          );
+            const startedAt = Date.now();
+            yield* Ref.set(lastQuestMutationAtRef, startedAt);
 
-          const finishedAt = Date.now();
-          yield* Ref.update(questActionFailuresRef, (current) =>
-            completed
-              ? clearQuestActionFailure(current, key)
-              : recordQuestActionFailure(current, key, finishedAt),
-          );
-        }).pipe(Effect.ensuring(releaseQuestAction(key))),
-      );
+            const effect =
+              intent.action === "accept"
+                ? quests.accept(intent.questId, true)
+                : quests.complete(
+                    intent.questId,
+                    undefined,
+                    intent.rewardItemId,
+                  );
+
+            const completed = yield* effect.pipe(
+              Effect.timeoutOption(QUEST_ACTION_TIMEOUT),
+              Effect.map(Option.isSome),
+              Effect.catchCause((cause) =>
+                Effect.logError({
+                  message: "environment quest mutation failed",
+                  questId: intent.questId,
+                  action: intent.action,
+                  cause,
+                }).pipe(Effect.as(false)),
+              ),
+            );
+
+            const finishedAt = Date.now();
+            yield* Ref.update(questActionFailuresRef, (current) =>
+              completed
+                ? clearQuestActionFailure(current, key)
+                : recordQuestActionFailure(current, key, finishedAt),
+            );
+          }),
+        );
+      }).pipe(Effect.ensuring(releaseQuestAction(key)));
     });
   };
 


### PR DESCRIPTION
## Summary
- skip environment quest accepts when AQW reports the loaded quest unavailable
- warn once per unavailable quest period and reset when actionable
- add regression coverage for stale availability and warning behavior

## Verification
- pnpm exec vitest run app/src/renderer/windows/game/environment/Layers/Environment.test.ts app/src/renderer/windows/game/environment/questAutomation.test.ts
- pnpm format
- pnpm lint
- pnpm typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced quest automation to prevent accepting quests that become unavailable between detection and execution, improving reliability.
  * Added warning messages to inform users when quests are unavailable and automation is skipped.

* **Tests**
  * Added test suite for environment quest automation covering edge cases around quest availability changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->