### PR TITLE
fix(autorelogin): logout when player stays unready

### DIFF
--- a/app/src/renderer/windows/game/bridge.d.ts
+++ b/app/src/renderer/windows/game/bridge.d.ts
@@ -53,17 +53,9 @@ declare global {
       "flash.isTextFieldFocused": () => boolean;
       "flash.selectArrayObjects": (path: string, selector: string) => string;
       "flash.sendClientPacket": (packet: string, type: string) => void;
-      "flash.setArrayObject": (
-        path: string,
-        index: number,
-        value: unknown,
-      ) => void;
+      "flash.setArrayObject": (path: string, index: number, value: unknown) => void;
       "flash.setGameObject": (path: string, value: unknown) => void;
-      "flash.setGameObjectKey": (
-        path: string,
-        key: string,
-        value: unknown,
-      ) => void;
+      "flash.setGameObjectKey": (path: string, key: string, value: unknown) => void;
       "house.getItem": (item: unknown) => Record<string, unknown>;
       "house.getItems": () => unknown[];
       "house.getSlots": () => number;
@@ -102,30 +94,20 @@ declare global {
       "player.isMember": () => boolean;
       "player.joinMap": (map: string, cell?: string, pad?: string) => void;
       "player.jump": (cell: string, pad?: string) => void;
-      "player.reloadAvatar": () => boolean;
       "player.rest": () => void;
       "player.useBoost": (itemId: number) => boolean;
       "player.walkTo": (x: number, y: number, walkSpeed?: unknown) => boolean;
       "quests.abandon": (questId: number) => void;
       "quests.accept": (questId: number) => void;
       "quests.canComplete": (questId: number) => boolean;
-      "quests.complete": (
-        questId: number,
-        turnIns?: number,
-        itemId?: number,
-        special?: boolean,
-      ) => void;
+      "quests.complete": (questId: number, turnIns?: number, itemId?: number, special?: boolean) => void;
       "quests.get": (questId: number) => void;
       "quests.getAccepted": () => unknown[];
       "quests.getMaxTurnIns": (questId: number) => number;
       "quests.getMultiple": (questIds: string) => void;
-      "quests.getQuestValidationString": (
-        questObj: Record<string, unknown>,
-      ) => string;
+      "quests.getQuestValidationString": (questObj: Record<string, unknown>) => string;
       "quests.getTree": () => unknown[];
-      "quests.hasRequiredItemsForQuest": (
-        questObj: Record<string, unknown>,
-      ) => boolean;
+      "quests.hasRequiredItemsForQuest": (questObj: Record<string, unknown>) => boolean;
       "quests.isAvailable": (questId: number) => boolean;
       "quests.isInProgress": (questId: number) => boolean;
       "quests.isOneTimeQuestDone": (questId: number) => boolean;
@@ -162,9 +144,7 @@ declare global {
       "world.getCellPads": () => unknown[];
       "world.getCells": () => unknown[];
       "world.getMapItem": (itemId: number) => void;
-      "world.getMonsterByMonMapId": (
-        monMapId: unknown,
-      ) => Record<string, unknown>;
+      "world.getMonsterByMonMapId": (monMapId: unknown) => Record<string, unknown>;
       "world.getMonsterByName": (name: string) => Record<string, unknown>;
       "world.isActionAvailable": (gameAction: string) => boolean;
       "world.isLoaded": () => boolean;
@@ -173,12 +153,12 @@ declare global {
       "world.reload": () => void;
       "world.setSpawnPoint": (cell?: string, pad?: string) => void;
     };
-    onConnection?: (status: string) => void;
-    onDebug?: (message: string) => void;
-    onExtensionResponse?: (packet: string) => void;
-    onLoaded?: () => void;
-    onProgress?: (percent: number) => void;
-    packetFromClient?: (packet: string) => void;
-    packetFromServer?: (packet: string) => void;
+    "onConnection"?: (status: string) => void;
+    "onDebug"?: (message: string) => void;
+    "onExtensionResponse"?: (packet: string) => void;
+    "onLoaded"?: () => void;
+    "onProgress"?: (percent: number) => void;
+    "packetFromClient"?: (packet: string) => void;
+    "packetFromServer"?: (packet: string) => void;
   }
 }

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.test.ts
@@ -1,6 +1,6 @@
 import { Server, type ServerData } from "@vexed/game";
 import { Effect, Exit, Fiber, Layer } from "effect";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import { SwfCallError } from "../../flash/Errors";
 import {
   Auth,
@@ -59,12 +59,12 @@ type HarnessOptions = {
   readonly iUpgDays?: number;
   readonly invalidCredentials?: boolean;
   readonly loginStalls?: boolean;
+  readonly logoutFails?: boolean;
   readonly password?: string;
   readonly playerReadyAfterConnectDelayMs?: number;
-  readonly playerReadyAfterReload?: boolean;
+  readonly playerReadyOnConnectOutcomes?: readonly boolean[];
   readonly playerReadyFailures?: number;
   readonly playerReadyOnConnect?: boolean;
-  readonly playerReloadSucceeds?: boolean;
   readonly serverInfo?: string;
   readonly serverSelectStalls?: boolean;
   readonly servers?: readonly ServerData[];
@@ -79,7 +79,6 @@ type Harness = {
   };
   readonly emitConnection: (status: ConnectionStatus) => void;
   readonly manualLogin: (server?: ServerData) => void;
-  readonly playerReloads: readonly string[];
   readonly settingsPatches: readonly unknown[];
 };
 
@@ -91,7 +90,6 @@ const withAutoRelogin = async <A>(
   ) => Effect.Effect<A, unknown>,
 ): Promise<A> => {
   const authCalls: string[] = [];
-  const playerReloads: string[] = [];
   const settingsPatches: unknown[] = [];
   const connectionHandlers = new Set<(status: ConnectionStatus) => void>();
   const jobsState: {
@@ -110,6 +108,9 @@ const withAutoRelogin = async <A>(
   const password = options.password ?? "secret-password";
   const servers = options.servers ?? [twigServer];
   let remainingPlayerReadyFailures = options.playerReadyFailures ?? 0;
+  const playerReadyOnConnectOutcomes = [
+    ...(options.playerReadyOnConnectOutcomes ?? []),
+  ];
 
   const bridge = {
     call<K extends keyof Window["swf"]>(
@@ -204,7 +205,10 @@ const withAutoRelogin = async <A>(
             `${options.playerReadyAfterConnectDelayMs} millis`,
           );
         }
-        if (options.playerReadyOnConnect !== false) {
+        const readyOnConnect =
+          playerReadyOnConnectOutcomes.shift() ??
+          options.playerReadyOnConnect !== false;
+        if (readyOnConnect) {
           playerReady = true;
         }
         return connectedOutcome(server);
@@ -246,6 +250,14 @@ const withAutoRelogin = async <A>(
     },
     logout() {
       authCalls.push("logout");
+      if (options.logoutFails === true) {
+        return Effect.fail(
+          new SwfCallError({
+            method: "auth.logout",
+            cause: "logout failed",
+          }),
+        );
+      }
       return Effect.void;
     },
   } satisfies AuthShape;
@@ -291,15 +303,6 @@ const withAutoRelogin = async <A>(
           });
         }
         return playerReady;
-      });
-    },
-    reloadAvatar() {
-      return Effect.sync(() => {
-        playerReloads.push("reloadAvatar");
-        if (options.playerReadyAfterReload === true) {
-          playerReady = true;
-        }
-        return options.playerReloadSucceeds ?? true;
       });
     },
   } as unknown as PlayerShape;
