### PR TITLE
feat(scripting): add script exit window close

### DIFF
--- a/app/src/main/ipc/methods/window.ts
+++ b/app/src/main/ipc/methods/window.ts
@@ -26,4 +26,21 @@ export const registerWindowIpcHandlers = (): Effect.Effect<
         yield* windows.openWindow(id, senderWindowId);
       }),
     );
+
+    yield* ipc.handle(WindowIpcChannels.requestCloseGameWindow, (event) =>
+      Effect.gen(function* () {
+        const senderWindow = BrowserWindow.fromWebContents(event.sender);
+        if (!senderWindow) {
+          return;
+        }
+
+        const windows = yield* WindowService;
+        const gameWindowId = yield* windows.getGameWindowId(senderWindow.id);
+        if (gameWindowId === undefined) {
+          return;
+        }
+
+        yield* windows.requestCloseGameWindow(gameWindowId);
+      }),
+    );
   });

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -961,6 +961,13 @@ const bridge: AppBridge = {
     open: async (id: WindowId) => {
       await ipcRenderer.invoke(WindowIpcChannels.open, id);
     },
+    requestCloseGameWindow: () => {
+      void ipcRenderer
+        .invoke(WindowIpcChannels.requestCloseGameWindow)
+        .catch((cause: unknown) => {
+          writePreloadError("Failed to request game window close", cause);
+        });
+    },
   },
 };
 

--- a/app/src/main/window/WindowService.test.ts
+++ b/app/src/main/window/WindowService.test.ts
@@ -47,6 +47,7 @@ class FakeWindow extends EventEmitter {
   public hidden = false;
   public readonly webContents = new FakeWebContents();
   public failLoad = false;
+  public closeCalls = 0;
 
   public constructor(
     public readonly id: number,
@@ -97,6 +98,7 @@ class FakeWindow extends EventEmitter {
   }
 
   public close(): boolean {
+    this.closeCalls += 1;
     let prevented = false;
     this.emit("close", {
       preventDefault() {
@@ -189,6 +191,11 @@ const createHarness = (
 
 const run = <A>(effect: Effect.Effect<A, WindowManagerError>) =>
   Effect.runPromise(effect);
+
+const waitForScheduledClose = () =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 
 describe("window reveal", () => {
   it("reveals when the first trigger fires", () => {
@@ -404,6 +411,55 @@ describe("window service", () => {
     )) as unknown as FakeWindow;
 
     expect(gameWindow.close()).toBe(false);
+
+    expect(environment.destroyed).toBe(true);
+    expect(packets.destroyed).toBe(true);
+  });
+
+  it("requests tracked game windows to close asynchronously", async () => {
+    const harness = createHarness();
+    const gameWindow = (await run(
+      harness.service.openGameWindow,
+    )) as unknown as FakeWindow;
+
+    await run(harness.service.requestCloseGameWindow(gameWindow.id));
+
+    expect(gameWindow.destroyed).toBe(false);
+
+    await waitForScheduledClose();
+
+    expect(gameWindow.closeCalls).toBe(1);
+    expect(gameWindow.destroyed).toBe(true);
+  });
+
+  it("ignores missing or destroyed game windows when close is requested", async () => {
+    const harness = createHarness();
+    const gameWindow = (await run(
+      harness.service.openGameWindow,
+    )) as unknown as FakeWindow;
+    gameWindow.destroy();
+
+    await run(harness.service.requestCloseGameWindow(gameWindow.id));
+    await run(harness.service.requestCloseGameWindow(9999));
+    await waitForScheduledClose();
+
+    expect(gameWindow.closeCalls).toBe(0);
+  });
+
+  it("cleans up child windows when a requested game window close runs", async () => {
+    const harness = createHarness();
+    const gameWindow = (await run(
+      harness.service.openGameWindow,
+    )) as unknown as FakeWindow;
+    const environment = (await run(
+      harness.service.openWindow(WindowIds.Environment, gameWindow.id),
+    )) as unknown as FakeWindow;
+    const packets = (await run(
+      harness.service.openWindow(WindowIds.Packets, gameWindow.id),
+    )) as unknown as FakeWindow;
+
+    await run(harness.service.requestCloseGameWindow(gameWindow.id));
+    await waitForScheduledClose();
 
     expect(environment.destroyed).toBe(true);
     expect(packets.destroyed).toBe(true);

--- a/app/src/main/window/WindowService.ts
+++ b/app/src/main/window/WindowService.ts
@@ -585,6 +585,19 @@ export const makeWindowService = (
         const gameWindow = gameWindows.get(gameWindowId)?.gameWindow;
         return isWindowUsable(gameWindow) ? gameWindow : null;
       }),
+    requestCloseGameWindow: (gameWindowId) =>
+      Effect.sync(() => {
+        const gameWindow = gameWindows.get(gameWindowId)?.gameWindow;
+        if (!isWindowOpen(gameWindow)) {
+          return;
+        }
+
+        setTimeout(() => {
+          if (!gameWindow.isDestroyed()) {
+            gameWindow.close();
+          }
+        }, 0);
+      }),
     setQuitting: (quitting) =>
       Effect.sync(() => {
         isQuitting = quitting;

--- a/app/src/main/window/WindowTypes.ts
+++ b/app/src/main/window/WindowTypes.ts
@@ -37,6 +37,9 @@ export interface WindowServiceShape {
   readonly getGameWindow: (
     gameWindowId: number,
   ) => Effect.Effect<BrowserWindow | null>;
+  readonly requestCloseGameWindow: (
+    gameWindowId: number,
+  ) => Effect.Effect<void>;
   readonly setQuitting: (quitting: boolean) => Effect.Effect<void>;
 }
 

--- a/app/src/renderer/windows/game/scripting/Layers/ScriptRunner.ts
+++ b/app/src/renderer/windows/game/scripting/Layers/ScriptRunner.ts
@@ -42,6 +42,7 @@ import type {
   ScriptAutoReloginShape,
   ScriptAutoZoneShape,
   ScriptContext,
+  ScriptExitOptions,
   ScriptAntiCounterEvent,
   ScriptAntiCounterListener,
   ScriptAntiCounterShape,
@@ -438,12 +439,99 @@ const make = Effect.gen(function* () {
         return Effect.sleep(`${Math.trunc(ms)} millis`);
       });
 
+    let closeWindowOnExit = false;
+
+    const validateExitOptions = (
+      options: ScriptExitOptions | undefined,
+    ): Effect.Effect<ScriptExitOptions, ScriptExecutionError> =>
+      Effect.suspend(() => {
+        if (options === undefined) {
+          return Effect.succeed({});
+        }
+
+        if (
+          typeof options !== "object" ||
+          options === null ||
+          Array.isArray(options)
+        ) {
+          return Effect.fail(
+            new ScriptExecutionError({
+              sourceName,
+              message: "script.exit(options) expects an options object",
+              cause: options,
+            }),
+          );
+        }
+
+        if (
+          options.logout !== undefined &&
+          typeof options.logout !== "boolean"
+        ) {
+          return Effect.fail(
+            new ScriptExecutionError({
+              sourceName,
+              message: "script.exit(options.logout) expects a boolean",
+              cause: options.logout,
+            }),
+          );
+        }
+
+        if (
+          options.closeWindow !== undefined &&
+          typeof options.closeWindow !== "boolean"
+        ) {
+          return Effect.fail(
+            new ScriptExecutionError({
+              sourceName,
+              message: "script.exit(options.closeWindow) expects a boolean",
+              cause: options.closeWindow,
+            }),
+          );
+        }
+
+        return Effect.succeed(options);
+      });
+
     const stopScript = (reason?: string): Effect.Effect<never> =>
       Effect.gen(function* () {
         const stopReason = reason?.trim() ? reason : "script request";
 
         yield* scriptScope.requestInterrupt(stopReason);
         runFork(interruptActiveScript(stopReason));
+
+        return yield* Effect.interrupt;
+      });
+
+    const exitScript = (
+      options?: ScriptExitOptions,
+    ): Effect.Effect<never, ScriptExecutionError | BridgeError> =>
+      Effect.gen(function* () {
+        const normalizedOptions = yield* validateExitOptions(options);
+        const shouldCloseWindow = normalizedOptions.closeWindow === true;
+        const shouldLogout = normalizedOptions.logout === true;
+
+        closeWindowOnExit = shouldCloseWindow;
+
+        if (shouldLogout) {
+          const loggedIn = yield* auth
+            .isLoggedIn()
+            .pipe(Effect.catchCause(() => Effect.succeed(false)));
+
+          if (loggedIn) {
+            yield* auth.logout().pipe(
+              Effect.catchCause((cause) =>
+                Cause.hasInterruptsOnly(cause)
+                  ? Effect.failCause(cause)
+                  : Effect.sync(() => {
+                      closeWindowOnExit = false;
+                    }).pipe(Effect.andThen(Effect.failCause(cause))),
+              ),
+            );
+          }
+        }
+
+        yield* scriptScope.requestInterrupt("script exit");
+        runFork(interruptActiveScript("script exit"));
 
         return yield* Effect.interrupt;
       });
@@ -1278,6 +1366,7 @@ const make = Effect.gen(function* () {
       },
       stop: stopScript,
       sleep,
+      exit: exitScript,
     };
 
     const api: ScriptApi = {
@@ -1379,6 +1468,13 @@ const make = Effect.gen(function* () {
           Effect.ensuring(
             Effect.sync(() => {
               runtime.clearContext();
+            }),
+          ),
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (closeWindowOnExit) {
+                window.ipc.windows.requestCloseGameWindow();
+              }
             }),
           ),
         ),

--- a/app/src/renderer/windows/game/scripting/ScriptApi.ts
+++ b/app/src/renderer/windows/game/scripting/ScriptApi.ts
@@ -9,7 +9,7 @@ import type { EnvironmentShape } from "../environment/Services/Environment";
 import type { AuthConnectOutcome } from "../flash/Services/Auth";
 import type { AutoZoneSupportedMap } from "../features/Services/AutoZone";
 import type { BankShape } from "../flash/Services/Bank";
-import type { BridgeEffect } from "../flash/Services/Bridge";
+import type { BridgeEffect, BridgeError } from "../flash/Services/Bridge";
 import type { CombatShape } from "../flash/Services/Combat";
 import type { DropsShape } from "../flash/Services/Drops";
 import type { HouseShape } from "../flash/Services/House";
@@ -366,6 +366,11 @@ export interface ScriptOptionsApi {
   reset(): Effect.Effect<void>;
 }
 
+export interface ScriptExitOptions {
+  readonly logout?: boolean;
+  readonly closeWindow?: boolean;
+}
+
 export interface ScriptRuntimeApi {
   /**
    * Current script cancellation signal; aborted when the script stops.
@@ -381,6 +386,12 @@ export interface ScriptRuntimeApi {
    * Waits for milliseconds and cancels when the script stops. Prefer this over homemade `setTimeout` helpers to avoid background timers that keep running after the script is stopped.
    */
   sleep(ms: number): Effect.Effect<void, ScriptExecutionError>;
+  /**
+   * Intentionally exits the current script, optionally logging out and closing the owning game window during teardown.
+   */
+  exit(
+    options?: ScriptExitOptions,
+  ): Effect.Effect<never, ScriptExecutionError | BridgeError>;
 }
 
 export interface ScriptApi {

--- a/app/src/renderer/windows/game/scripting/ScriptRuntimeStd.test.ts
+++ b/app/src/renderer/windows/game/scripting/ScriptRuntimeStd.test.ts
@@ -34,6 +34,7 @@ const makeContext = (): ScriptContext => {
       log: (message: string) => `log:${message}`,
       stop: () => "stop",
       sleep: (ms: number) => `sleep:${ms}`,
+      exit: (_options?: unknown) => "exit",
     },
     features,
   } as unknown as ScriptContext;
@@ -54,6 +55,7 @@ describe("script runtime std", () => {
     expect(api.wait.forMapLoaded("battleon")).toBe("map:battleon");
     expect(useSkill(1)).toBe("skill:1");
     expect(script.log("ready")).toBe("log:ready");
+    expect(script.exit()).toBe("exit");
     expect(autoZone.enable()).toBe("zone:enabled");
     expect(api.wait.until(() => true)).toBe("until");
   });

--- a/app/src/shared/ipc.ts
+++ b/app/src/shared/ipc.ts
@@ -146,6 +146,7 @@ export const ScriptingIpcChannels = {
 
 export const WindowIpcChannels = {
   open: "windows:open",
+  requestCloseGameWindow: "windows:request-close-game-window",
 } as const;
 
 export const AccountManagerIpcChannels = {
@@ -535,10 +536,15 @@ export interface ScriptingBridge {
 
 export interface WindowInvokeChannels {
   readonly [WindowIpcChannels.open]: IpcInvokeDefinition<[id: WindowId], void>;
+  readonly [WindowIpcChannels.requestCloseGameWindow]: IpcInvokeDefinition<
+    [],
+    void
+  >;
 }
 
 export interface WindowsBridge {
   open(id: WindowId): Promise<void>;
+  requestCloseGameWindow(): void;
 }
 
 export interface AccountManagerInvokeChannels {


### PR DESCRIPTION
## Summary

- Add `script.exit(options)` so scripts can intentionally stop, optionally log out, and close the owning game window from runner teardown.
- Route game-window close requests through renderer IPC into the main window service.
- Cover asynchronous game-window close behavior and script runtime exposure in tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scripts now support an explicit `exit()` method for controlled termination with optional logout and game window-close capabilities during teardown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->