@@ -354,7 +357,6 @@ const withAutoRelogin = async <A>(
               handler("OnConnection");
             }
           },
-          playerReloads,
           settingsPatches,
         });
       }),
@@ -690,11 +692,10 @@ test("direct login cancels and fails explicitly when authentication stalls", asy
   );
 });
 
-test("direct login reloads avatar art when connected player stays unready", async () => {
+test("direct login retries after connected player stays unready", async () => {
   const result = await withAutoRelogin(
     {
-      playerReadyAfterReload: true,
-      playerReadyOnConnect: false,
+      playerReadyOnConnectOutcomes: [false, true],
     },
     (autoRelogin, harness) =>
       Effect.gen(function* () {
@@ -704,15 +705,21 @@ test("direct login reloads avatar art when connected player stays unready", asyn
           server: "Twig",
         });
         return {
+          calls: harness.authCalls,
           outcome,
-          reloads: harness.playerReloads,
         };
       }),
   );
 
   expect(result.outcome).toEqual({ stage: "player-ready" });
-  expect(result.reloads).toEqual(["reloadAvatar"]);
-}, 15_000);
+  expect(result.calls).toEqual([
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+    "logout",
+    "login:Hero:secret-password",
+    "connectTo:Twig",
+  ]);
+}, 25_000);
 
 test("socket connection during relogin does not interrupt before player ready", async () => {
   const result = await withAutoRelogin(
@@ -766,19 +773,161 @@ test("waits delayMs after logout before attempting", async () => {
   ]);
 });
 
-test("does not start logout delay while connected but still loading", async () => {
-  const harness = await withAutoRelogin({}, (autoRelogin, currentHarness) =>
-    Effect.gen(function* () {
-      yield* autoRelogin.enable();
-      yield* autoRelogin.setDelay(0);
-      currentHarness.emitConnection("OnConnection");
-      yield* Effect.sleep("10 millis");
-      yield* currentHarness.jobsState.task!;
-      return currentHarness;
-    }),
-  );
+test("does not logout steady-state connected player while still loading", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+  try {
+    const harness = await withAutoRelogin({}, (autoRelogin, currentHarness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelay(0);
+        currentHarness.emitConnection("OnConnection");
+        yield* Effect.sleep("10 millis");
 
-  expect(harness.authCalls).toEqual([]);
+        now.mockReturnValue(11_000);
+        yield* currentHarness.jobsState.task!;
+        return currentHarness;
+      }),
+    );
+
+    expect(harness.authCalls).toEqual([]);
+  } finally {
+    now.mockRestore();
+  }
+});
+
+test("connected unready session waits before logout", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+  try {
+    const result = await withAutoRelogin(
+      { playerReadyOnConnect: false },
+      (autoRelogin, harness) =>
+        Effect.gen(function* () {
+          yield* autoRelogin.enable();
+          yield* autoRelogin.setDelay(0);
+          harness.emitConnection("OnConnectionLost");
+          yield* Effect.sleep("10 millis");
+          harness.emitConnection("OnConnection");
+          yield* Effect.sleep("10 millis");
+
+          now.mockReturnValue(10_999);
+          yield* harness.jobsState.task!;
+          return {
+            calls: harness.authCalls,
+            state: yield* autoRelogin.getState(),
+          };
+        }),
+    );
+
+    expect(result.calls).toEqual([]);
+    expect(result.state.lastError).toBeUndefined();
+  } finally {
+    now.mockRestore();
+  }
+});
+
+test("connected unready missing capture reports once", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+  const states: AutoReloginState[] = [];
+  try {
+    const result = await withAutoRelogin(
+      { serverInfo: "null" },
+      (autoRelogin, harness) =>
+        Effect.gen(function* () {
+          yield* autoRelogin.onState((state) => {
+            states.push(state);
+          });
+          yield* autoRelogin.enable();
+          yield* autoRelogin.setDelay(0);
+          harness.emitConnection("OnConnectionLost");
+          yield* Effect.sleep("10 millis");
+          harness.emitConnection("OnConnection");
+          yield* Effect.sleep("10 millis");
+          states.length = 0;
+
+          now.mockReturnValue(11_000);
+          yield* harness.jobsState.task!;
+          const emittedAfterFirstRun = states.length;
+
+          now.mockReturnValue(12_000);
+          yield* harness.jobsState.task!;
+          return {
+            emittedAfterFirstRun,
+            emittedAfterSecondRun: states.length,
+            state: yield* autoRelogin.getState(),
+          };
+        }),
+    );
+
+    expect(result.emittedAfterFirstRun).toBe(1);
+    expect(result.emittedAfterSecondRun).toBe(1);
+    expect(result.state.lastError).toBe("current session is not capturable");
+  } finally {
+    now.mockRestore();
+  }
+});
+
+test("connected unready session logs out and retries relogin after timeout", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+  try {
+    const result = await withAutoRelogin({}, (autoRelogin, harness) =>
+      Effect.gen(function* () {
+        yield* autoRelogin.enable();
+        yield* autoRelogin.setDelay(0);
+        harness.emitConnection("OnConnectionLost");
+        yield* Effect.sleep("10 millis");
+        harness.emitConnection("OnConnection");
+        yield* Effect.sleep("10 millis");
+
+        now.mockReturnValue(11_000);
+        yield* harness.jobsState.task!;
+        return {
+          calls: harness.authCalls,
+          state: yield* autoRelogin.getState(),
+        };
+      }),
+    );
+
+    expect(result.calls).toEqual([
+      "logout",
+      "login:Hero:secret-password",
+      "connectTo:Twig",
+    ]);
+    expect(result.state.lastError).toBeUndefined();
+    expect(result.state.attempting).toBe(false);
+  } finally {
+    now.mockRestore();
+  }
+});
+
+test("connected unready session stops when recovery logout fails", async () => {
+  const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+  try {
+    const result = await withAutoRelogin(
+      { logoutFails: true },
+      (autoRelogin, harness) =>
+        Effect.gen(function* () {
+          yield* autoRelogin.enable();
+          yield* autoRelogin.setDelay(0);
+          harness.emitConnection("OnConnectionLost");
+          yield* Effect.sleep("10 millis");
+          harness.emitConnection("OnConnection");
+          yield* Effect.sleep("10 millis");
+
+          now.mockReturnValue(11_000);
+          yield* harness.jobsState.task!;
+          return {
+            calls: harness.authCalls,
+            state: yield* autoRelogin.getState(),
+          };
+        }),
+    );
+
+    expect(result.calls).toEqual(["logout"]);
+    expect(result.state.enabled).toBe(false);
+    expect(result.state.lastError).toBe("logout failed");
+  } finally {
+    now.mockRestore();
+  }
 });
 
 test("starts delay from connection lost event", async () => {

--- a/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
+++ b/app/src/renderer/windows/game/features/Layers/AutoRelogin.ts
@@ -38,8 +38,8 @@ const MAX_DELAY_MS = 300_000;
 const TEMP_KICK_TIMEOUT = "70 seconds";
 const SERVER_SELECT_TIMEOUT = "10 seconds";
 const SERVERS_LOAD_TIMEOUT = "5 seconds";
-const PLAYER_READY_TIMEOUT = "10 seconds";
-const AVATAR_RELOAD_READY_TIMEOUT = "20 seconds";
+const PLAYER_READY_TIMEOUT_MS = 10_000;
+const PLAYER_READY_TIMEOUT_DURATION = `${PLAYER_READY_TIMEOUT_MS} millis`;
 const MIN_FAILURE_COOLDOWN_MS = 5_000;
 const MAX_FAILURE_COOLDOWN_MS = 60_000;
 const MAX_RELOGIN_RETRIES = 3;
@@ -47,6 +47,8 @@ const INVALID_CREDENTIALS_DETAIL =
   "The username and password you entered did not match.\rPlease check the spelling and try again.";
 const INVALID_CREDENTIALS_ERROR = "invalid username or password";
 const LOGIN_STALLED_ERROR = "login did not reach server select";
+const LOGOUT_FAILED_ERROR = "logout failed";
+const PLAYER_NOT_READY_ERROR = "player did not become ready";
 
 class AutoReloginAttemptError extends Data.TaggedError(
   "AutoReloginAttemptError",
@@ -86,6 +88,8 @@ type RuntimeState = {
   loggedOutSince: number | undefined;
   // SmartFox can be connected while player.isReady() is still false.
   connected: boolean;
+  // Tracks connected sessions that have not reached player readiness yet.
+  connectedUnreadySince: number | undefined;
   // Prevents the relogin attempt's own socket connection from interrupting itself.
   ownedConnectionServerName: string | undefined;
   // Bumped on external connections so long waits can be interrupted safely.
@@ -123,9 +127,14 @@ const initialState = (): RuntimeState => ({
   lastAttemptAt: 0,
   loggedOutSince: undefined,
   connected: false,
+  connectedUnreadySince: undefined,
   ownedConnectionServerName: undefined,
   connectionSeq: 0,
 });
+
+const clearConnectedUnreadyRecovery = (state: RuntimeState) => {
+  state.connectedUnreadySince = undefined;
+};
 
 const isWaitingForReloginDelay = (state: RuntimeState): boolean => {
   if (
@@ -397,6 +406,7 @@ const make = Effect.gen(function* () {
         state.attempting = false;
         state.attemptsRemaining = terminal ? undefined : 0;
         state.connected = false;
+        clearConnectedUnreadyRecovery(state);
         state.ownedConnectionServerName = undefined;
 
         // Non-retryable failures, such as the captured server being unavailable
@@ -426,6 +436,7 @@ const make = Effect.gen(function* () {
       state.attemptsRemaining = undefined;
       state.attempting = false;
       state.connected = true;
+      clearConnectedUnreadyRecovery(state);
       state.ownedConnectionServerName = undefined;
       state.loggedOutSince = undefined;
       state.lastAttemptAt = 0;
@@ -437,6 +448,7 @@ const make = Effect.gen(function* () {
     updateState((state) => {
       state.attempting = false;
       state.attemptsRemaining = undefined;
+      clearConnectedUnreadyRecovery(state);
       state.ownedConnectionServerName = undefined;
     });
 
@@ -454,6 +466,7 @@ const make = Effect.gen(function* () {
       state.attempting = false;
       state.attemptsRemaining = undefined;
       state.connected = true;
+      clearConnectedUnreadyRecovery(state);
       state.ownedConnectionServerName = undefined;
       state.loggedOutSince = undefined;
       state.lastAttemptAt = 0;
@@ -471,6 +484,7 @@ const make = Effect.gen(function* () {
       state.attempting = false;
       state.attemptsRemaining = undefined;
       state.connected = false;
+      clearConnectedUnreadyRecovery(state);
       state.ownedConnectionServerName = undefined;
     });
 
@@ -479,6 +493,7 @@ const make = Effect.gen(function* () {
       // A ready player closes the disconnect window.
       state.connected = true;
       state.attemptsRemaining = undefined;
+      clearConnectedUnreadyRecovery(state);
       state.ownedConnectionServerName = undefined;
       state.loggedOutSince = undefined;
       state.lastAttemptAt = 0;
@@ -491,6 +506,7 @@ const make = Effect.gen(function* () {
       (state): readonly [LogoutObservation, RuntimeState] => {
         // Keep the first logout timestamp stable across periodic job ticks.
         state.connected = false;
+        clearConnectedUnreadyRecovery(state);
         state.ownedConnectionServerName = undefined;
         if (state.loggedOutSince !== undefined) {
           return [
@@ -766,6 +782,24 @@ const make = Effect.gen(function* () {
   const failAttempt = (message: string, retryable: boolean) =>
     Effect.fail(new AutoReloginAttemptError({ message, retryable }));
 
+  const logoutForReadinessRecovery = () =>
+    auth.logout().pipe(
+      Effect.catchCause((cause) =>
+        Effect.logError({
+          message: "[autorelogin] logout failed during readiness recovery",
+          cause,
+        }).pipe(Effect.andThen(failAttempt(LOGOUT_FAILED_ERROR, false))),
+      ),
+    );
+
+  const isRetryableAttemptError = (error: unknown) =>
+    error instanceof AutoReloginAttemptError && error.retryable;
+
+  const isPlayerNotReadyAttemptError = (error: unknown) =>
+    error instanceof AutoReloginAttemptError &&
+    error.retryable &&
+    error.message === PLAYER_NOT_READY_ERROR;
+
   const connectFailureMessage = (
     outcome: Exclude<AuthConnectOutcome, { readonly status: "connected" }>,
     requestedServer: string,
@@ -830,7 +864,7 @@ const make = Effect.gen(function* () {
     Effect.gen(function* () {
       yield* logStage("waiting for player ready");
       const ready = yield* wait.until(isPlayerReady(), {
-        timeout: PLAYER_READY_TIMEOUT,
+        timeout: PLAYER_READY_TIMEOUT_DURATION,
         schedule: Schedule.spaced("250 millis"),
       });
       if (ready) {
@@ -838,23 +872,13 @@ const make = Effect.gen(function* () {
       }
 
       yield* logStage("player ready timed out", {
-        recovery: "reload avatar",
+        recovery: "logout",
       });
-      const reloadStarted = yield* player
-        .reloadAvatar()
-        .pipe(Effect.catchCause(() => Effect.succeed(false)));
-      if (!reloadStarted) {
-        return yield* failAttempt("player avatar did not load", true);
-      }
-
-      yield* logStage("avatar reload requested");
-      const readyAfterReload = yield* wait.until(isPlayerReady(), {
-        timeout: AVATAR_RELOAD_READY_TIMEOUT,
-        schedule: Schedule.spaced("250 millis"),
-      });
-      if (!readyAfterReload) {
-        return yield* failAttempt("player avatar did not load", true);
-      }
+      yield* Effect.logWarning(
+        "[autorelogin] player still not ready after 10s; logging out",
+      );
+      yield* logoutForReadinessRecovery();
+      return yield* failAttempt(PLAYER_NOT_READY_ERROR, true);
     });
 
   const performLogin = (
@@ -927,7 +951,13 @@ const make = Effect.gen(function* () {
   ): Effect.Effect<AutoLoginOutcome, unknown> =>
     Effect.gen(function* () {
       yield* markLoginStart();
-      return yield* performLogin(credentials).pipe(
+      const runLogin = performLogin(credentials).pipe(
+        Effect.retry({
+          schedule: reloginRetrySchedule,
+          while: isPlayerNotReadyAttemptError,
+        }),
+      );
+      return yield* runLogin.pipe(
         Effect.matchEffect({
           onFailure: (error) =>
             markLoginFailure(error, credentials).pipe(
@@ -1102,6 +1132,103 @@ const make = Effect.gen(function* () {
       return attempt;
     });
 
+  type ConnectedUnreadyAction =
+    | {
+        readonly status: "wait";
+      }
+    | {
+        readonly status: "logout";
+      }
+    | {
+        readonly status: "missing-capture";
+      };
+
+  const reserveConnectedUnreadyAction = (
+    now: number,
+  ): Effect.Effect<ConnectedUnreadyAction> =>
+    SynchronizedRef.modify(
+      stateRef,
+      (state): readonly [ConnectedUnreadyAction, RuntimeState] => {
+        if (
+          !state.enabled ||
+          !state.connected ||
+          state.attempting ||
+          state.loggedOutSince === undefined ||
+          state.connectedUnreadySince === undefined
+        ) {
+          return [{ status: "wait" }, state] as const;
+        }
+
+        if (
+          now <
+          state.connectedUnreadySince + PLAYER_READY_TIMEOUT_MS
+        ) {
+          return [{ status: "wait" }, state] as const;
+        }
+
+        if (state.captured === null) {
+          state.connectedUnreadySince = undefined;
+          return [{ status: "missing-capture" }, state] as const;
+        }
+
+        return [{ status: "logout" }, state] as const;
+      },
+    );
+
+  const runReloginAttempt = (attempt: ReservedAttempt) =>
+    interruptible(
+      attempt.connectionSeq,
+      performRelogin(attempt).pipe(
+        Effect.retry({
+          schedule: reloginRetrySchedule,
+          while: isRetryableAttemptError,
+        }),
+      ),
+    ).pipe(
+      Effect.matchEffect({
+        onFailure: (error) =>
+          error instanceof AutoReloginInterrupted
+            ? markInterrupted(error).pipe(Effect.asVoid)
+            : markFailure(error).pipe(Effect.asVoid),
+        onSuccess: () =>
+          logStage("attempt succeeded").pipe(
+            Effect.andThen(markReloginSuccess()),
+            Effect.asVoid,
+          ),
+      }),
+    );
+
+  const handleConnectedUnready = (
+    now: number,
+  ): Effect.Effect<void, AutoReloginAttemptError> =>
+    Effect.gen(function* () {
+      const action = yield* reserveConnectedUnreadyAction(now);
+      if (action.status === "wait") {
+        return;
+      }
+
+      if (action.status === "missing-capture") {
+        yield* updateState((state) => {
+          state.lastError = "current session is not capturable";
+        });
+        return;
+      }
+
+      yield* Effect.logWarning(
+        "[autorelogin] player still not ready after 10s; logging out",
+      );
+      yield* logoutForReadinessRecovery();
+      yield* markLoggedOut(Date.now());
+
+      const attempt = yield* reserveAttempt(Date.now());
+      if (attempt === null) {
+        yield* emitCurrentState;
+        return;
+      }
+
+      yield* runReloginAttempt(attempt);
+    });
+
   const runAttemptCycle = Effect.gen(function* () {
     const now = Date.now();
     const ready = yield* isPlayerReady();
@@ -1117,6 +1244,7 @@ const make = Effect.gen(function* () {
       })),
     );
     if (connectionState.connected) {
+      yield* handleConnectedUnready(now);
       return;
     }
 
@@ -1139,28 +1267,7 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* interruptible(
-      attempt.connectionSeq,
-      performRelogin(attempt).pipe(
-        Effect.retry({
-          schedule: reloginRetrySchedule,
-          while: (error) =>
-            error instanceof AutoReloginAttemptError && error.retryable,
-        }),
-      ),
-    ).pipe(
-      Effect.matchEffect({
-        onFailure: (error) =>
-          error instanceof AutoReloginInterrupted
-            ? markInterrupted(error).pipe(Effect.asVoid)
-            : markFailure(error).pipe(Effect.asVoid),
-        onSuccess: () =>
-          logStage("attempt succeeded").pipe(
-            Effect.andThen(markReloginSuccess()),
-            Effect.asVoid,
-          ),
-      }),
-    );
+    yield* runReloginAttempt(attempt);
   }).pipe(
     Effect.catchCause((cause) =>
       Cause.hasInterruptsOnly(cause)
@@ -1212,6 +1319,7 @@ const make = Effect.gen(function* () {
       return yield* updateState((state) => {
         state.enabled = false;
         state.attempting = false;
+        clearConnectedUnreadyRecovery(state);
         state.ownedConnectionServerName = undefined;
         state.lastError = undefined;
         state.attemptsRemaining = undefined;
@@ -1307,9 +1415,10 @@ const make = Effect.gen(function* () {
         SynchronizedRef.modify(stateRef, (state) => {
           const ownedConnectionServerName = state.ownedConnectionServerName;
           // objServerInfo is refreshed after SmartFox connects.
-          state.loggedOutSince = undefined;
           state.lastAttemptAt = 0;
           state.connected = true;
+          state.connectedUnreadySince =
+            state.loggedOutSince === undefined ? undefined : Date.now();
           if (ownedConnectionServerName === undefined) {
             state.connectionSeq += 1;
           }

--- a/app/src/renderer/windows/game/flash/BridgeFallbacks.ts
+++ b/app/src/renderer/windows/game/flash/BridgeFallbacks.ts
@@ -88,7 +88,6 @@ export const bridgeFallbacks = {
   "player.isMember": () => false,
   "player.joinMap": () => undefined,
   "player.jump": () => undefined,
-  "player.reloadAvatar": () => false,
   "player.rest": () => undefined,
   "player.useBoost": () => false,
   "player.walkTo": () => false,

--- a/app/src/renderer/windows/game/flash/Layers/Player.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Player.ts
@@ -139,9 +139,6 @@ const make = Effect.gen(function* () {
   const isMember: PlayerShape["isMember"] = () =>
     bridge.call("player.isMember");
 
-  const reloadAvatar: PlayerShape["reloadAvatar"] = () =>
-    bridge.call("player.reloadAvatar");
-
   const jumpToCell: PlayerShape["jumpToCell"] = (cell, pad, correction) =>
     Effect.gen(function* () {
       if (pad === undefined) {
@@ -419,7 +416,6 @@ const make = Effect.gen(function* () {
     isAfk,
     isReady,
     isMember,
-    reloadAvatar,
     jumpToCell,
     joinMap,
     goToPlayer,

--- a/app/src/renderer/windows/game/flash/Services/Player.ts
+++ b/app/src/renderer/windows/game/flash/Services/Player.ts
@@ -23,7 +23,6 @@ export interface PlayerShape {
   isAfk(): BridgeEffect<boolean>;
   isReady(): BridgeEffect<boolean>;
   isMember(): BridgeEffect<boolean>;
-  reloadAvatar(): BridgeEffect<boolean>;
   jumpToCell(
     cell: string,
     pad?: string,

--- a/as3/src/vexed/game/Player.as
+++ b/as3/src/vexed/game/Player.as
@@ -179,37 +179,6 @@ package vexed.game {
     }
 
     [BridgeExport]
-    public static function reloadAvatar():Boolean {
-      var reloaded:Boolean = false;
-      try {
-        var avatar:Object = game.world.myAvatar;
-        if (!avatar || !avatar.pMC || !avatar.objData) {
-          return false;
-        }
-
-        if (avatar.pMC.artLoaded()) {
-          return true;
-        }
-
-        if (avatar.objData.eqp != null) {
-          for (var slot:String in avatar.objData.eqp) {
-            var item:Object = avatar.objData.eqp[slot];
-            if (item != null && item.sFile != null && item.sLink != null) {
-              avatar.loadMovieAtES(slot, item.sFile, item.sLink);
-            }
-          }
-        }
-
-        avatar.pMC.loadHair();
-        reloaded = true;
-      }
-      catch (e:Error) {
-        reloaded = false;
-      }
-      return reloaded;
-    }
-
-    [BridgeExport]
     public static function goToPlayer(name:String):void {
       if (!name) {
         return;

--- a/as3/src/vexed/generated/BridgeRegistryGenerated.as
+++ b/as3/src/vexed/generated/BridgeRegistryGenerated.as
@@ -108,7 +108,6 @@ package vexed.generated
       external.externalize("player.isMember", Player.isMember);
       external.externalize("player.joinMap", Player.joinMap);
       external.externalize("player.jump", Player.jump);
-      external.externalize("player.reloadAvatar", Player.reloadAvatar);
       external.externalize("player.rest", Player.rest);
       external.externalize("player.useBoost", Player.useBoost);
       external.externalize("player.walkTo", Player.walkTo);

--- a/docs/public/script-api.d.ts
+++ b/docs/public/script-api.d.ts
@@ -378,7 +378,6 @@ interface PlayerApi {
   isAfk(): Effect<boolean, BridgeError>;
   isReady(): Effect<boolean, BridgeError>;
   isMember(): Effect<boolean, BridgeError>;
-  reloadAvatar(): Effect<boolean, BridgeError>;
   jumpToCell(
     cell: string,
     pad?: string,

--- a/docs/src/content/docs/scripting/api/player.md
+++ b/docs/src/content/docs/scripting/api/player.md
@@ -286,18 +286,6 @@ api.player.jumpToCell(cell: string, pad?: string, correction?: boolean): BridgeE
 
 **Errors:** <a href="/scripting/types/bridge-error/" data-script-type="bridge-error"><code>BridgeError</code></a>
 
-<a id="member-api-player-reloadavatar"></a>
-
-### `api.player.reloadAvatar()` <a class="source-reference__heading-link" style="float: right; display: inline-flex; align-items: center; justify-content: center; margin-block: -0.125rem; margin-inline-start: 0.5rem; border-radius: var(--radius-sm); text-decoration: none;" href="https://github.com/toommyliu/vexed/blob/dev/app/src/renderer/windows/game/flash/Services/Player.ts#L26" tabindex="-1" aria-hidden="true" title="Open source: app/src/renderer/windows/game/flash/Services/Player.ts:26" target="_blank" rel="noreferrer"><svg class="source-reference__icon" width="16" height="16" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"></path><path d="m6 8-4 4 4 4"></path><path d="m14.5 4-5 16"></path></svg></a>
-
-```ts
-api.player.reloadAvatar(): BridgeEffect<boolean>
-```
-
-**Yields:** `boolean`
-
-**Errors:** <a href="/scripting/types/bridge-error/" data-script-type="bridge-error"><code>BridgeError</code></a>
-
 <a id="member-api-player-rest"></a>
 
 ### `api.player.rest()` <a class="source-reference__heading-link" style="float: right; display: inline-flex; align-items: center; justify-content: center; margin-block: -0.125rem; margin-inline-start: 0.5rem; border-radius: var(--radius-sm); text-decoration: none;" href="https://github.com/toommyliu/vexed/blob/dev/app/src/renderer/windows/game/flash/Services/Player.ts#L34" tabindex="-1" aria-hidden="true" title="Open source: app/src/renderer/windows/game/flash/Services/Player.ts:34" target="_blank" rel="noreferrer"><svg class="source-reference__icon" width="16" height="16" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"></path><path d="m6 8-4 4 4 4"></path><path d="m14.5 4-5 16"></path></svg></a>


### PR DESCRIPTION
## Summary
- Log out when a connected player stays unready past the 10s readiness window.
- Retry direct account launches after readiness-timeout logout instead of terminating at the login screen.
- Scope connected-unready recovery to post-disconnect connection events so steady-state map loading does not trigger logout.
- Prevent repeated missing-capture emissions and stop recovery if logout itself fails.
- Remove the ineffective player.reloadAvatar bridge/API/docs surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `player.isMember` method to the scripting API.

* **Bug Fixes**
  * Improved auto-relogin behavior when a player remains unready after connecting by implementing timeout-based logout recovery.

* **Documentation**
  * Removed deprecated `player.reloadAvatar()` method from API documentation and scripting interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->