### PR TITLE
refactor(army): move and harden loop taunt over IPC

### DIFF
--- a/app/src/main/ipc/methods/LoopTauntCoordinator.ts
+++ b/app/src/main/ipc/methods/LoopTauntCoordinator.ts
@@ -1,0 +1,250 @@
+import {
+  type ArmyLoopTauntCommandPayload,
+  type ArmyLoopTauntObservationPayload,
+  type ArmyLoopTauntParticipantPayload,
+  type ArmyLoopTauntStartPayload,
+  type ArmyLoopTauntStopPayload,
+} from "../../../shared/ipc";
+import {
+  DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS,
+  LOOP_TAUNT_FOCUS_AURA_ICON,
+  LOOP_TAUNT_FOCUS_AURA_NAME,
+  LOOP_TAUNT_RETRY_SETTLE_MS,
+  LOOP_TAUNT_SHORT_RETRY_MS,
+} from "../../../shared/loop-taunt";
+
+type LoopTauntPhase = "idle" | "settling" | "retry-wait" | "retry-settling";
+
+interface LoopTauntState {
+  readonly id: string;
+  readonly aura: string;
+  readonly delayMs: number;
+  readonly skill: number | string;
+  readonly targetMonMapId: number;
+  readonly participants: readonly ArmyLoopTauntParticipantPayload[];
+  readonly registeredPlayerKeys: Set<string>;
+  readonly timers: Set<ReturnType<typeof setTimeout>>;
+  currentSelected: ArmyLoopTauntParticipantPayload | undefined;
+  epoch: number;
+  nextIndex: number;
+  phase: LoopTauntPhase;
+  targetAuraActive: boolean;
+}
+
+export interface LoopTauntCoordinatorOptions {
+  readonly sessionId: string;
+  readonly sendCommand: (
+    player: ArmyLoopTauntParticipantPayload,
+    command: ArmyLoopTauntCommandPayload,
+  ) => void;
+}
+
+const normalizeKey = (value: string): string => value.trim().toLowerCase();
+
+const isFocusAura = (aura: string): boolean =>
+  normalizeKey(aura) === normalizeKey(LOOP_TAUNT_FOCUS_AURA_NAME);
+
+const matchesAuraObservation = (
+  state: LoopTauntState,
+  observation: ArmyLoopTauntObservationPayload,
+): boolean => {
+  if (observation.targetMonMapId !== state.targetMonMapId) {
+    return false;
+  }
+
+  if (
+    observation.auraName !== undefined &&
+    normalizeKey(observation.auraName) !== normalizeKey(state.aura)
+  ) {
+    return false;
+  }
+
+  return (
+    !isFocusAura(state.aura) ||
+    observation.auraIcon === undefined ||
+    observation.auraIcon === LOOP_TAUNT_FOCUS_AURA_ICON
+  );
+};
+
+const clearTimers = (state: LoopTauntState): void => {
+  for (const timer of state.timers) {
+    clearTimeout(timer);
+  }
+  state.timers.clear();
+};
+
+const resetTurn = (state: LoopTauntState): void => {
+  state.phase = "idle";
+  state.currentSelected = undefined;
+};
+
+export class LoopTauntCoordinator {
+  private readonly loops = new Map<string, LoopTauntState>();
+
+  public constructor(private readonly options: LoopTauntCoordinatorOptions) {}
+
+  public clear(): void {
+    for (const state of this.loops.values()) {
+      clearTimers(state);
+    }
+    this.loops.clear();
+  }
+
+  public start(payload: ArmyLoopTauntStartPayload): void {
+    const playerKey = normalizeKey(payload.playerName);
+    const existing = this.loops.get(payload.id);
+    if (existing) {
+      existing.registeredPlayerKeys.add(playerKey);
+      return;
+    }
+
+    this.loops.set(payload.id, {
+      aura: payload.aura,
+      currentSelected: undefined,
+      delayMs: payload.delayMs,
+      epoch: 0,
+      id: payload.id,
+      nextIndex: 0,
+      participants: payload.participants,
+      phase: "idle",
+      registeredPlayerKeys: new Set([playerKey]),
+      skill: payload.skill,
+      targetAuraActive: true,
+      targetMonMapId: payload.targetMonMapId,
+      timers: new Set(),
+    });
+  }
+
+  public stop(payload: ArmyLoopTauntStopPayload): void {
+    const state = this.loops.get(payload.id);
+    if (!state) {
+      return;
+    }
+
+    state.registeredPlayerKeys.delete(normalizeKey(payload.playerName));
+    if (state.registeredPlayerKeys.size === 0) {
+      clearTimers(state);
+      this.loops.delete(payload.id);
+    }
+  }
+
+  public observe(payload: ArmyLoopTauntObservationPayload): void {
+    const state = this.loops.get(payload.id);
+    if (!state || !matchesAuraObservation(state, payload)) {
+      return;
+    }
+
+    if (payload.epoch !== undefined && payload.epoch < state.epoch) {
+      return;
+    }
+
+    if (payload.type === "aura-added") {
+      state.targetAuraActive = true;
+      clearTimers(state);
+      resetTurn(state);
+      return;
+    }
+
+    if (payload.type !== "aura-missing" && payload.type !== "aura-removed") {
+      return;
+    }
+
+    if (state.phase !== "idle") {
+      return;
+    }
+
+    state.targetAuraActive = false;
+    this.startTurn(state, payload.type);
+  }
+
+  private schedule(
+    state: LoopTauntState,
+    delayMs: number,
+    callback: () => void,
+  ): void {
+    const timer = setTimeout(() => {
+      state.timers.delete(timer);
+      callback();
+    }, Math.max(0, Math.trunc(delayMs)));
+    state.timers.add(timer);
+  }
+
+  private sendCommand(
+    state: LoopTauntState,
+    attempt: number,
+    reason: string,
+  ): void {
+    const selected = state.currentSelected;
+    if (!selected) {
+      return;
+    }
+
+    this.options.sendCommand(selected, {
+      attempt,
+      epoch: state.epoch,
+      id: state.id,
+      reason,
+      selected,
+      sessionId: this.options.sessionId,
+      skill: state.skill,
+      targetMonMapId: state.targetMonMapId,
+    });
+  }
+
+  private startTurn(state: LoopTauntState, reason: string): void {
+    if (state.participants.length === 0 || state.phase !== "idle") {
+      return;
+    }
+
+    clearTimers(state);
+    state.epoch += 1;
+    state.phase = "settling";
+    state.targetAuraActive = false;
+
+    const selectedIndex = state.nextIndex % state.participants.length;
+    state.currentSelected = state.participants[selectedIndex];
+    state.nextIndex = (selectedIndex + 1) % state.participants.length;
+
+    const epoch = state.epoch;
+    this.schedule(state, state.delayMs, () => {
+      if (state.epoch !== epoch || state.phase !== "settling") {
+        return;
+      }
+
+      this.sendCommand(state, 1, reason);
+      this.schedule(state, DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS, () => {
+        if (state.epoch !== epoch || state.phase !== "settling") {
+          return;
+        }
+
+        if (state.targetAuraActive) {
+          resetTurn(state);
+          return;
+        }
+
+        state.phase = "retry-wait";
+        this.schedule(state, LOOP_TAUNT_SHORT_RETRY_MS, () => {
+          if (state.epoch !== epoch || state.phase !== "retry-wait") {
+            return;
+          }
+
+          state.phase = "retry-settling";
+          this.sendCommand(state, 2, "missed cast retry");
+          this.schedule(state, LOOP_TAUNT_RETRY_SETTLE_MS, () => {
+            if (state.epoch !== epoch || state.phase !== "retry-settling") {
+              return;
+            }
+
+            if (state.targetAuraActive) {
+              resetTurn(state);
+              return;
+            }
+
+            resetTurn(state);
+            this.startTurn(state, "missed cast recovery expired");
+          });
+        });
+      });
+    });
+  }
+}

--- a/app/src/main/ipc/methods/army.test.ts
+++ b/app/src/main/ipc/methods/army.test.ts
@@ -1,0 +1,712 @@
+import { EventEmitter } from "node:events";
+import type { IpcMainInvokeEvent, WebContents } from "electron";
+import { Effect, Exit, Fiber, Layer } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArmyConfigPayload } from "../../../shared/army";
+import {
+  ArmyIpcChannels,
+  type ArmyBarrierPayload,
+  type ArmyLoopTauntCommandPayload,
+  type ArmyLoopTauntObservationPayload,
+  type ArmyLoopTauntStartPayload,
+  type ArmySessionPayload,
+  type ArmyStatusResult,
+} from "../../../shared/ipc";
+import {
+  WorkspaceFiles,
+  type WorkspaceFilesShape,
+} from "../../workspace/WorkspaceFiles";
+import { MainIpc, type MainIpcShape } from "../MainIpc";
+import { registerArmyIpcHandlers } from "./army";
+
+const electronMock = vi.hoisted(() => {
+  const windowsByWebContents = new WeakMap<object, unknown>();
+
+  return {
+    windowsByWebContents,
+    BrowserWindow: {
+      fromWebContents: vi.fn((webContents: object) =>
+        windowsByWebContents.get(webContents) ?? null,
+      ),
+    },
+  };
+});
+
+vi.mock("electron", () => ({
+  BrowserWindow: electronMock.BrowserWindow,
+}));
+
+class FakeWebContents extends EventEmitter {
+  public readonly id: number;
+  public readonly sent: Array<{
+    readonly channel: string;
+    readonly payload: unknown;
+  }> = [];
+  private destroyed = false;
+
+  public constructor(id: number) {
+    super();
+    this.id = id;
+  }
+
+  public isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  public destroy(): void {
+    this.destroyed = true;
+    this.emit("destroyed");
+  }
+
+  public send(channel: string, payload: unknown): void {
+    this.sent.push({ channel, payload });
+    this.emit(channel, payload);
+  }
+}
+
+class FakeWindow extends EventEmitter {
+  public readonly webContents: FakeWebContents;
+  private destroyed = false;
+
+  public constructor(id: number) {
+    super();
+    this.webContents = new FakeWebContents(id);
+  }
+
+  public isDestroyed(): boolean {
+    return this.destroyed;
+  }
+
+  public destroy(): void {
+    this.destroyed = true;
+    this.emit("closed");
+    this.webContents.destroy();
+  }
+}
+
+type CapturedHandler = (
+  event: IpcMainInvokeEvent,
+  ...args: readonly unknown[]
+) => Effect.Effect<unknown, unknown, unknown>;
+
+interface ArmyIpcHarness {
+  readonly start: (
+    playerName: string,
+  ) => Effect.Effect<ArmySessionPayload, unknown>;
+  readonly barrier: (
+    session: ArmySessionPayload,
+    playerName: string,
+    payload: Omit<ArmyBarrierPayload, "sessionId" | "playerName">,
+  ) => Effect.Effect<void, unknown>;
+  readonly status: (
+    session: ArmySessionPayload,
+  ) => Effect.Effect<ArmyStatusResult, unknown>;
+  readonly startLoopTaunt: (
+    session: ArmySessionPayload,
+    payload: Omit<ArmyLoopTauntStartPayload, "playerName" | "sessionId">,
+    playerName?: string,
+    senderPlayerName?: string,
+  ) => Effect.Effect<void, unknown>;
+  readonly publishLoopTauntObservation: (
+    session: ArmySessionPayload,
+    payload: Omit<ArmyLoopTauntObservationPayload, "playerName" | "sessionId">,
+    playerName?: string,
+    senderPlayerName?: string,
+  ) => Effect.Effect<void, unknown>;
+  readonly detachedStartLoopTaunt: (
+    session: ArmySessionPayload,
+    payload: Omit<ArmyLoopTauntStartPayload, "playerName" | "sessionId">,
+    playerName?: string,
+  ) => Effect.Effect<void, unknown>;
+  readonly commandsFor: (
+    playerName: string,
+  ) => readonly ArmyLoopTauntCommandPayload[];
+}
+
+const config: ArmyConfigPayload = {
+  configName: "barrier-test",
+  leader: "Main",
+  players: ["Main", "Alt", "Third", "Fourth"],
+  raw: {},
+  roomNumber: "1",
+};
+
+const makeWorkspace = (): WorkspaceFilesShape => ({
+  scriptsDir: "/tmp/vexed-test-scripts",
+  flashPluginPath: null,
+  readScript: () => Effect.die("not used"),
+  readArmyConfig: (configName) => Effect.succeed({ ...config, configName }),
+});
+
+const exitString = <A, E>(exit: Exit.Exit<A, E>): string =>
+  Exit.match(exit, {
+    onFailure: (cause) => String(cause),
+    onSuccess: () => "",
+  });
+
+const withArmyIpc = async <A>(
+  body: (harness: ArmyIpcHarness) => Effect.Effect<A, unknown>,
+): Promise<A> => {
+  const handlers = new Map<string, CapturedHandler>();
+  const windowsByPlayer = new Map<string, FakeWindow>();
+  let nextWindowId = 1;
+
+  const makeEvent = (): IpcMainInvokeEvent => {
+    const window = new FakeWindow(nextWindowId++);
+    electronMock.windowsByWebContents.set(window.webContents, window);
+    return {
+      sender: window.webContents as unknown as WebContents,
+    } as IpcMainInvokeEvent;
+  };
+
+  const makePlayerEvent = (playerName: string): IpcMainInvokeEvent => {
+    const window = windowsByPlayer.get(playerName.toLowerCase());
+    if (!window) {
+      throw new Error(`No test window for player: ${playerName}`);
+    }
+
+    return {
+      sender: window.webContents as unknown as WebContents,
+    } as IpcMainInvokeEvent;
+  };
+
+  const invoke = <A>(
+    channel: string,
+    event: IpcMainInvokeEvent,
+    ...args: readonly unknown[]
+  ): Effect.Effect<A, unknown> => {
+    const handler = handlers.get(channel);
+    if (handler === undefined) {
+      return Effect.die(new Error(`Missing IPC handler: ${channel}`));
+    }
+
+    return handler(event, ...args) as Effect.Effect<A, unknown>;
+  };
+
+  const ipc: MainIpcShape = {
+    handle: (channel, handler) =>
+      Effect.sync(() => {
+        handlers.set(channel, handler as CapturedHandler);
+      }),
+    on: () => Effect.void,
+  };
+
+  const harness: ArmyIpcHarness = {
+    start: (playerName) =>
+      Effect.gen(function* () {
+        const event = makeEvent();
+        const session = yield* invoke<ArmySessionPayload>(
+          ArmyIpcChannels.start,
+          event,
+          {
+            configName: config.configName,
+            playerName,
+          },
+        );
+        const window = electronMock.windowsByWebContents.get(
+          event.sender,
+        ) as FakeWindow;
+        windowsByPlayer.set(playerName.toLowerCase(), window);
+        return session;
+      }),
+    barrier: (session, playerName, payload) =>
+      invoke<void>(ArmyIpcChannels.barrier, makeEvent(), {
+        ...payload,
+        playerName,
+        sessionId: session.sessionId,
+      }),
+    status: (session) =>
+      invoke<ArmyStatusResult>(ArmyIpcChannels.status, makeEvent(), {
+        sessionId: session.sessionId,
+      }),
+    startLoopTaunt: (
+      session,
+      payload,
+      playerName = session.playerName,
+      senderPlayerName = playerName,
+    ) =>
+      invoke<void>(ArmyIpcChannels.loopTauntStart, makePlayerEvent(senderPlayerName), {
+        ...payload,
+        playerName,
+        sessionId: session.sessionId,
+      }),
+    publishLoopTauntObservation: (
+      session,
+      payload,
+      playerName = session.playerName,
+      senderPlayerName = playerName,
+    ) =>
+      invoke<void>(ArmyIpcChannels.loopTauntObservation, makePlayerEvent(senderPlayerName), {
+        ...payload,
+        playerName,
+        sessionId: session.sessionId,
+      }),
+    detachedStartLoopTaunt: (session, payload, playerName = session.playerName) =>
+      invoke<void>(ArmyIpcChannels.loopTauntStart, makeEvent(), {
+        ...payload,
+        playerName,
+        sessionId: session.sessionId,
+      }),
+    commandsFor: (playerName) =>
+      (windowsByPlayer.get(playerName.toLowerCase())?.webContents.sent ?? [])
+        .filter((event) => event.channel === ArmyIpcChannels.loopTauntCommand)
+        .map((event) => event.payload as ArmyLoopTauntCommandPayload),
+  };
+
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        yield* registerArmyIpcHandlers();
+        return yield* body(harness);
+      }),
+    ).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(MainIpc)(ipc),
+          Layer.succeed(WorkspaceFiles)(makeWorkspace()),
+        ),
+      ),
+    ),
+  );
+};
+
+const startFullArmy = (harness: ArmyIpcHarness) =>
+  Effect.gen(function* () {
+    const session = yield* harness.start("Main");
+    yield* harness.start("Alt");
+    yield* harness.start("Third");
+    yield* harness.start("Fourth");
+    return session;
+  });
+
+const loopTauntStartPayload = (
+  overrides: Partial<
+    Omit<ArmyLoopTauntStartPayload, "playerName" | "sessionId">
+  > = {},
+): Omit<ArmyLoopTauntStartPayload, "playerName" | "sessionId"> => ({
+  aura: "Focus",
+  delayMs: 4_000,
+  id: "focus",
+  participants: [
+    { name: "Main", number: 1 },
+    { name: "Alt", number: 2 },
+  ],
+  skill: 5,
+  targetMonMapId: 1,
+  ...overrides,
+});
+
+describe("army IPC barriers", () => {
+  beforeEach(() => {
+    electronMock.BrowserWindow.fromWebContents.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("releases same-step same-label barriers with the same expected players", async () => {
+    const status = await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        const main = yield* Effect.forkDetach(
+          harness.barrier(session, "Main", {
+            label: "same",
+            players: ["Main", "Alt"],
+            step: 1,
+          }),
+          { startImmediately: true },
+        );
+
+        yield* Effect.sleep("1 millis");
+        yield* harness.barrier(session, "Alt", {
+          label: "same",
+          players: ["Main", "Alt"],
+          step: 1,
+        });
+        yield* Fiber.join(main);
+        return yield* harness.status(session);
+      }),
+    );
+
+    expect(status.waitingBarriers).toBe(0);
+  });
+
+  it("rejects same-step same-label barriers with different expected players", async () => {
+    const result = await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        const main = yield* Effect.forkDetach(
+          harness.barrier(session, "Main", {
+            label: "same",
+            players: ["Main", "Alt"],
+            step: 2,
+          }),
+          { startImmediately: true },
+        );
+
+        yield* Effect.sleep("1 millis");
+        const exit = yield* Effect.exit(
+          harness.barrier(session, "Third", {
+            label: "same",
+            players: ["Third", "Fourth"],
+            step: 2,
+          }),
+        );
+
+        yield* harness.barrier(session, "Alt", {
+          label: "same",
+          players: ["Main", "Alt"],
+          step: 2,
+        });
+        yield* Fiber.join(main);
+
+        return {
+          exit,
+          status: yield* harness.status(session),
+        };
+      }),
+    );
+
+    expect(Exit.isFailure(result.exit)).toBe(true);
+    expect(exitString(result.exit)).toContain("Army step player set mismatch");
+    expect(result.status.waitingBarriers).toBe(0);
+  });
+
+  it("allows same-step different-label barriers with disjoint expected players", async () => {
+    const result = await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        const executioner = yield* Effect.forkDetach(
+          harness.barrier(session, "Main", {
+            label: "loop-taunt-target:executioner",
+            players: ["Main", "Alt"],
+            step: 3,
+          }),
+          { startImmediately: true },
+        );
+        const bowmaster = yield* Effect.forkDetach(
+          harness.barrier(session, "Third", {
+            label: "loop-taunt-target:bowmaster",
+            players: ["Third", "Fourth"],
+            step: 3,
+          }),
+          { startImmediately: true },
+        );
+
+        yield* Effect.sleep("1 millis");
+        const pendingStatus = yield* harness.status(session);
+
+        yield* harness.barrier(session, "Alt", {
+          label: "loop-taunt-target:executioner",
+          players: ["Main", "Alt"],
+          step: 3,
+        });
+        yield* harness.barrier(session, "Fourth", {
+          label: "loop-taunt-target:bowmaster",
+          players: ["Third", "Fourth"],
+          step: 3,
+        });
+        yield* Fiber.join(executioner);
+        yield* Fiber.join(bowmaster);
+
+        return {
+          pendingStatus,
+          releasedStatus: yield* harness.status(session),
+        };
+      }),
+    );
+
+    expect(result.pendingStatus.waitingBarriers).toBe(2);
+    expect(result.releasedStatus.waitingBarriers).toBe(0);
+  });
+
+  it("keeps same-step different-label all-player barriers separate until timeout", async () => {
+    const result = await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        const left = yield* Effect.forkDetach(
+          harness.barrier(session, "Main", {
+            label: "left",
+            step: 4,
+            timeoutMs: 10,
+          }),
+          { startImmediately: true },
+        );
+        const right = yield* Effect.forkDetach(
+          harness.barrier(session, "Third", {
+            label: "right",
+            step: 4,
+            timeoutMs: 10,
+          }),
+          { startImmediately: true },
+        );
+
+        yield* Effect.sleep("1 millis");
+        const pendingStatus = yield* harness.status(session);
+        yield* Effect.sleep("20 millis");
+
+        const leftExit = yield* Effect.exit(Fiber.join(left));
+        const rightExit = yield* Effect.exit(Fiber.join(right));
+
+        return {
+          leftExit,
+          pendingStatus,
+          rightExit,
+          releasedStatus: yield* harness.status(session),
+        };
+      }),
+    );
+
+    expect(result.pendingStatus.waitingBarriers).toBe(2);
+    expect(Exit.isFailure(result.leftExit)).toBe(true);
+    expect(exitString(result.leftExit)).toContain(
+      "Timed out waiting for army step 4 (left)",
+    );
+    expect(Exit.isFailure(result.rightExit)).toBe(true);
+    expect(exitString(result.rightExit)).toContain(
+      "Timed out waiting for army step 4 (right)",
+    );
+    expect(result.releasedStatus.waitingBarriers).toBe(0);
+  });
+});
+
+describe("army loop taunt coordinator", () => {
+  beforeEach(() => {
+    electronMock.BrowserWindow.fromWebContents.mockClear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects malformed loop taunt IPC payload values", async () => {
+    const result = await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        yield* harness.startLoopTaunt(session, loopTauntStartPayload(), "Main");
+
+        const blankSkill = yield* Effect.exit(
+          harness.startLoopTaunt(
+            session,
+            loopTauntStartPayload({ skill: " " }),
+            "Main",
+          ),
+        );
+        const fractionalSkill = yield* Effect.exit(
+          harness.startLoopTaunt(
+            session,
+            loopTauntStartPayload({ skill: 1.5 }),
+            "Main",
+          ),
+        );
+        const invalidOutcome = yield* Effect.exit(
+          harness.publishLoopTauntObservation(session, {
+            id: "focus",
+            outcome: "ignored" as never,
+            targetMonMapId: 1,
+            type: "cast-outcome",
+          }),
+        );
+        const invalidReason = yield* Effect.exit(
+          harness.publishLoopTauntObservation(session, {
+            id: "focus",
+            reason: "ignored" as never,
+            targetMonMapId: 1,
+            type: "cast-outcome",
+          }),
+        );
+
+        return {
+          blankSkill,
+          fractionalSkill,
+          invalidOutcome,
+          invalidReason,
+        };
+      }),
+    );
+
+    expect(Exit.isFailure(result.blankSkill)).toBe(true);
+    expect(Exit.isFailure(result.fractionalSkill)).toBe(true);
+    expect(Exit.isFailure(result.invalidOutcome)).toBe(true);
+    expect(Exit.isFailure(result.invalidReason)).toBe(true);
+  });
+
+  it("rejects loop taunt starts from unattached windows", async () => {
+    const result = await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        return yield* Effect.exit(
+          harness.detachedStartLoopTaunt(
+            session,
+            loopTauntStartPayload(),
+            "Main",
+          ),
+        );
+      }),
+    );
+
+    expect(Exit.isFailure(result)).toBe(true);
+    expect(exitString(result)).toContain(
+      "Army sender is not attached to this session",
+    );
+  });
+
+  it("waits configured delay before commanding after Focus removal", async () => {
+    await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        yield* harness.startLoopTaunt(
+          session,
+          loopTauntStartPayload({ delayMs: 1_000 }),
+          "Main",
+        );
+        yield* harness.publishLoopTauntObservation(session, {
+          auraName: "Focus",
+          id: "focus",
+          targetMonMapId: 1,
+          type: "aura-removed",
+        });
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(999));
+        expect(harness.commandsFor("Main")).toHaveLength(0);
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(1));
+        expect(harness.commandsFor("Main")).toHaveLength(1);
+      }),
+    );
+  });
+
+  it("uses the default 4000ms aura delay", async () => {
+    await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        yield* harness.startLoopTaunt(
+          session,
+          loopTauntStartPayload(),
+          "Main",
+        );
+        yield* harness.publishLoopTauntObservation(session, {
+          auraName: "Focus",
+          id: "focus",
+          targetMonMapId: 1,
+          type: "aura-removed",
+        });
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(3_999));
+        expect(harness.commandsFor("Main")).toHaveLength(0);
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(1));
+        expect(harness.commandsFor("Main")).toHaveLength(1);
+      }),
+    );
+  });
+
+  it("dedupes duplicate Focus removal reports into one epoch", async () => {
+    await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        yield* harness.startLoopTaunt(
+          session,
+          loopTauntStartPayload({ delayMs: 0 }),
+          "Main",
+        );
+        yield* harness.publishLoopTauntObservation(session, {
+          auraName: "Focus",
+          id: "focus",
+          targetMonMapId: 1,
+          type: "aura-removed",
+        });
+        yield* harness.publishLoopTauntObservation(
+          session,
+          {
+            auraName: "Focus",
+            id: "focus",
+            targetMonMapId: 1,
+            type: "aura-removed",
+          },
+          "Alt",
+        );
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(0));
+        expect(harness.commandsFor("Main")).toHaveLength(1);
+        expect(harness.commandsFor("Main")[0]?.epoch).toBe(1);
+      }),
+    );
+  });
+
+  it("does one retry then hands off when Focus never returns", async () => {
+    await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        yield* harness.startLoopTaunt(
+          session,
+          loopTauntStartPayload({ delayMs: 0 }),
+          "Main",
+        );
+        yield* harness.publishLoopTauntObservation(session, {
+          auraName: "Focus",
+          id: "focus",
+          targetMonMapId: 1,
+          type: "aura-missing",
+        });
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(0));
+        expect(harness.commandsFor("Main")).toHaveLength(1);
+
+        yield* Effect.promise(() =>
+          vi.advanceTimersByTimeAsync(1_500 + 2_500),
+        );
+        expect(harness.commandsFor("Main")).toHaveLength(2);
+        expect(harness.commandsFor("Main")[1]?.attempt).toBe(2);
+
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(1_500));
+        yield* Effect.promise(() => vi.runOnlyPendingTimersAsync());
+        const altCommands = harness.commandsFor("Alt");
+        expect(altCommands).toHaveLength(1);
+        expect(altCommands[0]?.epoch).toBe(2);
+      }),
+    );
+  });
+
+  it("cancels retry and handoff when Focus is restored", async () => {
+    await withArmyIpc((harness) =>
+      Effect.gen(function* () {
+        const session = yield* startFullArmy(harness);
+        yield* harness.startLoopTaunt(
+          session,
+          loopTauntStartPayload({ delayMs: 0 }),
+          "Main",
+        );
+        yield* harness.publishLoopTauntObservation(session, {
+          auraName: "Focus",
+          id: "focus",
+          targetMonMapId: 1,
+          type: "aura-missing",
+        });
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(0));
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(1_000));
+        yield* harness.publishLoopTauntObservation(session, {
+          auraIcon: "iwd1,ied1",
+          auraName: "Focus",
+          id: "focus",
+          targetMonMapId: 1,
+          type: "aura-added",
+        });
+        yield* Effect.promise(() => vi.advanceTimersByTimeAsync(10_000));
+
+        expect(
+          harness
+            .commandsFor("Main")
+            .filter((command) => command.selected.name === "Main"),
+        ).toHaveLength(1);
+        expect(
+          harness
+            .commandsFor("Alt")
+            .filter((command) => command.selected.name === "Alt"),
+        ).toHaveLength(0);
+      }),
+    );
+  });
+});

--- a/app/src/main/ipc/methods/army.ts
+++ b/app/src/main/ipc/methods/army.ts
@@ -4,6 +4,11 @@ import {
   ArmyIpcChannels,
   type ArmyBarrierPayload,
   type ArmyLeavePayload,
+  type ArmyLoopTauntCastOutcomeReason,
+  type ArmyLoopTauntObservationPayload,
+  type ArmyLoopTauntParticipantPayload,
+  type ArmyLoopTauntStartPayload,
+  type ArmyLoopTauntStopPayload,
   type ArmySessionPayload,
   type ArmyStartPayload,
   type ArmyStatusPayload,
@@ -15,6 +20,7 @@ import {
 } from "../../../shared/army";
 import { WorkspaceFiles } from "../../workspace/WorkspaceFiles";
 import { MainIpc } from "../MainIpc";
+import { LoopTauntCoordinator } from "./LoopTauntCoordinator";
 
 const ARMY_START_TIMEOUT_MS = 120_000;
 const ARMY_BARRIER_TIMEOUT_MS = 30 * 60_000;
@@ -34,6 +40,7 @@ interface PendingStart {
 }
 
 interface ArmyBarrierState {
+  readonly key: string;
   readonly step: number;
   readonly label?: string;
   readonly expectedPlayerKeys: ReadonlySet<string>;
@@ -46,7 +53,8 @@ interface ArmySessionState extends ArmyConfigPayload {
   readonly sessionId: string;
   readonly playerKeys: ReadonlySet<string>;
   readonly windows: Map<string, BrowserWindow>;
-  readonly barriers: Map<number, ArmyBarrierState>;
+  readonly barriers: Map<string, ArmyBarrierState>;
+  readonly loopTaunts: LoopTauntCoordinator;
 }
 
 let nextSessionId = 0;
@@ -66,6 +74,27 @@ const getSenderWindow = (sender: WebContents): BrowserWindow => {
   }
 
   return senderWindow;
+};
+
+const findSessionPlayerName = (
+  session: Pick<ArmySessionState, "players">,
+  playerKey: string,
+): string =>
+  session.players.find((player) => normalizePlayerName(player) === playerKey) ??
+  playerKey;
+
+const resolveSenderPlayerName = (
+  session: Pick<ArmySessionState, "players" | "windows">,
+  sender: WebContents,
+): string => {
+  const senderWindow = getSenderWindow(sender);
+  for (const [playerKey, window] of session.windows) {
+    if (window === senderWindow) {
+      return findSessionPlayerName(session, playerKey);
+    }
+  }
+
+  throw new Error("Army sender is not attached to this session");
 };
 
 const readArmyConfig = (
@@ -226,6 +255,218 @@ const parseStatusPayload = (payload: unknown): ArmyStatusPayload => {
   return { sessionId: record["sessionId"] };
 };
 
+const parseLoopTauntParticipant = (
+  value: unknown,
+): ArmyLoopTauntParticipantPayload => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Invalid loop taunt participant");
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record["name"] !== "string" ||
+    record["name"].trim() === "" ||
+    typeof record["number"] !== "number" ||
+    !Number.isInteger(record["number"]) ||
+    record["number"] < 1
+  ) {
+    throw new Error("Invalid loop taunt participant");
+  }
+
+  return {
+    name: record["name"].trim(),
+    number: record["number"],
+  };
+};
+
+const hasOwn = (
+  record: Record<string, unknown>,
+  key: string,
+): boolean => Object.prototype.hasOwnProperty.call(record, key);
+
+const parseLoopTauntSkill = (skill: unknown): number | string => {
+  if (typeof skill === "number") {
+    if (!Number.isFinite(skill) || !Number.isInteger(skill)) {
+      throw new Error("Invalid loop taunt start payload");
+    }
+
+    return skill;
+  }
+
+  if (typeof skill === "string" && skill.trim() !== "") {
+    return skill.trim();
+  }
+
+  throw new Error("Invalid loop taunt start payload");
+};
+
+const parseLoopTauntStartPayload = (
+  payload: unknown,
+): ArmyLoopTauntStartPayload => {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    throw new Error("Invalid loop taunt start payload");
+  }
+
+  const record = payload as Record<string, unknown>;
+  const participants = record["participants"];
+  const skill = parseLoopTauntSkill(record["skill"]);
+  if (
+    typeof record["sessionId"] !== "string" ||
+    record["sessionId"].trim() === "" ||
+    typeof record["playerName"] !== "string" ||
+    record["playerName"].trim() === "" ||
+    typeof record["id"] !== "string" ||
+    record["id"].trim() === "" ||
+    typeof record["aura"] !== "string" ||
+    record["aura"].trim() === "" ||
+    typeof record["delayMs"] !== "number" ||
+    !Number.isFinite(record["delayMs"]) ||
+    record["delayMs"] < 0 ||
+    typeof record["targetMonMapId"] !== "number" ||
+    !Number.isInteger(record["targetMonMapId"]) ||
+    record["targetMonMapId"] < 1 ||
+    !Array.isArray(participants) ||
+    participants.length === 0
+  ) {
+    throw new Error("Invalid loop taunt start payload");
+  }
+
+  return {
+    sessionId: record["sessionId"],
+    playerName: record["playerName"],
+    id: record["id"].trim(),
+    aura: record["aura"].trim(),
+    delayMs: Math.trunc(record["delayMs"]),
+    skill,
+    targetMonMapId: record["targetMonMapId"],
+    participants: participants.map(parseLoopTauntParticipant),
+  };
+};
+
+const parseLoopTauntStopPayload = (
+  payload: unknown,
+): ArmyLoopTauntStopPayload => {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    throw new Error("Invalid loop taunt stop payload");
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (
+    typeof record["sessionId"] !== "string" ||
+    record["sessionId"].trim() === "" ||
+    typeof record["playerName"] !== "string" ||
+    record["playerName"].trim() === "" ||
+    typeof record["id"] !== "string" ||
+    record["id"].trim() === ""
+  ) {
+    throw new Error("Invalid loop taunt stop payload");
+  }
+
+  return {
+    sessionId: record["sessionId"],
+    playerName: record["playerName"],
+    id: record["id"].trim(),
+  };
+};
+
+const parseLoopTauntObservationPayload = (
+  payload: unknown,
+): ArmyLoopTauntObservationPayload => {
+  if (
+    typeof payload !== "object" ||
+    payload === null ||
+    Array.isArray(payload)
+  ) {
+    throw new Error("Invalid loop taunt observation payload");
+  }
+
+  const record = payload as Record<string, unknown>;
+  if (
+    typeof record["sessionId"] !== "string" ||
+    record["sessionId"].trim() === "" ||
+    typeof record["playerName"] !== "string" ||
+    record["playerName"].trim() === "" ||
+    typeof record["id"] !== "string" ||
+    record["id"].trim() === "" ||
+    typeof record["type"] !== "string" ||
+    typeof record["targetMonMapId"] !== "number" ||
+    !Number.isInteger(record["targetMonMapId"]) ||
+    record["targetMonMapId"] < 1
+  ) {
+    throw new Error("Invalid loop taunt observation payload");
+  }
+
+  const validTypes = new Set([
+    "aura-added",
+    "aura-missing",
+    "aura-removed",
+    "cast-outcome",
+    "client-cast-attempt",
+    "server-cast-confirmed",
+  ]);
+  if (!validTypes.has(record["type"])) {
+    throw new Error("Invalid loop taunt observation payload");
+  }
+
+  const validReasons = new Set<ArmyLoopTauntCastOutcomeReason>([
+    "failed",
+    "in-flight",
+    "not-alive",
+    "not-ready",
+    "not-usable",
+  ]);
+  const reason = record["reason"];
+  if (
+    hasOwn(record, "reason") &&
+    (typeof reason !== "string" ||
+      !validReasons.has(reason as ArmyLoopTauntCastOutcomeReason))
+  ) {
+    throw new Error("Invalid loop taunt observation payload");
+  }
+
+  const outcome = record["outcome"];
+  if (
+    hasOwn(record, "outcome") &&
+    outcome !== "cast" &&
+    outcome !== "skipped"
+  ) {
+    throw new Error("Invalid loop taunt observation payload");
+  }
+
+  return {
+    sessionId: record["sessionId"],
+    playerName: record["playerName"],
+    id: record["id"].trim(),
+    type: record["type"] as ArmyLoopTauntObservationPayload["type"],
+    targetMonMapId: record["targetMonMapId"],
+    ...(typeof record["auraName"] === "string"
+      ? { auraName: record["auraName"] }
+      : null),
+    ...(typeof record["auraIcon"] === "string"
+      ? { auraIcon: record["auraIcon"] }
+      : null),
+    ...(typeof record["epoch"] === "number" && Number.isInteger(record["epoch"])
+      ? { epoch: record["epoch"] }
+      : null),
+    ...(typeof record["attempt"] === "number" &&
+    Number.isInteger(record["attempt"])
+      ? { attempt: record["attempt"] }
+      : null),
+    ...(outcome === "cast" || outcome === "skipped" ? { outcome } : null),
+    ...(typeof reason === "string"
+      ? { reason: reason as ArmyLoopTauntCastOutcomeReason }
+      : null),
+  };
+};
+
 const resolvePlayerNumber = (
   session: Pick<ArmySessionState, "players">,
   playerName: string,
@@ -264,6 +505,9 @@ const rejectBarrier = (barrier: ArmyBarrierState, error: Error): void => {
   barrier.arrived.clear();
 };
 
+const armyBarrierKey = (step: number, label?: string): string =>
+  JSON.stringify([step, label ?? ""]);
+
 const abortSession = (session: ArmySessionState, reason: string): void => {
   sessions.delete(session.sessionId);
 
@@ -275,6 +519,8 @@ const abortSession = (session: ArmySessionState, reason: string): void => {
     rejectBarrier(barrier, new Error(reason));
   }
   session.barriers.clear();
+
+  session.loopTaunts.clear();
 
   for (const window of session.windows.values()) {
     const windowSessions = windowSessionIds.get(window);
@@ -389,12 +635,29 @@ const createSession = (
     );
   }
 
-  const session: ArmySessionState = {
+  let session: ArmySessionState;
+  const sessionId = `${Date.now().toString(36)}-${nextSessionId++}`;
+  const loopTaunts = new LoopTauntCoordinator({
+    sessionId,
+    sendCommand: (participant, command) => {
+      const window = session.windows.get(normalizePlayerName(participant.name));
+      if (
+        window &&
+        !window.isDestroyed() &&
+        !window.webContents.isDestroyed()
+      ) {
+        window.webContents.send(ArmyIpcChannels.loopTauntCommand, command);
+      }
+    },
+  });
+
+  session = {
     ...config,
-    sessionId: `${Date.now().toString(36)}-${nextSessionId++}`,
+    sessionId,
     playerKeys: new Set(config.players.map(normalizePlayerName)),
     windows: new Map<string, BrowserWindow>(),
-    barriers: new Map<number, ArmyBarrierState>(),
+    barriers: new Map<string, ArmyBarrierState>(),
+    loopTaunts,
   };
 
   sessions.set(session.sessionId, session);
@@ -448,7 +711,7 @@ const releaseBarrierIfComplete = (
   }
 
   clearTimeout(barrier.timer);
-  session.barriers.delete(barrier.step);
+  session.barriers.delete(barrier.key);
   for (const waiter of barrier.arrived.values()) {
     waiter.resolve();
   }
@@ -547,11 +810,12 @@ const waitAtBarrier = (
     return Promise.resolve();
   }
 
-  let barrier = session.barriers.get(payload.step);
+  const key = armyBarrierKey(payload.step, payload.label);
+  let barrier = session.barriers.get(key);
   if (!barrier) {
     const step = payload.step;
     const timer = setTimeout(() => {
-      const current = session.barriers.get(step);
+      const current = session.barriers.get(key);
       if (!current) {
         return;
       }
@@ -560,7 +824,7 @@ const waitAtBarrier = (
       const missing = current.expectedPlayers.filter(
         (player) => !arrived.has(normalizePlayerName(player)),
       );
-      session.barriers.delete(step);
+      session.barriers.delete(key);
       rejectBarrier(
         current,
         new Error(
@@ -572,6 +836,7 @@ const waitAtBarrier = (
     }, getBarrierTimeoutMs(payload));
 
     barrier = {
+      key,
       step,
       ...(payload.label !== undefined ? { label: payload.label } : null),
       expectedPlayerKeys: expectedPlayers.keys,
@@ -579,7 +844,7 @@ const waitAtBarrier = (
       arrived: new Map<string, DeferredVoid>(),
       timer,
     };
-    session.barriers.set(payload.step, barrier);
+    session.barriers.set(key, barrier);
   }
 
   if (barrier.arrived.has(playerKey)) {
@@ -720,6 +985,53 @@ export const registerArmyIpcHandlers = (): Effect.Effect<
           waitingBarriers: session.barriers.size,
         } satisfies ArmyStatusResult;
       }),
+    );
+
+    yield* ipc.handle(ArmyIpcChannels.loopTauntStart, (event, rawPayload) =>
+      Effect.sync(() => {
+        const payload = parseLoopTauntStartPayload(rawPayload);
+        const session = sessions.get(payload.sessionId);
+        if (!session) {
+          throw new Error("Army session is not active");
+        }
+
+        session.loopTaunts.start({
+          ...payload,
+          playerName: resolveSenderPlayerName(session, event.sender),
+        });
+      }),
+    );
+
+    yield* ipc.handle(ArmyIpcChannels.loopTauntStop, (event, rawPayload) =>
+      Effect.sync(() => {
+        const payload = parseLoopTauntStopPayload(rawPayload);
+        const session = sessions.get(payload.sessionId);
+        if (!session) {
+          return;
+        }
+
+        session.loopTaunts.stop({
+          ...payload,
+          playerName: resolveSenderPlayerName(session, event.sender),
+        });
+      }),
+    );
+
+    yield* ipc.handle(
+      ArmyIpcChannels.loopTauntObservation,
+      (event, rawPayload) =>
+        Effect.sync(() => {
+          const payload = parseLoopTauntObservationPayload(rawPayload);
+          const session = sessions.get(payload.sessionId);
+          if (!session) {
+            return;
+          }
+
+          session.loopTaunts.observe({
+            ...payload,
+            playerName: resolveSenderPlayerName(session, event.sender),
+          });
+        }),
     );
 
     yield* Effect.addFinalizer(() =>

--- a/app/src/main/preload.ts
+++ b/app/src/main/preload.ts
@@ -27,6 +27,10 @@ import {
   type ArmyBarrierPayload,
   type ArmyConfigPayload,
   type ArmyLeavePayload,
+  type ArmyLoopTauntCommandPayload,
+  type ArmyLoopTauntObservationPayload,
+  type ArmyLoopTauntStartPayload,
+  type ArmyLoopTauntStopPayload,
   type ArmySessionPayload,
   type ArmyStartPayload,
   type ArmyStatusPayload,
@@ -475,6 +479,34 @@ const bridge: AppBridge = {
         ArmyIpcChannels.status,
         payload,
       )) as ArmyStatusResult;
+    },
+    startLoopTaunt: async (payload: ArmyLoopTauntStartPayload) => {
+      await ipcRenderer.invoke(ArmyIpcChannels.loopTauntStart, payload);
+    },
+    stopLoopTaunt: async (payload: ArmyLoopTauntStopPayload) => {
+      await ipcRenderer.invoke(ArmyIpcChannels.loopTauntStop, payload);
+    },
+    publishLoopTauntObservation: async (
+      payload: ArmyLoopTauntObservationPayload,
+    ) => {
+      await ipcRenderer.invoke(ArmyIpcChannels.loopTauntObservation, payload);
+    },
+    onLoopTauntCommand: (listener) => {
+      const subscription = (
+        _event: unknown,
+        payload: ArmyLoopTauntCommandPayload,
+      ) => {
+        listener(payload);
+      };
+
+      ipcRenderer.on(ArmyIpcChannels.loopTauntCommand, subscription);
+
+      return () => {
+        ipcRenderer.removeListener(
+          ArmyIpcChannels.loopTauntCommand,
+          subscription,
+        );
+      };
     },
   },
   combatProfiles: {

--- a/app/src/renderer/windows/game/army/Layers/Army.loop-taunt.test.ts
+++ b/app/src/renderer/windows/game/army/Layers/Army.loop-taunt.test.ts
@@ -1,8 +1,18 @@
 import { Collection } from "@vexed/collection";
-import { EntityState, Monster, type Aura } from "@vexed/game";
+import { Avatar, EntityState, Monster, type Aura } from "@vexed/game";
 import { Effect, Layer, Option } from "effect";
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import type { ArmyBarrierPayload } from "../../../../../shared/army";
+import type {
+  ArmyLoopTauntCommandPayload,
+  ArmyLoopTauntObservationPayload,
+  ArmyLoopTauntStartPayload,
+  ArmyLoopTauntStopPayload,
+} from "../../../../../shared/army";
+import {
+  DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS,
+  DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS,
+} from "../LoopTaunt";
 import type { ArmySession } from "../Services/Army";
 import { Army } from "../Services/Army";
 import { Auth, type AuthShape } from "../../flash/Services/Auth";
@@ -33,6 +43,8 @@ const createStore = (): HandlerStore => ({
   antiCounterEnd: new Set(),
   antiCounterStart: new Set(),
   joinMap: new Set(),
+  loopTauntClientCastAttempt: new Set(),
+  loopTauntServerCastConfirmed: new Set(),
   monsterDeath: new Set(),
   playerLocation: new Set(),
   zone: new Set(),
@@ -81,9 +93,27 @@ const monster = new Monster({
   strMonName: "Ultra Boss",
 });
 
+const otherMonster = new Monster({
+  iLvl: 1,
+  intHP: 100,
+  intHPMax: 100,
+  intMP: 100,
+  intMPMax: 100,
+  intState: EntityState.Idle,
+  monId: 2,
+  monMapId: 8,
+  sRace: "None",
+  strFrame: "Boss",
+  strMonName: "Other Boss",
+});
+
 const auraKey = (auraName: string): string => auraName.trim().toLowerCase();
 
-const makeWorld = (auras: Map<string, Aura>): WorldShape => ({
+const makeWorld = (
+  auras: Map<string, Aura>,
+  playerNames: readonly string[],
+  playerAuras: ReadonlyMap<number, ReadonlyMap<string, Aura>> = new Map(),
+): WorldShape => ({
   map: {
     getCellMonsters: () => Effect.succeed([monster]),
     getCells: () => Effect.succeed(["Enter", "Boss"]),
@@ -105,11 +135,96 @@ const makeWorld = (auras: Map<string, Aura>): WorldShape => ({
     add: () => Effect.void,
     addAura: () => Effect.void,
     clearAuras: () => Effect.void,
-    get: () => Effect.succeed(Option.none()),
-    getAll: () => Effect.succeed(new Collection()),
-    getAura: () => Effect.succeed(Option.none()),
-    getAuras: () => Effect.succeed([]),
-    getByName: () => Effect.succeed(Option.none()),
+    get: (username) =>
+      Effect.succeed(
+        Option.fromNullishOr(
+          playerNames
+            .map(
+              (name, index) =>
+                new Avatar({
+                  afk: false,
+                  entID: index + 1,
+                  entType: "player",
+                  intHP: 100,
+                  intHPMax: 100,
+                  intLevel: 100,
+                  intMP: 100,
+                  intMPMax: 100,
+                  intState: EntityState.Idle,
+                  strFrame: "Boss",
+                  strPad: "Spawn",
+                  strUsername: name,
+                  tx: 0,
+                  ty: 0,
+                  uoName: name.toLowerCase(),
+                }),
+            )
+            .find(
+              (player) =>
+                player.username.toLowerCase() === username.toLowerCase(),
+            ),
+        ),
+      ),
+    getAll: () =>
+      Effect.succeed(
+        new Collection(
+          playerNames.map((name, index) => [
+            name.toLowerCase(),
+            new Avatar({
+              afk: false,
+              entID: index + 1,
+              entType: "player",
+              intHP: 100,
+              intHPMax: 100,
+              intLevel: 100,
+              intMP: 100,
+              intMPMax: 100,
+              intState: EntityState.Idle,
+              strFrame: "Boss",
+              strPad: "Spawn",
+              strUsername: name,
+              tx: 0,
+              ty: 0,
+              uoName: name.toLowerCase(),
+            }),
+          ]),
+        ),
+      ),
+    getAura: (entId, auraName) =>
+      Effect.succeed(
+        Option.fromNullishOr(playerAuras.get(entId)?.get(auraKey(auraName))),
+      ),
+    getAuras: (entId) =>
+      Effect.succeed(Array.from(playerAuras.get(entId)?.values() ?? [])),
+    getByName: (name) =>
+      Effect.succeed(
+        Option.fromNullishOr(
+          playerNames
+            .map(
+              (playerName, index) =>
+                new Avatar({
+                  afk: false,
+                  entID: index + 1,
+                  entType: "player",
+                  intHP: 100,
+                  intHPMax: 100,
+                  intLevel: 100,
+                  intMP: 100,
+                  intMPMax: 100,
+                  intState: EntityState.Idle,
+                  strFrame: "Boss",
+                  strPad: "Spawn",
+                  strUsername: playerName,
+                  tx: 0,
+                  ty: 0,
+                  uoName: playerName.toLowerCase(),
+                }),
+            )
+            .find(
+              (player) => player.username.toLowerCase() === name.toLowerCase(),
+            ),
+        ),
+      ),
     getSelf: () => Effect.succeed(Option.none()),
     register: () => Effect.void,
     remove: () => Effect.void,
@@ -128,8 +243,21 @@ const makeWorld = (auras: Map<string, Aura>): WorldShape => ({
         name === "Ultra Boss" ? Option.some(monster) : Option.none(),
       ),
     get: (monMapId) =>
-      Effect.succeed(monMapId === 7 ? Option.some(monster) : Option.none()),
-    getAll: () => Effect.succeed(new Collection([[7, monster]])),
+      Effect.succeed(
+        Option.fromNullishOr(
+          new Map([
+            [7, monster],
+            [8, otherMonster],
+          ]).get(monMapId),
+        ),
+      ),
+    getAll: () =>
+      Effect.succeed(
+        new Collection([
+          [7, monster],
+          [8, otherMonster],
+        ]),
+      ),
     getAura: (_monMapId, auraName) =>
       Effect.succeed(Option.fromNullishOr(auras.get(auraKey(auraName)))),
     removeAura: () => Effect.void,
@@ -164,11 +292,20 @@ const withArmy = async <A>(
   ) => Effect.Effect<A, unknown>,
   options?: {
     readonly hasAura?: boolean;
+    readonly isAlive?: () => Effect.Effect<boolean>;
+    readonly isReady?: () => Effect.Effect<boolean>;
+    readonly playerAuras?: ReadonlyMap<number, ReadonlyMap<string, Aura>>;
   },
 ): Promise<A> => {
   const store = createStore();
   const calls: string[] = [];
   const barriers: ArmyBarrierPayload[] = [];
+  const loopTauntCommandListeners = new Set<
+    (payload: ArmyLoopTauntCommandPayload) => void
+  >();
+  let loopTaunt:
+    | (ArmyLoopTauntStartPayload & { readonly nextIndex: number })
+    | undefined;
   const auras = new Map<string, Aura>();
   if (options?.hasAura === true) {
     auras.set(auraKey("Focus"), {
@@ -190,8 +327,69 @@ const withArmy = async <A>(
           },
           leave: async () => undefined,
           loadConfig: async () => session,
+          onLoopTauntCommand: (
+            listener: (payload: ArmyLoopTauntCommandPayload) => void,
+          ) => {
+            loopTauntCommandListeners.add(listener);
+            return () => {
+              loopTauntCommandListeners.delete(listener);
+            };
+          },
+          publishLoopTauntObservation: async (
+            observation: ArmyLoopTauntObservationPayload,
+          ) => {
+            if (
+              loopTaunt === undefined ||
+              loopTaunt.id !== observation.id ||
+              loopTaunt.targetMonMapId !== observation.targetMonMapId ||
+              (observation.type !== "aura-missing" &&
+                observation.type !== "aura-removed")
+            ) {
+              return;
+            }
+
+            const selected =
+              loopTaunt.participants[
+                loopTaunt.nextIndex % loopTaunt.participants.length
+              ];
+            if (selected === undefined) {
+              return;
+            }
+
+            loopTaunt = {
+              ...loopTaunt,
+              nextIndex: (loopTaunt.nextIndex + 1) % loopTaunt.participants.length,
+            };
+
+            const command: ArmyLoopTauntCommandPayload = {
+              attempt: 1,
+              epoch: loopTaunt.nextIndex,
+              id: loopTaunt.id,
+              reason: observation.type,
+              selected,
+              sessionId: loopTaunt.sessionId,
+              skill: loopTaunt.skill,
+              targetMonMapId: loopTaunt.targetMonMapId,
+            };
+            const sendCommand = () => {
+              for (const listener of loopTauntCommandListeners) {
+                listener(command);
+              }
+            };
+
+            setTimeout(
+              sendCommand,
+              observation.type === "aura-removed" ? loopTaunt.delayMs : 0,
+            );
+          },
           start: async () => session,
+          startLoopTaunt: async (payload: ArmyLoopTauntStartPayload) => {
+            loopTaunt = { ...payload, nextIndex: 0 };
+          },
           status: async () => ({ active: true }),
+          stopLoopTaunt: async (_payload: ArmyLoopTauntStopPayload) => {
+            loopTaunt = undefined;
+          },
         },
       },
     },
@@ -238,7 +436,13 @@ const withArmy = async <A>(
     exit: () => Effect.succeed(true),
     getConsumableSkillItem: () => Effect.succeed(null),
     getTarget: () =>
-      Effect.succeed(currentTargetMonMapId === 7 ? monster : null),
+      Effect.succeed(
+        currentTargetMonMapId === 7
+          ? monster
+          : currentTargetMonMapId === 8
+            ? otherMonster
+            : null,
+      ),
     hasTarget: () => Effect.succeed(false),
     hunt: () => Effect.succeed(""),
     kill: () => Effect.void,
@@ -279,9 +483,9 @@ const withArmy = async <A>(
     goToPlayer: () => Effect.void,
     hasActiveBoost: () => Effect.succeed(false),
     isAfk: () => Effect.succeed(false),
-    isAlive: () => Effect.succeed(true),
+    isAlive: options?.isAlive ?? (() => Effect.succeed(true)),
     isMember: () => Effect.succeed(false),
-    isReady: () => Effect.succeed(true),
+    isReady: options?.isReady ?? (() => Effect.succeed(true)),
     joinMap: () => Effect.void,
     jumpToCell: () => Effect.void,
     rest: () => Effect.void,
@@ -328,7 +532,9 @@ const withArmy = async <A>(
         Layer.succeed(PacketDomain)(packetDomain),
         Layer.succeed(Player)(player),
         Layer.succeed(Wait)(wait),
-        Layer.succeed(World)(makeWorld(auras)),
+        Layer.succeed(World)(
+          makeWorld(auras, session.players, options?.playerAuras),
+        ),
       ),
     ),
   );
@@ -373,6 +579,86 @@ test("Loop Taunt autonomously taunts first in aura mode when aura is absent", as
   expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
 });
 
+test("Loop Taunt skips local cast while player is petrified", async () => {
+  const calls = await withArmy(
+    makeSession(1),
+    (army, _emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep("100 millis");
+        yield* handle.stop();
+        return calls;
+      }),
+    {
+      playerAuras: new Map([
+        [
+          1,
+          new Map([
+            [
+              auraKey("Petrified"),
+              {
+                cat: "stone",
+                duration: 4,
+                name: "Petrified",
+              },
+            ],
+          ]),
+        ],
+      ]),
+    },
+  );
+
+  expect(calls).toEqual(["attack:7"]);
+});
+
+test("Loop Taunt selects replacement participant in aura mode", async () => {
+  const calls = await withArmy(makeSession(2), (army, _emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const handle = yield* army.startLoopTaunt({
+        aura: "Focus",
+        players: [1, 2],
+        shouldTaunt: ({ candidate }) => candidate.number === 2,
+        skill: 5,
+        target: "Ultra Boss",
+      });
+
+      yield* Effect.sleep("100 millis");
+      yield* handle.stop();
+      return calls;
+    }),
+  );
+
+  expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
+});
+
+test("Loop Taunt does not cast locally when replacement is another participant", async () => {
+  const calls = await withArmy(makeSession(1), (army, _emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const handle = yield* army.startLoopTaunt({
+        aura: "Focus",
+        players: [1, 2],
+        shouldTaunt: ({ candidate }) => candidate.number === 2,
+        skill: 5,
+        target: "Ultra Boss",
+      });
+
+      yield* Effect.sleep("100 millis");
+      yield* handle.stop();
+      return calls;
+    }),
+  );
+
+  expect(calls).toEqual(["attack:7"]);
+});
+
 test("Loop Taunt advances message turns and only casts on local player turn", async () => {
   const calls = await withArmy(makeSession(2), (army, emit, calls) =>
     Effect.gen(function* () {
@@ -406,73 +692,483 @@ test("Loop Taunt advances message turns and only casts on local player turn", as
   expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
 });
 
-test("Loop Taunt waits for aura removal and delay before next participant casts", async () => {
-  const result = await withArmy(makeSession(2), (army, emit, calls) =>
+test("Loop Taunt selects replacement participant in message mode", async () => {
+  const calls = await withArmy(makeSession(2), (army, emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const handle = yield* army.startLoopTaunt({
+        message: "defense shattering",
+        players: [1, 2],
+        shouldTaunt: ({ candidate }) => candidate.number === 2,
+        skill: 5,
+        target: "id:7",
+      });
+
+      yield* Effect.sleep("25 millis");
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 7,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+      });
+      yield* Effect.sleep("25 millis");
+
+      yield* handle.stop();
+      return calls;
+    }),
+  );
+
+  expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
+});
+
+test("Loop Taunt message mode prefers animation source monster id", async () => {
+  const calls = await withArmy(makeSession(2), (army, emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const handle = yield* army.startLoopTaunt({
+        message: "defense shattering",
+        players: [2],
+        skill: 5,
+        target: "id:7",
+      });
+
+      yield* Effect.sleep("25 millis");
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 8,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+        sourceMonMapId: 8,
+        targetMonMapId: 7,
+      });
+      yield* Effect.sleep("25 millis");
+      const afterWrongSource = [...calls];
+
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 7,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+        sourceMonMapId: 7,
+        targetMonMapId: 8,
+      });
+      yield* Effect.sleep("25 millis");
+
+      yield* handle.stop();
+      return { afterWrongSource, calls };
+    }),
+  );
+
+  expect(calls.afterWrongSource).toEqual(["attack:7"]);
+  expect(calls.calls).toEqual(["attack:7", "attack:7", "skill:5"]);
+});
+
+test("Loop Taunt debounces duplicate message triggers for the same target", async () => {
+  const calls = await withArmy(makeSession(2), (army, emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const handle = yield* army.startLoopTaunt({
+        debounceMs: 1000,
+        message: "defense shattering",
+        players: [2],
+        skill: 5,
+        target: "id:7",
+      });
+
+      yield* Effect.sleep("25 millis");
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 7,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+        sourceMonMapId: 7,
+      });
+      yield* Effect.sleep("25 millis");
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 7,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+        sourceMonMapId: 7,
+      });
+      yield* Effect.sleep("25 millis");
+
+      yield* handle.stop();
+      return calls;
+    }),
+  );
+
+  expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
+});
+
+test("Loop Taunt debounces message triggers per target", async () => {
+  const calls = await withArmy(makeSession(2), (army, emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const first = yield* army.startLoopTaunt({
+        debounceMs: 1000,
+        id: "first",
+        message: "defense shattering",
+        players: [2],
+        skill: 5,
+        target: "id:7",
+      });
+      const second = yield* army.startLoopTaunt({
+        debounceMs: 1000,
+        id: "second",
+        message: "defense shattering",
+        players: [2],
+        skill: 5,
+        target: "id:8",
+      });
+
+      yield* Effect.sleep("25 millis");
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 7,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+        sourceMonMapId: 7,
+      });
+      yield* emit("animationMessage", {
+        message: "defense shattering",
+        monMapId: 8,
+        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+        sourceMonMapId: 8,
+      });
+      yield* Effect.sleep("25 millis");
+
+      yield* first.stop();
+      yield* second.stop();
+      return calls;
+    }),
+  );
+
+  expect(calls.filter((call) => call === "skill:5")).toHaveLength(2);
+  expect(calls).toContain("attack:7");
+  expect(calls).toContain("attack:8");
+});
+
+test("Loop Taunt skips a candidate when shouldTaunt fails", async () => {
+  const calls = await withArmy(makeSession(2), (army, _emit, calls) =>
     Effect.gen(function* () {
       yield* army.start("config");
       const handle = yield* army.startLoopTaunt({
         aura: "Focus",
-        delayMs: 30,
         players: [1, 2],
+        shouldTaunt: ({ candidate }) => {
+          if (candidate.number === 1) {
+            throw new Error("candidate unavailable");
+          }
+
+          return true;
+        },
         skill: 5,
         target: "Ultra Boss",
       });
 
       yield* Effect.sleep("100 millis");
-      yield* emit("auraRemoved", {
-        auraName: "Focus",
-        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
-        targetId: 7,
-        targetType: "monster",
-      });
-      yield* Effect.sleep("50 millis");
-      const afterStaleRemoval = [...calls];
-
-      yield* emit("auraAdded", {
-        aura: { duration: 4, icon: "i,i,i,Chavengea2", name: "Focus" },
-        auraName: "Focus",
-        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
-        targetId: 7,
-        targetType: "monster",
-      });
-      yield* emit("auraRemoved", {
-        auraName: "Focus",
-        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
-        targetId: 7,
-        targetType: "monster",
-      });
-      yield* Effect.sleep("50 millis");
-      const afterClassFocus = [...calls];
-
-      yield* emit("auraAdded", {
-        aura: { duration: 6, icon: "iwd1,ied1", name: "Focus" },
-        auraName: "Focus",
-        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
-        targetId: 7,
-        targetType: "monster",
-      });
-      yield* emit("auraRemoved", {
-        auraName: "Focus",
-        packet: { cmd: "ct", data: {}, raw: "", type: "server" },
-        targetId: 7,
-        targetType: "monster",
-      });
-      yield* Effect.sleep("10 millis");
-      const beforeDelay = [...calls];
-      yield* Effect.sleep("50 millis");
-
       yield* handle.stop();
-      return {
-        afterClassFocus,
-        afterStaleRemoval,
-        beforeDelay,
-        calls,
-      };
+      return calls;
     }),
   );
 
-  expect(result.afterStaleRemoval).toEqual(["attack:7"]);
-  expect(result.afterClassFocus).toEqual(["attack:7"]);
+  expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
+});
+
+test("Loop Taunt shouldTaunt can skip a high Vendetta candidate", async () => {
+  const calls = await withArmy(
+    makeSession(2),
+    (army, _emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          players: [1, 2],
+          shouldTaunt: ({ candidate, world }) =>
+            Effect.gen(function* () {
+              const player = yield* world.players.getByName(candidate.name);
+              if (Option.isNone(player)) {
+                return false;
+              }
+
+              const vendetta = yield* world.players.getAura(
+                player.value.data.entID,
+                "Vendetta",
+              );
+              if (Option.isNone(vendetta)) {
+                return true;
+              }
+
+              return (vendetta.value.stack ?? vendetta.value.value ?? 1) <= 3;
+            }),
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep("100 millis");
+        yield* handle.stop();
+        return calls;
+      }),
+    {
+      playerAuras: new Map([
+        [
+          1,
+          new Map([
+            [auraKey("Vendetta"), { duration: 10, name: "Vendetta", stack: 4 }],
+          ]),
+        ],
+      ]),
+    },
+  );
+
+  expect(calls).toEqual(["attack:7", "attack:7", "skill:5"]);
+});
+
+test("Loop Taunt stops without casting when every participant is skipped", async () => {
+  const calls = await withArmy(makeSession(1), (army, _emit, calls) =>
+    Effect.gen(function* () {
+      yield* army.start("config");
+      const handle = yield* army.startLoopTaunt({
+        aura: "Focus",
+        players: [1, 2],
+        shouldTaunt: () => false,
+        skill: 5,
+        target: "Ultra Boss",
+      });
+
+      yield* Effect.sleep("100 millis");
+      yield* handle.stop();
+      return calls;
+    }),
+  );
+
+  expect(calls).toEqual(["attack:7"]);
+});
+
+test("Loop Taunt does not retry locally when selected player is unavailable", async () => {
+  vi.useFakeTimers();
+  try {
+    let aliveChecks = 0;
+    const promise = withArmy(
+      makeSession(1),
+      (army, _emit, calls) =>
+        Effect.gen(function* () {
+          yield* army.start("config");
+          const handle = yield* army.startLoopTaunt({
+            aura: "Focus",
+            delayMs: 0,
+            players: [1],
+            skill: 5,
+            target: "Ultra Boss",
+          });
+
+          yield* Effect.sleep(
+            `${DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS + 500} millis`,
+          );
+          yield* handle.stop();
+          return calls;
+        }),
+      {
+        isAlive: () =>
+          Effect.sync(() => {
+            aliveChecks += 1;
+            return aliveChecks > 1;
+          }),
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS + 500);
+    const calls = await promise;
+
+    expect(calls).toEqual(["attack:7"]);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("Loop Taunt leaves missed-turn handoff to the coordinator", async () => {
+  vi.useFakeTimers();
+  try {
+    const recoveryMs =
+      DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS +
+      DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS +
+      DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS +
+      50;
+    const promise = withArmy(makeSession(2), (army, _emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          delayMs: 0,
+          players: [1, 2],
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep(`${recoveryMs} millis`);
+        yield* handle.stop();
+        return calls;
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(recoveryMs);
+    const calls = await promise;
+
+    expect(calls).toEqual(["attack:7"]);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("Loop Taunt cancels recovery when Focus is restored", async () => {
+  vi.useFakeTimers();
+  try {
+    const recoveryMs =
+      DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS +
+      DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS +
+      DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS +
+      50;
+    const promise = withArmy(makeSession(2), (army, emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          delayMs: 0,
+          players: [1, 2],
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep(
+          `${DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS + 100} millis`,
+        );
+        yield* emit("auraAdded", {
+          aura: { duration: 6, icon: "iwd1,ied1", name: "Focus" },
+          auraName: "Focus",
+          packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+          targetId: 7,
+          targetType: "monster",
+        });
+        yield* Effect.sleep(`${recoveryMs} millis`);
+        yield* handle.stop();
+        return calls;
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(
+      recoveryMs + DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS + 100,
+    );
+    const calls = await promise;
+
+    expect(calls).toEqual(["attack:7"]);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("Loop Taunt renderer does not run local recovery timers", async () => {
+  vi.useFakeTimers();
+  try {
+    const delayMs = 1_000;
+    const beforeRecoveryMs =
+      delayMs + DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS - 1;
+    const recoveryMs =
+      DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS +
+      DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS +
+      50;
+    const promise = withArmy(makeSession(2), (army, _emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          delayMs,
+          players: [1, 2],
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep(`${beforeRecoveryMs} millis`);
+        const beforeRecovery = [...calls];
+        yield* Effect.sleep(`${recoveryMs} millis`);
+        yield* handle.stop();
+        return { beforeRecovery, calls };
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(beforeRecoveryMs + recoveryMs);
+    const result = await promise;
+
+    expect(result.beforeRecovery).toEqual(["attack:7"]);
+    expect(result.calls).toEqual(["attack:7"]);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("Loop Taunt finalizer interrupts pending recovery", async () => {
+  vi.useFakeTimers();
+  try {
+    const recoveryStartedMs = DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS + 100;
+    const afterStopMs =
+      DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS +
+      DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS +
+      100;
+    const promise = withArmy(makeSession(2), (army, _emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          delayMs: 0,
+          players: [1, 2],
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep(`${recoveryStartedMs} millis`);
+        yield* handle.stop();
+        yield* Effect.sleep(`${afterStopMs} millis`);
+        return calls;
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(recoveryStartedMs + afterStopMs);
+    const calls = await promise;
+
+    expect(calls).toEqual(["attack:7"]);
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test("Loop Taunt waits for aura removal and delay before next participant casts", async () => {
+  const result = await withArmy(
+    makeSession(2),
+    (army, emit, calls) =>
+      Effect.gen(function* () {
+        yield* army.start("config");
+        const handle = yield* army.startLoopTaunt({
+          aura: "Focus",
+          delayMs: 30,
+          players: [2],
+          skill: 5,
+          target: "Ultra Boss",
+        });
+
+        yield* Effect.sleep("100 millis");
+        yield* emit("auraRemoved", {
+          auraName: "Focus",
+          packet: { cmd: "ct", data: {}, raw: "", type: "server" },
+          targetId: 7,
+          targetType: "monster",
+        });
+        yield* Effect.sleep("10 millis");
+        const beforeDelay = [...calls];
+        yield* Effect.sleep("50 millis");
+
+        yield* handle.stop();
+        return {
+          beforeDelay,
+          calls,
+        };
+      }),
+    { hasAura: true },
+  );
+
   expect(result.beforeDelay).toEqual(["attack:7"]);
   expect(result.calls).toEqual(["attack:7", "attack:7", "skill:5"]);
 });

--- a/app/src/renderer/windows/game/army/Layers/Army.ts
+++ b/app/src/renderer/windows/game/army/Layers/Army.ts
@@ -6,6 +6,7 @@ import {
   Option,
   SynchronizedRef,
 } from "effect";
+import type { Aura } from "@vexed/game";
 import {
   Army,
   ArmyError,
@@ -16,15 +17,21 @@ import {
   type ArmyShape,
 } from "../Services/Army";
 import {
-  advanceLoopTauntTurn,
+  DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS,
+  DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS,
+  LOOP_TAUNT_ACTION_LOCK_AURA_CATEGORIES,
   matchesLoopTauntAuraAdd,
   matchesLoopTauntAura,
   matchesLoopTauntMessage,
   normalizeLoopTauntOptions,
-  ownsLoopTauntTurn,
   resolveTargetMonMapIdToken,
   type ArmyLoopTauntHandle,
+  type ArmyLoopTauntTurnContext,
+  type LoopTauntCastOutcome,
+  type LoopTauntTurnResolution,
+  type LoopTauntTurnState,
   type NormalizedLoopTauntOptions,
+  type ResolvedArmyPlayer,
 } from "../LoopTaunt";
 import { Auth } from "../../flash/Services/Auth";
 import { Combat } from "../../flash/Services/Combat";
@@ -32,7 +39,7 @@ import { Inventory } from "../../flash/Services/Inventory";
 import { PacketDomain } from "../../flash/Services/PacketDomain";
 import { Player } from "../../flash/Services/Player";
 import { Wait } from "../../flash/Services/Wait";
-import { World } from "../../flash/Services/World";
+import { World, type WorldShape } from "../../flash/Services/World";
 import { Jobs } from "../../jobs/Services/Jobs";
 
 interface ArmyState {
@@ -50,6 +57,44 @@ const DEFAULT_JOIN_PAD = "Spawn";
 const WAIT_FOR_MAP_TIMEOUT = "2 minutes";
 const LOOP_TAUNT_RESOLVE_INTERVAL = "250 millis";
 const LOOP_TAUNT_TARGET_SELECTION_TIMEOUT = "10 seconds";
+const LOOP_TAUNT_COMMAND_DEDUPE_EPOCHS = 8;
+const LOOP_TAUNT_ACTION_LOCK_CATEGORY_SET = new Set<string>(
+  LOOP_TAUNT_ACTION_LOCK_AURA_CATEGORIES,
+);
+
+const getLoopTauntActionLockCategory = (
+  auras: readonly Aura[],
+): string | undefined => {
+  for (const aura of auras) {
+    const category = aura.cat?.trim().toLowerCase();
+    if (
+      category !== undefined &&
+      LOOP_TAUNT_ACTION_LOCK_CATEGORY_SET.has(category)
+    ) {
+      return category;
+    }
+  }
+
+  return undefined;
+};
+
+const readPlayerActionLockCategory = (
+  world: WorldShape,
+  playerName: string,
+): Effect.Effect<string | undefined> =>
+  Effect.gen(function* () {
+    const self = yield* world.players
+      .getByName(playerName)
+      .pipe(Effect.catchCause(() => Effect.succeed(Option.none())));
+    if (Option.isNone(self)) {
+      return undefined;
+    }
+
+    const auras = yield* world.players
+      .getAuras(self.value.data.entID)
+      .pipe(Effect.catchCause(() => Effect.succeed([] as readonly Aura[])));
+    return getLoopTauntActionLockCategory(auras);
+  });
 
 const cloneSession = (session: ArmySession): ArmySession => ({
   ...session,
@@ -535,21 +580,23 @@ const make = Effect.gen(function* () {
       return monMapId;
     });
 
-  const runLoopTaunt = (
+  const runMainCoordinatedAuraLoopTaunt = (
     session: ArmySession,
-    options: NormalizedLoopTauntOptions,
+    options: NormalizedLoopTauntOptions & {
+      readonly trigger: Extract<NormalizedLoopTauntOptions["trigger"], { type: "aura" }>;
+    },
     initialTargetMonMapId: number,
     armedStep: number,
     armed: Deferred.Deferred<void, ArmyError>,
   ) =>
     Effect.scoped(
       Effect.gen(function* () {
-        let targetMonMapId: number | undefined = initialTargetMonMapId;
-        let turn = { nextIndex: 0 };
-        let initialAuraCheckComplete = false;
+        let targetMonMapId = initialTargetMonMapId;
         let armedComplete = false;
-        let targetAuraActive = false;
+        let initialAuraCheckComplete = false;
         let tauntInFlight = false;
+        let latestCommandEpoch = 0;
+        const handledCommandAttempts = new Map<number, Set<number>>();
         const pendingTauntFibers = new Set<ReturnType<typeof runFork>>();
 
         const log = (message: string, details?: Record<string, unknown>) =>
@@ -557,27 +604,33 @@ const make = Effect.gen(function* () {
             message,
             id: options.id,
             playerNumber: session.playerNumber,
-            ...(details ?? {}),
+            ...details,
           });
 
-        const resolveTarget = () =>
-          Effect.gen(function* () {
-            if (targetMonMapId !== undefined) {
-              return targetMonMapId;
-            }
+        const publishObservation = (
+          payload: Omit<
+            Parameters<typeof window.ipc.army.publishLoopTauntObservation>[0],
+            "id" | "playerName" | "sessionId" | "targetMonMapId"
+          >,
+        ) =>
+          fromArmyIpc("Failed to publish loop taunt observation", () =>
+            window.ipc.army.publishLoopTauntObservation({
+              id: options.id,
+              playerName: session.playerName,
+              sessionId: session.sessionId,
+              targetMonMapId,
+              ...payload,
+            }),
+          ).pipe(Effect.asVoid);
 
-            targetMonMapId = yield* resolveLoopTauntTarget(options);
-            return targetMonMapId;
-          });
-
-        const taunt = (monMapId: number) =>
+        const taunt = (monMapId: number): Effect.Effect<LoopTauntCastOutcome> =>
           Effect.gen(function* () {
             if (tauntInFlight) {
               yield* log("Loop Taunt cast skipped", {
-                reason: "cast already in flight",
                 monMapId,
+                reason: "cast already in flight",
               });
-              return;
+              return { reason: "in-flight", type: "skipped" } as const;
             }
 
             tauntInFlight = true;
@@ -589,13 +642,27 @@ const make = Effect.gen(function* () {
                 .isAlive()
                 .pipe(Effect.catchCause(() => Effect.succeed(false)));
               if (!ready || !alive) {
+                const reason = ready ? "not-alive" : "not-ready";
                 yield* log("Loop Taunt cast skipped", {
-                  reason: !ready ? "player not ready" : "player not alive",
-                  ready,
                   alive,
                   monMapId,
+                  ready,
+                  reason,
                 });
-                return;
+                return { reason, type: "skipped" } as const;
+              }
+
+              const actionLockCategory = yield* readPlayerActionLockCategory(
+                world,
+                session.playerName,
+              );
+              if (actionLockCategory !== undefined) {
+                yield* log("Loop Taunt cast skipped", {
+                  actionLockCategory,
+                  monMapId,
+                  reason: "player action locked",
+                });
+                return { reason: "not-usable", type: "skipped" } as const;
               }
 
               yield* log("Loop Taunt casting", {
@@ -604,15 +671,19 @@ const make = Effect.gen(function* () {
               });
               yield* combat.attackMonster(monMapId);
               yield* combat.useSkill(options.skill, true, true);
+              return { type: "cast" } as const;
             } finally {
               tauntInFlight = false;
             }
           }).pipe(
             Effect.catchCause((cause) =>
-              Effect.logError({
-                message: "loop taunt failed",
-                id: options.id,
-                cause,
+              Effect.gen(function* () {
+                yield* Effect.logError({
+                  cause,
+                  id: options.id,
+                  message: "loop taunt failed",
+                });
+                return { reason: "failed", type: "skipped" } as const;
               }),
             ),
           );
@@ -634,6 +705,724 @@ const make = Effect.gen(function* () {
             pendingTauntFibers.add(fiber);
           });
 
+        const onCommand = window.ipc.army.onLoopTauntCommand((command) => {
+          if (
+            command.sessionId !== session.sessionId ||
+            command.id !== options.id ||
+            command.targetMonMapId !== targetMonMapId ||
+            command.selected.number !== session.playerNumber
+          ) {
+            return;
+          }
+
+          if (command.epoch < latestCommandEpoch) {
+            return;
+          }
+
+          const attempts =
+            handledCommandAttempts.get(command.epoch) ?? new Set<number>();
+          handledCommandAttempts.set(command.epoch, attempts);
+          if (attempts.has(command.attempt)) {
+            return;
+          }
+
+          latestCommandEpoch = command.epoch;
+          attempts.add(command.attempt);
+          for (const epoch of handledCommandAttempts.keys()) {
+            if (epoch < latestCommandEpoch - LOOP_TAUNT_COMMAND_DEDUPE_EPOCHS) {
+              handledCommandAttempts.delete(epoch);
+            }
+          }
+
+          void Effect.runPromise(
+            forkTrackedTaunt(
+              Effect.gen(function* () {
+                const outcome = yield* taunt(command.targetMonMapId);
+                yield* publishObservation({
+                  attempt: command.attempt,
+                  epoch: command.epoch,
+                  outcome: outcome.type === "cast" ? "cast" : "skipped",
+                  ...(outcome.type === "skipped"
+                    ? { reason: outcome.reason }
+                    : null),
+                  type: "cast-outcome",
+                });
+              }),
+            ),
+          ).catch(() => undefined);
+        });
+
+        const onAuraAdded = yield* packetDomain.on("auraAdded", (event) =>
+          Effect.gen(function* () {
+            if (
+              !armedComplete ||
+              event.targetType !== "monster" ||
+              event.targetId !== targetMonMapId ||
+              !matchesLoopTauntAuraAdd(
+                options.trigger.aura,
+                event.auraName,
+                event.aura,
+              )
+            ) {
+              return;
+            }
+
+            const auraIcon = event.aura?.icon;
+            yield* publishObservation({
+              ...(auraIcon === undefined ? null : { auraIcon }),
+              auraName: event.auraName,
+              type: "aura-added",
+            }).pipe(Effect.ignore);
+            yield* log("Loop Taunt aura added", {
+              aura: event.auraName,
+              monMapId: targetMonMapId,
+            });
+          }),
+        );
+
+        const onAuraRemoved = yield* packetDomain.on("auraRemoved", (event) =>
+          Effect.gen(function* () {
+            if (
+              !armedComplete ||
+              event.targetType !== "monster" ||
+              event.targetId !== targetMonMapId ||
+              !matchesLoopTauntAura(options.trigger.aura, event.auraName)
+            ) {
+              return;
+            }
+
+            const remainingAura = yield* world.monsters
+              .getAura(targetMonMapId, options.trigger.aura)
+              .pipe(Effect.catchCause(() => Effect.succeed(Option.none())));
+            if (Option.isSome(remainingAura)) {
+              yield* log("Loop Taunt aura removal ignored", {
+                aura: event.auraName,
+                monMapId: targetMonMapId,
+                reason: "aura still active",
+                stack: remainingAura.value.stack,
+              });
+              return;
+            }
+
+            yield* publishObservation({
+              auraName: event.auraName,
+              type: "aura-removed",
+            }).pipe(Effect.ignore);
+            yield* log("Loop Taunt aura removed", {
+              aura: event.auraName,
+              delayMs: options.trigger.delayMs,
+              monMapId: targetMonMapId,
+            });
+          }),
+        );
+
+        const onClientCastAttempt = yield* packetDomain.on(
+          "loopTauntClientCastAttempt",
+          (event) =>
+            Effect.gen(function* () {
+              if (!armedComplete || event.monMapId !== targetMonMapId) {
+                return;
+              }
+
+              yield* publishObservation({ type: "client-cast-attempt" }).pipe(
+                Effect.ignore,
+              );
+            }),
+        );
+
+        const onServerCastConfirmed = yield* packetDomain.on(
+          "loopTauntServerCastConfirmed",
+          (event) =>
+            Effect.gen(function* () {
+              if (!armedComplete || event.monMapId !== targetMonMapId) {
+                return;
+              }
+
+              yield* publishObservation({
+                auraIcon: event.auraIcon,
+                auraName: event.auraName,
+                type: "server-cast-confirmed",
+              }).pipe(Effect.ignore);
+            }),
+        );
+
+        yield* Effect.addFinalizer(() =>
+          Effect.gen(function* () {
+            yield* Effect.sync(() => {
+              onCommand();
+              onAuraAdded();
+              onAuraRemoved();
+              onClientCastAttempt();
+              onServerCastConfirmed();
+            });
+            yield* Effect.forEach(
+              Array.from(pendingTauntFibers),
+              (fiber) => Fiber.interrupt(fiber),
+              { discard: true },
+            );
+            pendingTauntFibers.clear();
+            yield* fromArmyIpc("Failed to stop coordinated loop taunt", () =>
+              window.ipc.army.stopLoopTaunt({
+                id: options.id,
+                playerName: session.playerName,
+                sessionId: session.sessionId,
+              }),
+            ).pipe(Effect.ignore);
+          }),
+        );
+
+        yield* waitAtBarrier(
+          session,
+          armedStep,
+          `loop-taunt-armed:${options.id}`,
+          {
+            players: options.participants.map(
+              (participant) => participant.name,
+            ),
+          },
+        );
+
+        yield* fromArmyIpc("Failed to start coordinated loop taunt", () =>
+          window.ipc.army.startLoopTaunt({
+            aura: options.trigger.aura,
+            delayMs: options.trigger.delayMs,
+            id: options.id,
+            participants: options.participants,
+            playerName: session.playerName,
+            sessionId: session.sessionId,
+            skill: options.skill,
+            targetMonMapId,
+          }),
+        );
+        armedComplete = true;
+        yield* Deferred.succeed(armed, undefined).pipe(Effect.asVoid);
+        yield* log("Loop Taunt armed", {
+          monMapId: targetMonMapId,
+          participants: options.participants.map((participant) => ({
+            name: participant.name,
+            number: participant.number,
+          })),
+          target: options.target,
+          trigger: options.trigger.type,
+        });
+
+        while (true) {
+          if (!initialAuraCheckComplete) {
+            initialAuraCheckComplete = true;
+            const aura = yield* world.monsters.getAura(
+              targetMonMapId,
+              options.trigger.aura,
+            );
+            if (
+              Option.isNone(aura) ||
+              !matchesLoopTauntAuraAdd(
+                options.trigger.aura,
+                aura.value.name,
+                aura.value,
+              )
+            ) {
+              yield* publishObservation({
+                auraName: options.trigger.aura,
+                type: "aura-missing",
+              });
+              yield* log("Loop Taunt initial aura absent", {
+                aura: options.trigger.aura,
+                monMapId: targetMonMapId,
+              });
+            } else {
+              yield* log("Loop Taunt waiting for aura removal", {
+                aura: options.trigger.aura,
+                delayMs: options.trigger.delayMs,
+                monMapId: targetMonMapId,
+              });
+            }
+          }
+
+          yield* Effect.sleep(LOOP_TAUNT_RESOLVE_INTERVAL);
+        }
+      }),
+    ).pipe(
+      Effect.catchCause((cause) =>
+        Effect.gen(function* () {
+          yield* Effect.logError({
+            cause,
+            id: options.id,
+            message: "Coordinated Loop Taunt failed",
+          });
+          yield* Deferred.fail(
+            armed,
+            new ArmyError("Loop Taunt failed to arm", cause),
+          );
+          return yield* Effect.failCause(cause);
+        }),
+      ),
+    );
+
+  const runLoopTaunt = (
+    session: ArmySession,
+    options: NormalizedLoopTauntOptions,
+    initialTargetMonMapId: number,
+    armedStep: number,
+    armed: Deferred.Deferred<void, ArmyError>,
+  ) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        let targetMonMapId: number | undefined = initialTargetMonMapId;
+        let turn: LoopTauntTurnState = { nextIndex: 0, triggerCount: 0 };
+        let initialAuraCheckComplete = false;
+        let armedComplete = false;
+        let targetAuraActive = false;
+        let tauntInFlight = false;
+        const lastMessageTriggerAtByMonMapId = new Map<number, number>();
+        const pendingTauntFibers = new Set<ReturnType<typeof runFork>>();
+        let reconciliationToken = 0;
+        let pendingReconciliationFiber:
+          | ReturnType<typeof runFork>
+          | undefined;
+
+        const log = (message: string, details?: Record<string, unknown>) =>
+          Effect.logInfo({
+            message,
+            id: options.id,
+            playerNumber: session.playerNumber,
+            ...details,
+          });
+
+        const resolveTarget = () =>
+          Effect.gen(function* () {
+            if (targetMonMapId !== undefined) {
+              return targetMonMapId;
+            }
+
+            targetMonMapId = yield* resolveLoopTauntTarget(options);
+            return targetMonMapId;
+          });
+
+        const readTargetAuraActive = (monMapId: number) =>
+          Effect.gen(function* () {
+            if (options.trigger.type !== "aura") {
+              return false;
+            }
+
+            const aura = yield* world.monsters.getAura(
+              monMapId,
+              options.trigger.aura,
+            );
+            return (
+              Option.isSome(aura) &&
+              matchesLoopTauntAuraAdd(
+                options.trigger.aura,
+                aura.value.name,
+                aura.value,
+              )
+            );
+          });
+
+        const refreshTargetAuraActive = (monMapId: number) =>
+          Effect.gen(function* () {
+            targetAuraActive = yield* readTargetAuraActive(monMapId);
+            return targetAuraActive;
+          });
+
+        const taunt = (monMapId: number): Effect.Effect<LoopTauntCastOutcome> =>
+          Effect.gen(function* () {
+            if (tauntInFlight) {
+              yield* log("Loop Taunt cast skipped", {
+                reason: "cast already in flight",
+                monMapId,
+              });
+              return { reason: "in-flight", type: "skipped" } as const;
+            }
+
+            tauntInFlight = true;
+            try {
+              const ready = yield* player
+                .isReady()
+                .pipe(Effect.catchCause(() => Effect.succeed(false)));
+              const alive = yield* player
+                .isAlive()
+                .pipe(Effect.catchCause(() => Effect.succeed(false)));
+              if (!ready || !alive) {
+                yield* log("Loop Taunt cast skipped", {
+                  reason: !ready ? "player not ready" : "player not alive",
+                  ready,
+                  alive,
+                  monMapId,
+                });
+                return {
+                  reason: ready ? "not-alive" : "not-ready",
+                  type: "skipped",
+                } as const;
+              }
+
+              const actionLockCategory = yield* readPlayerActionLockCategory(
+                world,
+                session.playerName,
+              );
+              if (actionLockCategory !== undefined) {
+                yield* log("Loop Taunt cast skipped", {
+                  actionLockCategory,
+                  monMapId,
+                  reason: "player action locked",
+                });
+                return { reason: "not-usable", type: "skipped" } as const;
+              }
+
+              yield* log("Loop Taunt casting", {
+                monMapId,
+                skill: options.skill,
+              });
+              yield* combat.attackMonster(monMapId);
+              yield* combat.useSkill(options.skill, true, true);
+              return { type: "cast" } as const;
+            } finally {
+              tauntInFlight = false;
+            }
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                yield* Effect.logError({
+                  message: "loop taunt failed",
+                  id: options.id,
+                  cause,
+                });
+                return { reason: "failed", type: "skipped" } as const;
+              }),
+            ),
+          );
+
+        const forkTrackedTaunt = (effect: Effect.Effect<void, unknown>) =>
+          Effect.sync(() => {
+            let fiber: ReturnType<typeof runFork> | undefined;
+            fiber = runFork(
+              effect.pipe(
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    if (fiber !== undefined) {
+                      pendingTauntFibers.delete(fiber);
+                    }
+                  }),
+                ),
+              ),
+            );
+            pendingTauntFibers.add(fiber);
+          });
+
+        const cancelReconciliation = () =>
+          Effect.gen(function* () {
+            reconciliationToken += 1;
+            const fiber = pendingReconciliationFiber;
+            pendingReconciliationFiber = undefined;
+            if (fiber !== undefined) {
+              yield* Fiber.interrupt(fiber);
+            }
+          });
+
+        const isReconciliationCurrent = (token: number): boolean =>
+          token === reconciliationToken;
+
+        const waitForLocalRecovery = (
+          token: number,
+          monMapId: number,
+          selected: ResolvedArmyPlayer,
+        ) =>
+          Effect.gen(function* () {
+            const deadline = Date.now() + DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS;
+
+            while (Date.now() < deadline) {
+              if (!isReconciliationCurrent(token)) {
+                return false;
+              }
+
+              if (targetAuraActive || (yield* refreshTargetAuraActive(monMapId))) {
+                return false;
+              }
+
+              const ready = yield* player
+                .isReady()
+                .pipe(Effect.catchCause(() => Effect.succeed(false)));
+              const alive = yield* player
+                .isAlive()
+                .pipe(Effect.catchCause(() => Effect.succeed(false)));
+              if (ready && alive) {
+                yield* log("Loop Taunt recovery retrying selected player", {
+                  monMapId,
+                  selectedName: selected.name,
+                  selectedNumber: selected.number,
+                });
+                yield* taunt(monMapId);
+                return true;
+              }
+
+              yield* Effect.sleep(LOOP_TAUNT_RESOLVE_INTERVAL);
+            }
+
+            return false;
+          });
+
+        const clearCurrentReconciliation = (token: number) =>
+          Effect.sync(() => {
+            if (isReconciliationCurrent(token)) {
+              reconciliationToken += 1;
+              pendingReconciliationFiber = undefined;
+            }
+          });
+
+        const scheduleAuraReconciliation = (
+          monMapId: number,
+          resolution: LoopTauntTurnResolution,
+          delayMs: number,
+        ) =>
+          Effect.gen(function* () {
+            if (options.trigger.type !== "aura") {
+              return;
+            }
+
+            yield* cancelReconciliation();
+            const token = reconciliationToken;
+            const ownsSelected =
+              resolution.selected.number === session.playerNumber;
+
+            let fiber: ReturnType<typeof runFork> | undefined;
+            fiber = runFork(
+              Effect.gen(function* () {
+                const initialWaitMs =
+                  delayMs + DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS;
+                if (initialWaitMs > 0) {
+                  yield* Effect.sleep(`${initialWaitMs} millis`);
+                }
+
+                if (!isReconciliationCurrent(token)) {
+                  return;
+                }
+
+                if (targetAuraActive || (yield* refreshTargetAuraActive(monMapId))) {
+                  return;
+                }
+
+                yield* log("Loop Taunt recovery started", {
+                  monMapId,
+                  selectedName: resolution.selected.name,
+                  selectedNumber: resolution.selected.number,
+                  triggerCount: turn.triggerCount,
+                });
+
+                if (ownsSelected) {
+                  yield* waitForLocalRecovery(
+                    token,
+                    monMapId,
+                    resolution.selected,
+                  );
+                } else {
+                  yield* Effect.sleep(
+                    `${DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS} millis`,
+                  );
+                }
+
+                if (!isReconciliationCurrent(token)) {
+                  return;
+                }
+
+                yield* Effect.sleep(
+                  `${DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS} millis`,
+                );
+
+                if (!isReconciliationCurrent(token)) {
+                  return;
+                }
+
+                if (targetAuraActive || (yield* refreshTargetAuraActive(monMapId))) {
+                  return;
+                }
+
+                yield* log("Loop Taunt recovery expired", {
+                  monMapId,
+                  selectedName: resolution.selected.name,
+                  selectedNumber: resolution.selected.number,
+                  triggerCount: turn.triggerCount,
+                });
+                yield* clearCurrentReconciliation(token);
+                yield* triggerNextTurn(monMapId, "missed cast recovery expired");
+              }).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logError({
+                    message: "Loop Taunt recovery failed",
+                    id: options.id,
+                    monMapId,
+                    selectedName: resolution.selected.name,
+                    selectedNumber: resolution.selected.number,
+                    cause,
+                  }),
+                ),
+                Effect.ensuring(
+                  Effect.sync(() => {
+                    if (
+                      fiber !== undefined &&
+                      pendingReconciliationFiber === fiber
+                    ) {
+                      pendingReconciliationFiber = undefined;
+                    }
+                  }),
+                ),
+              ),
+            );
+            pendingReconciliationFiber = fiber;
+          });
+
+        const localPlayer = {
+          name: session.playerName,
+          number: session.playerNumber,
+        };
+
+        const readonlyWorld: ArmyLoopTauntTurnContext["world"] = {
+          monsters: {
+            get: world.monsters.get,
+            getAura: world.monsters.getAura,
+          },
+          players: {
+            getAll: world.players.getAll,
+            getAura: world.players.getAura,
+            getAuras: world.players.getAuras,
+            getByName: world.players.getByName,
+          },
+        };
+
+        const shouldCandidateTaunt = (
+          context: ArmyLoopTauntTurnContext,
+        ): Effect.Effect<boolean> =>
+          Effect.suspend(() => {
+            if (options.shouldTaunt === undefined) {
+              return Effect.succeed(true);
+            }
+
+            const result = options.shouldTaunt(context);
+            return Effect.isEffect(result)
+              ? (result as Effect.Effect<boolean, unknown>)
+              : Effect.succeed(result);
+          }).pipe(
+            Effect.map((result) => result === true),
+            Effect.catchCause((cause) =>
+              Effect.gen(function* () {
+                yield* Effect.logError({
+                  message: "Loop Taunt shouldTaunt failed",
+                  id: options.id,
+                  candidateName: context.candidate.name,
+                  candidateNumber: context.candidate.number,
+                  scheduledName: context.scheduled.name,
+                  scheduledNumber: context.scheduled.number,
+                  triggerCount: context.turn.triggerCount,
+                  cause,
+                });
+                return false;
+              }),
+            ),
+          );
+
+        const resolveTurn = (
+          monMapId: number,
+          currentTurn: LoopTauntTurnState,
+        ): Effect.Effect<LoopTauntTurnResolution, ArmyError> =>
+          Effect.gen(function* () {
+            if (options.participants.length === 0) {
+              return yield* Effect.fail(
+                new ArmyError("Loop Taunt requires at least one participant"),
+              );
+            }
+
+            const startIndex =
+              currentTurn.nextIndex % options.participants.length;
+            const scheduled = options.participants[startIndex]!;
+            const skipped: ResolvedArmyPlayer[] = [];
+
+            yield* log("Loop Taunt turn resolving", {
+              monMapId,
+              scheduledName: scheduled.name,
+              scheduledNumber: scheduled.number,
+              trigger: options.trigger.type,
+              triggerCount: currentTurn.triggerCount,
+            });
+
+            for (
+              let offset = 0;
+              offset < options.participants.length;
+              offset += 1
+            ) {
+              const candidateIndex =
+                (startIndex + offset) % options.participants.length;
+              const candidate = options.participants[candidateIndex]!;
+              const shouldTaunt = yield* shouldCandidateTaunt({
+                candidate,
+                id: options.id,
+                localPlayer,
+                participants: options.participants,
+                scheduled,
+                target: {
+                  monMapId,
+                  token: options.target,
+                },
+                trigger: options.trigger,
+                turn: {
+                  index: currentTurn.nextIndex,
+                  triggerCount: currentTurn.triggerCount,
+                },
+                world: readonlyWorld,
+              });
+
+              if (shouldTaunt) {
+                const nextState = {
+                  nextIndex: (candidateIndex + 1) % options.participants.length,
+                  triggerCount: currentTurn.triggerCount + 1,
+                };
+                return {
+                  nextState,
+                  scheduled,
+                  selected: candidate,
+                  selectedIndex: candidateIndex,
+                  skipped,
+                };
+              }
+
+              skipped.push(candidate);
+              yield* log("Loop Taunt candidate skipped", {
+                candidateName: candidate.name,
+                candidateNumber: candidate.number,
+                monMapId,
+                scheduledName: scheduled.name,
+                scheduledNumber: scheduled.number,
+                triggerCount: currentTurn.triggerCount,
+              });
+            }
+
+            yield* log("Loop Taunt no eligible participant", {
+              monMapId,
+              noEligiblePolicy: options.noEligiblePolicy,
+              scheduledName: scheduled.name,
+              scheduledNumber: scheduled.number,
+              skipped: skipped.map((participant) => ({
+                name: participant.name,
+                number: participant.number,
+              })),
+              triggerCount: currentTurn.triggerCount,
+            });
+
+            if (options.noEligiblePolicy === "cast-scheduled") {
+              return {
+                nextState: {
+                  nextIndex: (startIndex + 1) % options.participants.length,
+                  triggerCount: currentTurn.triggerCount + 1,
+                },
+                scheduled,
+                selected: scheduled,
+                selectedIndex: startIndex,
+                skipped,
+              };
+            }
+
+            return yield* Effect.fail(
+              new ArmyError("Loop Taunt found no eligible participant"),
+            );
+          });
+
         const triggerNextTurn = (
           monMapId: number,
           reason: string,
@@ -641,19 +1430,57 @@ const make = Effect.gen(function* () {
         ) =>
           Effect.gen(function* () {
             const currentTurn = turn;
-            const participant = options.participants[currentTurn.nextIndex];
-            const ownsTurn = ownsLoopTauntTurn(
-              options.participants,
-              session.playerNumber,
-              currentTurn,
+            const resolution = yield* resolveTurn(monMapId, currentTurn).pipe(
+              Effect.catchCause((cause) =>
+                Effect.gen(function* () {
+                  yield* Effect.logError({
+                    message: "Loop Taunt turn resolution failed",
+                    id: options.id,
+                    monMapId,
+                    reason,
+                    triggerCount: currentTurn.triggerCount,
+                    cause,
+                  });
+                  yield* jobs.stop(loopTauntJobKey(options.id));
+                  return undefined;
+                }),
+              ),
             );
-            turn = advanceLoopTauntTurn(options.participants, currentTurn);
+
+            if (resolution === undefined) {
+              return;
+            }
+
+            turn = resolution.nextState;
+            const ownsTurn =
+              resolution.selected.number === session.playerNumber;
+
+            yield* log("Loop Taunt turn selected", {
+              reason,
+              monMapId,
+              scheduledName: resolution.scheduled.name,
+              scheduledNumber: resolution.scheduled.number,
+              selectedName: resolution.selected.name,
+              selectedNumber: resolution.selected.number,
+              selectedIndex: resolution.selectedIndex,
+              skipped: resolution.skipped.map((participant) => ({
+                name: participant.name,
+                number: participant.number,
+              })),
+              trigger: options.trigger.type,
+              triggerCount: currentTurn.triggerCount,
+              nextParticipantNumber:
+                options.participants[turn.nextIndex]?.number,
+            });
+
+            yield* scheduleAuraReconciliation(monMapId, resolution, delayMs);
+
             if (ownsTurn) {
               yield* log("Loop Taunt turn matched local player", {
                 reason,
                 monMapId,
-                participantNumber: participant?.number,
-                participantName: participant?.name,
+                participantNumber: resolution.selected.number,
+                participantName: resolution.selected.name,
                 delayMs,
                 nextParticipantNumber:
                   options.participants[turn.nextIndex]?.number,
@@ -671,8 +1498,8 @@ const make = Effect.gen(function* () {
               yield* log("Loop Taunt waiting for turn", {
                 reason,
                 monMapId,
-                participantNumber: participant?.number,
-                participantName: participant?.name,
+                participantNumber: resolution.selected.number,
+                participantName: resolution.selected.name,
                 delayMs,
                 nextParticipantNumber:
                   options.participants[turn.nextIndex]?.number,
@@ -765,6 +1592,7 @@ const make = Effect.gen(function* () {
 
             initialAuraCheckComplete = true;
             targetAuraActive = true;
+            yield* cancelReconciliation();
             yield* log("Loop Taunt aura added", {
               aura: event.auraName,
               monMapId,
@@ -839,12 +1667,31 @@ const make = Effect.gen(function* () {
               }
 
               const monMapId = yield* resolveTarget();
-              if (
-                monMapId === undefined ||
-                event.monMapId === undefined ||
-                event.monMapId !== monMapId
-              ) {
+              const eventMonMapId =
+                event.sourceMonMapId ?? event.targetMonMapId ?? event.monMapId;
+              if (monMapId === undefined || eventMonMapId !== monMapId) {
                 return;
+              }
+
+              if (options.trigger.debounceMs > 0) {
+                const now = Date.now();
+                const lastTriggeredAt =
+                  lastMessageTriggerAtByMonMapId.get(monMapId);
+                if (
+                  lastTriggeredAt !== undefined &&
+                  now - lastTriggeredAt < options.trigger.debounceMs
+                ) {
+                  yield* log("Loop Taunt message debounced", {
+                    configuredMessage: options.trigger.message,
+                    animationMessage: event.message,
+                    debounceMs: options.trigger.debounceMs,
+                    elapsedMs: now - lastTriggeredAt,
+                    monMapId,
+                  });
+                  return;
+                }
+
+                lastMessageTriggerAtByMonMapId.set(monMapId, now);
               }
 
               yield* log("Loop Taunt message matched", {
@@ -884,6 +1731,12 @@ const make = Effect.gen(function* () {
               { discard: true },
             );
             pendingTauntFibers.clear();
+            const reconciliationFiber = pendingReconciliationFiber;
+            pendingReconciliationFiber = undefined;
+            reconciliationToken += 1;
+            if (reconciliationFiber !== undefined) {
+              yield* Fiber.interrupt(reconciliationFiber);
+            }
           }),
         );
 
@@ -991,9 +1844,24 @@ const make = Effect.gen(function* () {
         id: normalized.id,
         monMapId,
       });
+      const loopTauntEffect =
+        normalized.trigger.type === "aura" && normalized.shouldTaunt === undefined
+          ? runMainCoordinatedAuraLoopTaunt(
+              session,
+              normalized as NormalizedLoopTauntOptions & {
+                readonly trigger: Extract<
+                  NormalizedLoopTauntOptions["trigger"],
+                  { type: "aura" }
+                >;
+              },
+              monMapId,
+              armedStep,
+              armed,
+            )
+          : runLoopTaunt(session, normalized, monMapId, armedStep, armed);
       yield* jobs.start(
         key,
-        runLoopTaunt(session, normalized, monMapId, armedStep, armed),
+        loopTauntEffect,
         {
           replace: true,
         },

--- a/app/src/renderer/windows/game/army/LoopTaunt.test.ts
+++ b/app/src/renderer/windows/game/army/LoopTaunt.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 import {
   advanceLoopTauntTurn,
   DEFAULT_LOOP_TAUNT_DELAY_MS,
+  DEFAULT_LOOP_TAUNT_MESSAGE_DEBOUNCE_MS,
   LOOP_TAUNT_FOCUS_AURA_ICON,
   matchesLoopTauntAuraAdd,
   matchesLoopTauntMessage,
   normalizeLoopTauntOptions,
   ownsLoopTauntTurn,
+  resolveLoopTauntTurn,
   resolveLoopTauntParticipants,
 } from "./LoopTaunt";
 
@@ -15,9 +17,16 @@ const players = ["Main", "Alt", "Third"] as const;
 describe("Loop Taunt helpers", () => {
   it("requires an explicit target, skill, and single trigger", () => {
     const normalized = normalizeLoopTauntOptions(
-      { aura: "Focus", skill: 5, target: "Boss" },
+      {
+        aura: "Focus",
+        shouldTaunt: () => true,
+        skill: 5,
+        target: "Boss",
+      },
       players,
     );
+    expect(normalized.noEligiblePolicy).toBe("throw");
+    expect(normalized.shouldTaunt).toBeTypeOf("function");
     expect(normalized.trigger).toEqual({
       aura: "Focus",
       delayMs: DEFAULT_LOOP_TAUNT_DELAY_MS,
@@ -31,12 +40,32 @@ describe("Loop Taunt helpers", () => {
       ),
     ).not.toThrow();
 
-    expect(() =>
+    expect(
       normalizeLoopTauntOptions(
         { message: "defense shattering", skill: 5, target: "Boss" },
         players,
-      ),
-    ).not.toThrow();
+      ).trigger,
+    ).toEqual({
+      debounceMs: DEFAULT_LOOP_TAUNT_MESSAGE_DEBOUNCE_MS,
+      message: "defense shattering",
+      type: "message",
+    });
+
+    expect(
+      normalizeLoopTauntOptions(
+        {
+          debounceMs: 1234.9,
+          message: "defense shattering",
+          skill: 5,
+          target: "Boss",
+        },
+        players,
+      ).trigger,
+    ).toEqual({
+      debounceMs: 1234,
+      message: "defense shattering",
+      type: "message",
+    });
 
     expect(() =>
       normalizeLoopTauntOptions({ skill: 5, target: "Boss" } as never, players),
@@ -69,6 +98,42 @@ describe("Loop Taunt helpers", () => {
         players,
       ),
     ).toThrow(/delayMs/);
+
+    expect(() =>
+      normalizeLoopTauntOptions(
+        {
+          debounceMs: -1,
+          message: "defense shattering",
+          skill: 5,
+          target: "Boss",
+        },
+        players,
+      ),
+    ).toThrow(/debounceMs/);
+
+    expect(() =>
+      normalizeLoopTauntOptions(
+        {
+          aura: "Focus",
+          shouldTaunt: true,
+          skill: 5,
+          target: "Boss",
+        } as never,
+        players,
+      ),
+    ).toThrow(/shouldTaunt/);
+
+    expect(() =>
+      normalizeLoopTauntOptions(
+        {
+          aura: "Focus",
+          noEligiblePolicy: "skip",
+          skill: 5,
+          target: "Boss",
+        } as never,
+        players,
+      ),
+    ).toThrow(/noEligiblePolicy/);
   });
 
   it("resolves participants by army slots or names while preserving order", () => {
@@ -98,16 +163,91 @@ describe("Loop Taunt helpers", () => {
 
   it("advances turns in round-robin order", () => {
     const participants = resolveLoopTauntParticipants(players, [2, 1]);
-    let state = { nextIndex: 0 };
+    let state = { nextIndex: 0, triggerCount: 0 };
 
     expect(ownsLoopTauntTurn(participants, 2, state)).toBe(true);
     expect(ownsLoopTauntTurn(participants, 1, state)).toBe(false);
 
     state = advanceLoopTauntTurn(participants, state);
+    expect(state.triggerCount).toBe(0);
     expect(ownsLoopTauntTurn(participants, 1, state)).toBe(true);
 
     state = advanceLoopTauntTurn(participants, state);
     expect(ownsLoopTauntTurn(participants, 2, state)).toBe(true);
+  });
+
+  it("resolves turn selection from the scheduled participant", () => {
+    const participants = resolveLoopTauntParticipants(players, [2, 1, 3]);
+    const resolution = resolveLoopTauntTurn(
+      participants,
+      { nextIndex: 0, triggerCount: 2 },
+      () => true,
+    );
+
+    expect(resolution.scheduled).toEqual({ name: "Alt", number: 2 });
+    expect(resolution.selected).toEqual({ name: "Alt", number: 2 });
+    expect(resolution.skipped).toEqual([]);
+    expect(resolution.nextState).toEqual({ nextIndex: 1, triggerCount: 3 });
+  });
+
+  it("skips candidates and advances after the selected replacement", () => {
+    const participants = resolveLoopTauntParticipants(players, [2, 1, 3]);
+    const resolution = resolveLoopTauntTurn(
+      participants,
+      { nextIndex: 0, triggerCount: 0 },
+      (candidate) => candidate.number === 3,
+    );
+
+    expect(resolution.scheduled).toEqual({ name: "Alt", number: 2 });
+    expect(resolution.selected).toEqual({ name: "Third", number: 3 });
+    expect(resolution.skipped).toEqual([
+      { name: "Alt", number: 2 },
+      { name: "Main", number: 1 },
+    ]);
+    expect(resolution.nextState).toEqual({ nextIndex: 0, triggerCount: 1 });
+  });
+
+  it("wraps turn selection around the participant list", () => {
+    const participants = resolveLoopTauntParticipants(players, [2, 1, 3]);
+    const resolution = resolveLoopTauntTurn(
+      participants,
+      { nextIndex: 2, triggerCount: 0 },
+      (candidate) => candidate.number === 2,
+    );
+
+    expect(resolution.scheduled).toEqual({ name: "Third", number: 3 });
+    expect(resolution.selected).toEqual({ name: "Alt", number: 2 });
+    expect(resolution.skipped).toEqual([{ name: "Third", number: 3 }]);
+    expect(resolution.nextState).toEqual({ nextIndex: 1, triggerCount: 1 });
+  });
+
+  it("handles no eligible candidates according to policy", () => {
+    const participants = resolveLoopTauntParticipants(players, [2, 1]);
+
+    expect(() =>
+      resolveLoopTauntTurn(
+        participants,
+        { nextIndex: 0, triggerCount: 0 },
+        () => false,
+      ),
+    ).toThrow(/no eligible/);
+
+    expect(
+      resolveLoopTauntTurn(
+        participants,
+        { nextIndex: 0, triggerCount: 0 },
+        () => false,
+        "cast-scheduled",
+      ),
+    ).toMatchObject({
+      nextState: { nextIndex: 1, triggerCount: 1 },
+      scheduled: { name: "Alt", number: 2 },
+      selected: { name: "Alt", number: 2 },
+      skipped: [
+        { name: "Alt", number: 2 },
+        { name: "Main", number: 1 },
+      ],
+    });
   });
 
   it("matches combat messages case-insensitively with normalized whitespace", () => {

--- a/app/src/renderer/windows/game/army/LoopTaunt.ts
+++ b/app/src/renderer/windows/game/army/LoopTaunt.ts
@@ -1,14 +1,78 @@
 import { parseMonsterMapIdToken } from "@vexed/game";
 import type { Aura } from "@vexed/game";
 import { equalsIgnoreCase } from "@vexed/shared/string";
+import type { Effect } from "effect";
+import type {
+  WorldMonstersShape,
+  WorldPlayersShape,
+} from "../flash/Services/World";
 import type { ArmyEffect } from "./Services/Army";
+export {
+  DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS,
+  DEFAULT_LOOP_TAUNT_DELAY_MS,
+  DEFAULT_LOOP_TAUNT_MESSAGE_DEBOUNCE_MS,
+  DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS,
+  LOOP_TAUNT_ACTION_LOCK_AURA_CATEGORIES,
+  LOOP_TAUNT_FOCUS_AURA_ICON,
+  LOOP_TAUNT_RETRY_SETTLE_MS,
+  LOOP_TAUNT_SHORT_RETRY_MS,
+} from "../../../../shared/loop-taunt";
+import {
+  DEFAULT_LOOP_TAUNT_DELAY_MS,
+  DEFAULT_LOOP_TAUNT_MESSAGE_DEBOUNCE_MS,
+  LOOP_TAUNT_FOCUS_AURA_ICON,
+} from "../../../../shared/loop-taunt";
 
 // Army player number or player name.
 export type ArmyLoopTauntPlayer = number | string;
 
+export type ArmyLoopTauntNoEligiblePolicy = "throw" | "cast-scheduled";
+
+export type NormalizedLoopTauntTrigger =
+  | {
+      readonly aura: string;
+      readonly delayMs: number;
+      readonly type: "aura";
+    }
+  | {
+      readonly debounceMs: number;
+      readonly message: string;
+      readonly type: "message";
+    };
+
+export interface ArmyLoopTauntTurnContext {
+  readonly id: string;
+  readonly target: {
+    readonly token: MonsterIdentifierToken;
+    readonly monMapId: number;
+  };
+  readonly localPlayer: ResolvedArmyPlayer;
+  readonly scheduled: ResolvedArmyPlayer;
+  readonly candidate: ResolvedArmyPlayer;
+  readonly participants: readonly ResolvedArmyPlayer[];
+  readonly turn: {
+    readonly index: number;
+    readonly triggerCount: number;
+  };
+  readonly trigger: NormalizedLoopTauntTrigger;
+  readonly world: {
+    readonly players: Pick<
+      WorldPlayersShape,
+      "getAll" | "getByName" | "getAuras" | "getAura"
+    >;
+    readonly monsters: Pick<WorldMonstersShape, "get" | "getAura">;
+  };
+}
+
+export type ArmyLoopTauntShouldTaunt = (
+  context: ArmyLoopTauntTurnContext,
+) => boolean | Effect.Effect<boolean, unknown>;
+
 interface ArmyLoopTauntBaseOptions {
   readonly id?: string;
+  readonly noEligiblePolicy?: ArmyLoopTauntNoEligiblePolicy;
   readonly players?: readonly ArmyLoopTauntPlayer[];
+  readonly shouldTaunt?: ArmyLoopTauntShouldTaunt;
   readonly skill: Skill;
   readonly target: MonsterIdentifierToken;
 }
@@ -17,10 +81,12 @@ export type ArmyLoopTauntOptions =
   | (ArmyLoopTauntBaseOptions & {
       readonly aura: string;
       readonly delayMs?: number;
+      readonly debounceMs?: never;
       readonly message?: never;
     })
   | (ArmyLoopTauntBaseOptions & {
       readonly aura?: never;
+      readonly debounceMs?: number;
       readonly delayMs?: never;
       readonly message: string;
     });
@@ -37,27 +103,40 @@ export interface ResolvedArmyPlayer {
 
 export type NormalizedLoopTauntOptions = {
   readonly id: string;
+  readonly noEligiblePolicy: ArmyLoopTauntNoEligiblePolicy;
   readonly participants: readonly ResolvedArmyPlayer[];
+  readonly shouldTaunt?: ArmyLoopTauntShouldTaunt;
   readonly skill: Skill;
   readonly target: MonsterIdentifierToken;
-  readonly trigger:
-    | {
-        readonly aura: string;
-        readonly delayMs: number;
-        readonly type: "aura";
-      }
-    | {
-        readonly message: string;
-        readonly type: "message";
-      };
+  readonly trigger: NormalizedLoopTauntTrigger;
 };
 
 export interface LoopTauntTurnState {
   readonly nextIndex: number;
+  readonly triggerCount: number;
 }
 
-export const DEFAULT_LOOP_TAUNT_DELAY_MS = 4_000;
-export const LOOP_TAUNT_FOCUS_AURA_ICON = "iwd1,ied1"; // Scroll of Enrage
+export interface LoopTauntTurnResolution {
+  readonly nextState: LoopTauntTurnState;
+  readonly scheduled: ResolvedArmyPlayer;
+  readonly selected: ResolvedArmyPlayer;
+  readonly selectedIndex: number;
+  readonly skipped: readonly ResolvedArmyPlayer[];
+}
+
+export type LoopTauntCastOutcome =
+  | {
+      readonly type: "cast";
+    }
+  | {
+      readonly reason:
+        | "failed"
+        | "in-flight"
+        | "not-alive"
+        | "not-ready"
+        | "not-usable";
+      readonly type: "skipped";
+    };
 
 const normalizeText = (value: string): string =>
   value.trim().toLowerCase().replace(/\s+/g, " ");
@@ -167,6 +246,50 @@ const assertValidDelayMs = (delayMs: unknown): number => {
   return Math.trunc(delayMs);
 };
 
+const assertValidMessageDebounceMs = (debounceMs: unknown): number => {
+  if (debounceMs === undefined) {
+    return DEFAULT_LOOP_TAUNT_MESSAGE_DEBOUNCE_MS;
+  }
+
+  if (
+    typeof debounceMs !== "number" ||
+    !Number.isFinite(debounceMs) ||
+    debounceMs < 0
+  ) {
+    throw new Error("debounceMs must be a finite non-negative number");
+  }
+
+  return Math.trunc(debounceMs);
+};
+
+const assertValidNoEligiblePolicy = (
+  policy: unknown,
+): ArmyLoopTauntNoEligiblePolicy => {
+  if (policy === undefined) {
+    return "throw";
+  }
+
+  if (policy !== "throw" && policy !== "cast-scheduled") {
+    throw new Error('noEligiblePolicy must be "throw" or "cast-scheduled"');
+  }
+
+  return policy;
+};
+
+const assertValidShouldTaunt = (
+  shouldTaunt: unknown,
+): ArmyLoopTauntShouldTaunt | undefined => {
+  if (shouldTaunt === undefined) {
+    return undefined;
+  }
+
+  if (typeof shouldTaunt !== "function") {
+    throw new Error("shouldTaunt must be a function");
+  }
+
+  return shouldTaunt as ArmyLoopTauntShouldTaunt;
+};
+
 export const resolveLoopTauntParticipants = (
   sessionPlayers: readonly string[],
   players: readonly ArmyLoopTauntPlayer[] | undefined,
@@ -240,10 +363,13 @@ export const normalizeLoopTauntOptions = (
     sessionPlayers,
     options.players,
   );
+  const shouldTaunt = assertValidShouldTaunt(options.shouldTaunt);
 
   return {
     id: createLoopTauntId(options),
+    noEligiblePolicy: assertValidNoEligiblePolicy(options.noEligiblePolicy),
     participants,
+    ...(shouldTaunt === undefined ? {} : { shouldTaunt }),
     skill,
     target,
     trigger: hasAura
@@ -253,6 +379,7 @@ export const normalizeLoopTauntOptions = (
           type: "aura",
         }
       : {
+          debounceMs: assertValidMessageDebounceMs(options.debounceMs),
           message: assertNonEmptyString("message", options.message),
           type: "message",
         },
@@ -271,4 +398,57 @@ export const advanceLoopTauntTurn = (
 ): LoopTauntTurnState => ({
   nextIndex:
     participants.length === 0 ? 0 : (state.nextIndex + 1) % participants.length,
+  triggerCount: state.triggerCount,
 });
+
+export const resolveLoopTauntTurn = (
+  participants: readonly ResolvedArmyPlayer[],
+  state: LoopTauntTurnState,
+  shouldSelect: (
+    candidate: ResolvedArmyPlayer,
+    index: number,
+  ) => boolean = () => true,
+  noEligiblePolicy: ArmyLoopTauntNoEligiblePolicy = "throw",
+): LoopTauntTurnResolution => {
+  if (participants.length === 0) {
+    throw new Error("Loop Taunt requires at least one participant");
+  }
+
+  const startIndex = state.nextIndex % participants.length;
+  const scheduled = participants[startIndex]!;
+  const skipped: ResolvedArmyPlayer[] = [];
+
+  for (let offset = 0; offset < participants.length; offset += 1) {
+    const candidateIndex = (startIndex + offset) % participants.length;
+    const candidate = participants[candidateIndex]!;
+    if (shouldSelect(candidate, candidateIndex)) {
+      return {
+        nextState: {
+          nextIndex: (candidateIndex + 1) % participants.length,
+          triggerCount: state.triggerCount + 1,
+        },
+        scheduled,
+        selected: candidate,
+        selectedIndex: candidateIndex,
+        skipped,
+      };
+    }
+
+    skipped.push(candidate);
+  }
+
+  if (noEligiblePolicy === "cast-scheduled") {
+    return {
+      nextState: {
+        nextIndex: (startIndex + 1) % participants.length,
+        triggerCount: state.triggerCount + 1,
+      },
+      scheduled,
+      selected: scheduled,
+      selectedIndex: startIndex,
+      skipped,
+    };
+  }
+
+  throw new Error("Loop Taunt found no eligible participant");
+};

--- a/app/src/renderer/windows/game/army/Services/Army.ts
+++ b/app/src/renderer/windows/game/army/Services/Army.ts
@@ -126,6 +126,9 @@ export class Army extends ServiceMap.Service<Army, ArmyShape>()(
 export type { ArmyConfigRaw };
 export type {
   ArmyLoopTauntHandle,
+  ArmyLoopTauntNoEligiblePolicy,
   ArmyLoopTauntOptions,
   ArmyLoopTauntPlayer,
+  ArmyLoopTauntShouldTaunt,
+  ArmyLoopTauntTurnContext,
 } from "../LoopTaunt";

--- a/app/src/renderer/windows/game/flash/Layers/PacketDomain.test.ts
+++ b/app/src/renderer/windows/game/flash/Layers/PacketDomain.test.ts
@@ -13,8 +13,12 @@ import { PacketLive } from "./Packet";
 import { PacketDomainLive } from "./PacketDomain";
 import { WaitLive } from "./Wait";
 import { WorldLive } from "./World";
+import { LOOP_TAUNT_SCROLL_ITEM_ID } from "../../../../../shared/loop-taunt";
 
-type PacketWindow = Pick<Window, "onExtensionResponse" | "packetFromServer">;
+type PacketWindow = Pick<
+  Window,
+  "onExtensionResponse" | "packetFromClient" | "packetFromServer"
+>;
 
 class PacketDomainTestError extends Data.TaggedError("PacketDomainTestError")<{
   readonly cause?: unknown;
@@ -141,6 +145,17 @@ const emitServerPacket = (raw: string): void => {
   if (typeof handler !== "function") {
     throw new PacketDomainTestError({
       message: "window.packetFromServer was not registered",
+    });
+  }
+
+  handler(raw);
+};
+
+const emitClientPacket = (raw: string): void => {
+  const handler = (window as PacketWindow).packetFromClient;
+  if (typeof handler !== "function") {
+    throw new PacketDomainTestError({
+      message: "window.packetFromClient was not registered",
     });
   }
 
@@ -291,6 +306,36 @@ test("packet domain emits animation message events with monster ids", async () =
       );
 
       emitServerPacket(
+        '{"t":"xt","b":{"o":{"cmd":"ct","anims":[{"msg":"defense shattering","cInf":"m:3","tInf":"m:2"}]}}}',
+      );
+
+      return yield* waitForEvent(observed);
+    }),
+  );
+
+  expect(event.message).toBe("defense shattering");
+  expect(event.monMapId).toBe(3);
+  expect(event.sourceMonMapId).toBe(3);
+  expect(event.targetMonMapId).toBe(2);
+});
+
+test("packet domain preserves animation message target monster id fallback", async () => {
+  const event = await withPacketDomain((packetDomain) =>
+    Effect.gen(function* () {
+      let resolveEvent:
+        | ((event: PacketDomainEventMap["animationMessage"]) => void)
+        | undefined;
+      const observed = new Promise<PacketDomainEventMap["animationMessage"]>(
+        (resolve) => {
+          resolveEvent = resolve;
+        },
+      );
+
+      yield* packetDomain.on("animationMessage", (messageEvent) =>
+        Effect.sync(() => resolveEvent?.(messageEvent)),
+      );
+
+      emitServerPacket(
         '{"t":"xt","b":{"o":{"cmd":"ct","anims":[{"msg":"defense shattering","tInf":"m:2"}]}}}',
       );
 
@@ -300,6 +345,38 @@ test("packet domain emits animation message events with monster ids", async () =
 
   expect(event.message).toBe("defense shattering");
   expect(event.monMapId).toBe(2);
+  expect(event.sourceMonMapId).toBeUndefined();
+  expect(event.targetMonMapId).toBe(2);
+});
+
+test("packet domain parses monster ids from animation target lists", async () => {
+  const event = await withPacketDomain((packetDomain) =>
+    Effect.gen(function* () {
+      let resolveEvent:
+        | ((event: PacketDomainEventMap["animationMessage"]) => void)
+        | undefined;
+      const observed = new Promise<PacketDomainEventMap["animationMessage"]>(
+        (resolve) => {
+          resolveEvent = resolve;
+        },
+      );
+
+      yield* packetDomain.on("animationMessage", (messageEvent) =>
+        Effect.sync(() => resolveEvent?.(messageEvent)),
+      );
+
+      emitServerPacket(
+        '{"t":"xt","b":{"o":{"cmd":"ct","anims":[{"msg":"defense shattering","cInf":"p:1","tInf":"p:2,m:4,m:5"}]}}}',
+      );
+
+      return yield* waitForEvent(observed);
+    }),
+  );
+
+  expect(event.message).toBe("defense shattering");
+  expect(event.monMapId).toBe(4);
+  expect(event.sourceMonMapId).toBeUndefined();
+  expect(event.targetMonMapId).toBe(4);
 });
 
 test("packet domain emits monster aura add and remove events", async () => {
@@ -335,7 +412,7 @@ test("packet domain emits monster aura add and remove events", async () => {
       );
 
       emitServerPacket(
-        '{"t":"xt","b":{"o":{"cmd":"ct","a":[{"cmd":"aura+","tInf":"m:2","auras":[{"icon":"iwd1,ied1","isNew":true,"nam":"Focus"}]},{"cmd":"aura-","tInf":"m:2","aura":{"nam":"Focus"}}]}}}',
+        '{"t":"xt","b":{"o":{"cmd":"ct","a":[{"cmd":"aura+","tInf":"m:2","auras":[{"cat":"stone","icon":"iwd1,ied1","isNew":true,"nam":"Focus"}]},{"cmd":"aura-","tInf":"m:2","aura":{"nam":"Focus"}}]}}}',
       );
 
       return yield* waitForEvent(done);
@@ -344,11 +421,86 @@ test("packet domain emits monster aura add and remove events", async () => {
 
   expect(events).toMatchObject([
     {
-      aura: { icon: "iwd1,ied1" },
+      aura: { cat: "stone", icon: "iwd1,ied1" },
       auraName: "Focus",
       targetId: 2,
       targetType: "monster",
     },
     { auraName: "Focus", targetId: 2, targetType: "monster" },
   ]);
+});
+
+test("packet domain reports outgoing loop taunt scroll attempt telemetry", async () => {
+  const event = await withPacketDomain((packetDomain) =>
+    Effect.gen(function* () {
+      let resolveObserved: (
+        event: PacketDomainEventMap["loopTauntClientCastAttempt"],
+      ) => void;
+      const observed = new Promise<
+        PacketDomainEventMap["loopTauntClientCastAttempt"]
+      >((resolve) => {
+        resolveObserved = resolve;
+      });
+      yield* packetDomain.on("loopTauntClientCastAttempt", (payload) =>
+        Effect.sync(() => resolveObserved(payload)),
+      );
+
+      emitClientPacket("%xt%zm%gar%1%0%i1>m:7%12917%wvz%");
+
+      return yield* waitForEvent(observed);
+    }),
+  );
+
+  expect(event.itemId).toBe(LOOP_TAUNT_SCROLL_ITEM_ID);
+  expect(event.monMapId).toBe(7);
+});
+
+test("packet domain reports server-confirmed loop taunt actions with matching Focus aura", async () => {
+  const event = await withPacketDomain((packetDomain) =>
+    Effect.gen(function* () {
+      let resolveObserved: (
+        event: PacketDomainEventMap["loopTauntServerCastConfirmed"],
+      ) => void;
+      const observed = new Promise<
+        PacketDomainEventMap["loopTauntServerCastConfirmed"]
+      >((resolve) => {
+        resolveObserved = resolve;
+      });
+      yield* packetDomain.on("loopTauntServerCastConfirmed", (payload) =>
+        Effect.sync(() => resolveObserved(payload)),
+      );
+
+      emitServerPacket(
+        '{"t":"xt","b":{"o":{"cmd":"ct","sarsa":[{"a":[{"actRef":"i1","tInf":"m:7"}]}],"a":[{"cmd":"aura+","tInf":"m:7","auras":[{"nam":"Focus","icon":"iwd1,ied1","dur":6,"t":"s","isNew":true}]}]}}}',
+      );
+
+      return yield* waitForEvent(observed);
+    }),
+  );
+
+  expect(event.auraIcon).toBe("iwd1,ied1");
+  expect(event.auraName).toBe("Focus");
+  expect(event.monMapId).toBe(7);
+});
+
+test("packet domain does not confirm loop taunt from server action without matching Focus aura", async () => {
+  const observed = await withPacketDomain((packetDomain) =>
+    Effect.gen(function* () {
+      let observed = false;
+      yield* packetDomain.on("loopTauntServerCastConfirmed", () =>
+        Effect.sync(() => {
+          observed = true;
+        }),
+      );
+
+      emitServerPacket(
+        '{"t":"xt","b":{"o":{"cmd":"ct","sarsa":[{"a":[{"actRef":"i1","tInf":"m:7"}]}]}}}',
+      );
+      yield* Effect.sleep("25 millis");
+
+      return observed;
+    }),
+  );
+
+  expect(observed).toBe(false);
 });

--- a/app/src/renderer/windows/game/flash/Layers/PacketDomain.ts
+++ b/app/src/renderer/windows/game/flash/Layers/PacketDomain.ts
@@ -29,6 +29,11 @@ import {
   matchAntiCounterAura,
   matchAntiCounterMessage,
 } from "../antiCounter";
+import {
+  LOOP_TAUNT_FOCUS_AURA_ICON,
+  LOOP_TAUNT_FOCUS_AURA_NAME,
+  LOOP_TAUNT_SCROLL_ITEM_ID,
+} from "../../../../../shared/loop-taunt";
 
 const AURA_ADD_COMMANDS = new Set(["aura+", "aura++"]);
 const AURA_REMOVE_COMMANDS = new Set(["aura-", "aura--"]);
@@ -41,12 +46,110 @@ const parseMonsterMapIdFromEntityInfo = (
     return undefined;
   }
 
-  const [entityType, entityId] = info.split(":");
-  if (entityType !== "m") {
+  for (const token of info.split(",")) {
+    const [entityType, entityId] = token.trim().split(":");
+    if (entityType !== "m") {
+      continue;
+    }
+
+    const monMapId = asNumber(entityId);
+    if (monMapId !== undefined) {
+      return monMapId;
+    }
+  }
+
+  return undefined;
+};
+
+const parseLoopTauntScrollTarget = (
+  token: unknown,
+): number | undefined => {
+  const text = asString(token);
+  if (!text?.startsWith("i1>m:")) {
     return undefined;
   }
 
-  return asNumber(entityId);
+  return asNumber(text.slice("i1>m:".length));
+};
+
+interface ServerLoopTauntConfirmation {
+  readonly auraIcon: string;
+  readonly auraName: string;
+  readonly monMapId: number;
+}
+
+const getServerLoopTauntConfirmation = (
+  payload: Record<string, unknown>,
+): ServerLoopTauntConfirmation | undefined => {
+  const actionTargets = new Set<number>();
+
+  for (const rawAction of asArray(payload["sarsa"])) {
+    const action = asRecord(rawAction);
+    if (!action) {
+      continue;
+    }
+
+    for (const rawApplied of asArray(action["a"])) {
+      const applied = asRecord(rawApplied);
+      if (!applied || asString(applied["actRef"]) !== "i1") {
+        continue;
+      }
+
+      const target = parseMonsterMapIdFromEntityInfo(applied["tInf"]);
+      if (target !== undefined) {
+        actionTargets.add(target);
+      }
+    }
+  }
+
+  if (actionTargets.size === 0) {
+    return undefined;
+  }
+
+  for (const rawAuraEvent of asArray(payload["a"])) {
+    const auraEvent = asRecord(rawAuraEvent);
+    const cmd = auraEvent ? asString(auraEvent["cmd"]) : undefined;
+    if (!auraEvent || cmd === undefined || !AURA_ADD_COMMANDS.has(cmd)) {
+      continue;
+    }
+
+    const targetInfo = asString(auraEvent["tInf"]);
+    if (!targetInfo) {
+      continue;
+    }
+
+    const [targetType, rawTargetId] = targetInfo.split(":");
+    const targetId = asNumber(rawTargetId);
+    if (
+      targetType !== "m" ||
+      targetId === undefined ||
+      !actionTargets.has(targetId)
+    ) {
+      continue;
+    }
+
+    for (const rawAura of asArray(auraEvent["auras"])) {
+      const aura = asRecord(rawAura);
+      if (!aura) {
+        continue;
+      }
+
+      const auraName = asString(aura["nam"]);
+      const auraIcon = asString(aura["icon"]);
+      if (
+        auraName === LOOP_TAUNT_FOCUS_AURA_NAME &&
+        auraIcon === LOOP_TAUNT_FOCUS_AURA_ICON
+      ) {
+        return {
+          auraIcon,
+          auraName,
+          monMapId: targetId,
+        };
+      }
+    }
+  }
+
+  return undefined;
 };
 
 const normalizeAnimationMessage = (value: unknown): string | undefined => {
@@ -166,6 +269,8 @@ const createDomainHandlerStore = (): DomainHandlerStore => ({
   auraRemoved: new Set(),
   antiCounterStart: new Set(),
   antiCounterEnd: new Set(),
+  loopTauntClientCastAttempt: new Set(),
+  loopTauntServerCastConfirmed: new Set(),
   playerLocation: new Set(),
 });
 
@@ -788,11 +893,50 @@ const make = Effect.gen(function* () {
     }),
   );
 
+  yield* packets.clientScoped("gar", (packet) =>
+    Effect.gen(function* () {
+      const monMapId = packet.params
+        .map(parseLoopTauntScrollTarget)
+        .find((value): value is number => value !== undefined);
+      const itemId = packet.params
+        .map(asNumber)
+        .find((value) => value === LOOP_TAUNT_SCROLL_ITEM_ID);
+
+      if (monMapId === undefined || itemId === undefined) {
+        return;
+      }
+
+      yield* dispatchDomainEvent(
+        domainHandlerStore,
+        "loopTauntClientCastAttempt",
+        {
+          itemId,
+          monMapId,
+          packet,
+        },
+      );
+    }),
+  );
+
   yield* packets.serverScoped("ct", (packet) =>
     Effect.gen(function* () {
       const payload = asRecord(packet.data);
       if (!payload) {
         return;
+      }
+
+      const loopTauntConfirmation = getServerLoopTauntConfirmation(payload);
+      if (loopTauntConfirmation !== undefined) {
+        yield* dispatchDomainEvent(
+          domainHandlerStore,
+          "loopTauntServerCastConfirmed",
+          {
+            auraIcon: loopTauntConfirmation.auraIcon,
+            auraName: loopTauntConfirmation.auraName,
+            monMapId: loopTauntConfirmation.monMapId,
+            packet,
+          },
+        );
       }
 
       for (const rawAnimation of asArray(payload["anims"])) {
@@ -806,12 +950,18 @@ const make = Effect.gen(function* () {
           continue;
         }
 
-        const monMapId =
-          parseMonsterMapIdFromEntityInfo(animation["cInf"]) ??
-          parseMonsterMapIdFromEntityInfo(animation["tInf"]);
+        const sourceMonMapId = parseMonsterMapIdFromEntityInfo(
+          animation["cInf"],
+        );
+        const targetMonMapId = parseMonsterMapIdFromEntityInfo(
+          animation["tInf"],
+        );
+        const monMapId = sourceMonMapId ?? targetMonMapId;
         yield* dispatchDomainEvent(domainHandlerStore, "animationMessage", {
           message,
           ...(monMapId === undefined ? {} : { monMapId }),
+          ...(sourceMonMapId === undefined ? {} : { sourceMonMapId }),
+          ...(targetMonMapId === undefined ? {} : { targetMonMapId }),
           packet,
         });
 
@@ -913,6 +1063,11 @@ const make = Effect.gen(function* () {
               name: auraName,
               duration: asNumber(auraPayload["dur"]) ?? 0,
             };
+
+            const category = asString(auraPayload["cat"]);
+            if (category !== undefined) {
+              aura.cat = category;
+            }
 
             const icon = asString(auraPayload["icon"]);
             if (icon !== undefined) {

--- a/app/src/renderer/windows/game/flash/Layers/World.ts
+++ b/app/src/renderer/windows/game/flash/Layers/World.ts
@@ -64,6 +64,10 @@ const addAuraToTarget = (
       existing.duration = aura.duration;
     }
 
+    if (aura.cat !== undefined) {
+      existing.cat = aura.cat;
+    }
+
     if (aura.icon !== undefined) {
       existing.icon = aura.icon;
     }
@@ -86,6 +90,10 @@ const updateAuraOnTarget = (
   if (existing) {
     if (aura.duration !== undefined) {
       existing.duration = aura.duration;
+    }
+
+    if (aura.cat !== undefined) {
+      existing.cat = aura.cat;
     }
 
     if (aura.icon !== undefined) {

--- a/app/src/renderer/windows/game/flash/Services/PacketDomain.ts
+++ b/app/src/renderer/windows/game/flash/Services/PacketDomain.ts
@@ -1,7 +1,11 @@
 import { ServiceMap } from "effect";
 import type { Effect } from "effect";
 import type { Aura } from "@vexed/game";
-import type { ExtensionPacket, ServerPacket } from "../PacketTypes";
+import type {
+  ClientPacket,
+  ExtensionPacket,
+  ServerPacket,
+} from "../PacketTypes";
 import type { PacketListenerDisposer } from "./Packet";
 
 export type PacketDomainEvent =
@@ -13,6 +17,8 @@ export type PacketDomainEvent =
   | "auraRemoved"
   | "antiCounterStart"
   | "antiCounterEnd"
+  | "loopTauntClientCastAttempt"
+  | "loopTauntServerCastConfirmed"
   | "playerLocation";
 
 export interface PacketDomainMonsterDeathEvent {
@@ -36,6 +42,8 @@ export interface PacketDomainJoinMapEvent {
 export interface PacketDomainAnimationMessageEvent {
   readonly message: string;
   readonly monMapId?: number;
+  readonly sourceMonMapId?: number;
+  readonly targetMonMapId?: number;
   readonly packet: ServerPacket;
 }
 
@@ -65,6 +73,19 @@ export interface PacketDomainPlayerLocationEvent {
   readonly packet: ExtensionPacket;
 }
 
+export interface PacketDomainLoopTauntClientCastAttemptEvent {
+  readonly itemId: number;
+  readonly monMapId: number;
+  readonly packet: ClientPacket;
+}
+
+export interface PacketDomainLoopTauntServerCastConfirmedEvent {
+  readonly auraIcon: string;
+  readonly auraName: string;
+  readonly monMapId: number;
+  readonly packet: ServerPacket;
+}
+
 export interface PacketDomainEventMap {
   monsterDeath: PacketDomainMonsterDeathEvent;
   zone: PacketDomainZoneEvent;
@@ -74,6 +95,8 @@ export interface PacketDomainEventMap {
   auraRemoved: PacketDomainAuraEvent;
   antiCounterStart: PacketDomainAntiCounterEvent;
   antiCounterEnd: PacketDomainAntiCounterEvent;
+  loopTauntClientCastAttempt: PacketDomainLoopTauntClientCastAttemptEvent;
+  loopTauntServerCastConfirmed: PacketDomainLoopTauntServerCastConfirmedEvent;
   playerLocation: PacketDomainPlayerLocationEvent;
 }
 

--- a/app/src/renderer/windows/game/scripting/Layers/ScriptRunner.ts
+++ b/app/src/renderer/windows/game/scripting/Layers/ScriptRunner.ts
@@ -3,7 +3,11 @@ import { equalsIgnoreCase } from "@vexed/shared/string";
 import { Cause, Effect, Fiber, Layer, Option, Ref, Semaphore } from "effect";
 import { type ScriptExecutePayload, type ScriptOptions } from "../ipc";
 import { Army, type ArmyShape } from "../../army/Services/Army";
-import type { ArmyLoopTauntHandle } from "../../army/LoopTaunt";
+import type {
+  ArmyLoopTauntHandle,
+  ArmyLoopTauntShouldTaunt,
+  ArmyLoopTauntTurnContext,
+} from "../../army/LoopTaunt";
 import { Auth } from "../../flash/Services/Auth";
 import { AutoRelogin } from "../../features/Services/AutoRelogin";
 import { AutoZone } from "../../features/Services/AutoZone";
@@ -420,13 +424,63 @@ const make = Effect.gen(function* () {
       return proxy;
     };
 
+    type ScriptLoopTauntOptions = Parameters<ArmyShape["startLoopTaunt"]>[0] & {
+      readonly shouldTaunt?: (
+        context: ArmyLoopTauntTurnContext,
+      ) =>
+        | boolean
+        | Effect.Effect<boolean, unknown>
+        | Generator<Effect.Yieldable<any, any, never, never>, boolean, never>;
+    };
+
+    const wrapLoopTauntOptions = (
+      options: Parameters<ArmyShape["startLoopTaunt"]>[0],
+    ): Parameters<ArmyShape["startLoopTaunt"]>[0] => {
+      const scriptOptions = options as ScriptLoopTauntOptions;
+      if (typeof scriptOptions.shouldTaunt !== "function") {
+        return options;
+      }
+
+      const shouldTaunt: ArmyLoopTauntShouldTaunt = (context) =>
+        Effect.try({
+          try: () => scriptOptions.shouldTaunt?.(context),
+          catch: (cause) =>
+            new ScriptExecutionError({
+              sourceName,
+              message: "shouldTaunt callback failed",
+              cause,
+            }),
+        }).pipe(
+          Effect.flatMap((result) => {
+            if (Effect.isEffect(result)) {
+              return wrapScriptEffect(
+                result as Effect.Effect<boolean, unknown, never>,
+              );
+            }
+
+            if (isGenerator(result)) {
+              return wrapScriptEffect(Effect.gen(() => result)).pipe(
+                Effect.map((value) => value === true),
+              );
+            }
+
+            return Effect.succeed(result === true);
+          }),
+        );
+
+      return {
+        ...options,
+        shouldTaunt,
+      };
+    };
+
     const sleep = (ms: number): Effect.Effect<void, ScriptExecutionError> =>
       Effect.suspend(() => {
         if (!Number.isFinite(ms) || ms < 0) {
           return Effect.fail(
             new ScriptExecutionError({
               sourceName,
-              message: "script.sleep(ms) expects a finite non-negative number",
+              message: "expected a finite non-negative number",
               cause: ms,
             }),
           );
@@ -1103,7 +1157,9 @@ const make = Effect.gen(function* () {
       options,
     ) =>
       Effect.gen(function* () {
-        const handle = yield* army.startLoopTaunt(options);
+        const handle = yield* army.startLoopTaunt(
+          wrapLoopTauntOptions(options),
+        );
         const cleanupKey = `loop-taunt:${handle.id}`;
         let stopped = false;
 

--- a/app/src/renderer/windows/game/scripting/recipes.ts
+++ b/app/src/renderer/windows/game/scripting/recipes.ts
@@ -89,6 +89,7 @@ const CONSUMABLE_SKILL_INDEX = 5;
 const GEAR_OF_DOOM = "Gear of Doom";
 const TREASURE_POTION = "Treasure Potion";
 const WHEEL_OF_DOOM_QUEST_ID = 3_076;
+const SCROLL_OF_ENRAGE_QUEST_ID = 2_330;
 
 const requireFiniteNumber = (
   deps: ScriptRecipeDependencies,
@@ -245,6 +246,24 @@ const consumableSkillItemMatches = (
   return false;
 };
 
+const abandonQuestAfterClientSettle = (
+  deps: ScriptRecipeDependencies,
+  questId: number,
+): Effect.Effect<void, unknown> =>
+  Effect.gen(function* () {
+    // Quest abandon is client-local in AQW. Give late quest-complete handlers
+    // and auto-reaccept a chance to run, then clear the in-progress flag.
+    yield* Effect.sleep("750 millis");
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (yield* deps.quests.isInProgress(questId)) {
+        yield* deps.quests.abandon(questId);
+      }
+
+      yield* Effect.sleep("250 millis");
+    }
+  });
+
 const waitForConsumableSkillSlot = (
   deps: ScriptRecipeDependencies,
   expectedItem: Item,
@@ -397,7 +416,7 @@ const ensureScrollOfEnrage = (
         yield* deps.drops.acceptDrop(itemName);
       }
 
-      yield* deps.quests.accept(2330, true);
+      yield* deps.quests.accept(SCROLL_OF_ENRAGE_QUEST_ID, true);
 
       if (!(yield* deps.inventory.contains("Gold Voucher 100k", 1))) {
         if ((yield* deps.player.getGold()) < 100_000) {
@@ -420,13 +439,23 @@ const ensureScrollOfEnrage = (
         yield* deps.shops.buyByName("Zealous Ink", 5);
       }
 
-      if (!(yield* deps.quests.canComplete(2330))) {
+      if (!(yield* deps.quests.canComplete(SCROLL_OF_ENRAGE_QUEST_ID))) {
         return;
       }
-      yield* deps.quests.complete(2330, 5);
+      yield* deps.quests.complete(SCROLL_OF_ENRAGE_QUEST_ID, 5);
     }
-    yield* deps.quests.abandon(2330);
+    yield* abandonQuestAfterClientSettle(deps, SCROLL_OF_ENRAGE_QUEST_ID);
   });
+
+const getCurrentHouseOwner = (
+  deps: ScriptRecipeDependencies,
+): Effect.Effect<string | undefined, unknown> =>
+  deps.bridge.call("flash.getGameObject", ["world.objHouseData"]).pipe(
+    Effect.map((objHouseData) => {
+      const houseData = asRecord(objHouseData);
+      return houseData ? asString(houseData["unm"]) : undefined;
+    }),
+  );
 
 const goToHouse = (
   deps: ScriptRecipeDependencies,
@@ -438,6 +467,17 @@ const goToHouse = (
         ? yield* deps.auth.getUsername()
         : yield* requireNonEmptyString(deps, "goToHouse", "player", player);
 
+    const mapName = yield* deps.world.map.getName();
+    if (equalsIgnoreCase(mapName, "house")) {
+      const houseOwner = yield* getCurrentHouseOwner(deps);
+      if (
+        houseOwner !== undefined &&
+        equalsIgnoreCase(houseOwner, playerName)
+      ) {
+        return;
+      }
+    }
+
     yield* deps.combat.exit();
     yield* deps.wait.forGameAction("tfer");
     yield* deps.packet.sendServer(`%xt%zm%house%1%${playerName}%`);
@@ -447,6 +487,14 @@ const goToHouse = (
 
         const mapName = yield* deps.world.map.getName();
         if (!equalsIgnoreCase(mapName, "house")) return false;
+
+        const houseOwner = yield* getCurrentHouseOwner(deps);
+        if (
+          houseOwner === undefined ||
+          !equalsIgnoreCase(houseOwner, playerName)
+        ) {
+          return false;
+        }
 
         return yield* deps.player.isReady();
       }),

--- a/app/src/shared/army.ts
+++ b/app/src/shared/army.ts
@@ -49,6 +49,68 @@ export interface ArmyStatusResult {
   readonly waitingBarriers?: number;
 }
 
+export interface ArmyLoopTauntParticipantPayload {
+  readonly name: string;
+  readonly number: number;
+}
+
+export interface ArmyLoopTauntStartPayload {
+  readonly sessionId: string;
+  readonly playerName: string;
+  readonly id: string;
+  readonly aura: string;
+  readonly delayMs: number;
+  readonly skill: number | string;
+  readonly targetMonMapId: number;
+  readonly participants: readonly ArmyLoopTauntParticipantPayload[];
+}
+
+export interface ArmyLoopTauntStopPayload {
+  readonly sessionId: string;
+  readonly playerName: string;
+  readonly id: string;
+}
+
+export type ArmyLoopTauntObservationType =
+  | "aura-added"
+  | "aura-missing"
+  | "aura-removed"
+  | "cast-outcome"
+  | "client-cast-attempt"
+  | "server-cast-confirmed";
+
+export type ArmyLoopTauntCastOutcomeReason =
+  | "failed"
+  | "in-flight"
+  | "not-alive"
+  | "not-ready"
+  | "not-usable";
+
+export interface ArmyLoopTauntObservationPayload {
+  readonly sessionId: string;
+  readonly playerName: string;
+  readonly id: string;
+  readonly type: ArmyLoopTauntObservationType;
+  readonly targetMonMapId: number;
+  readonly auraName?: string;
+  readonly auraIcon?: string;
+  readonly epoch?: number;
+  readonly attempt?: number;
+  readonly outcome?: "cast" | "skipped";
+  readonly reason?: ArmyLoopTauntCastOutcomeReason;
+}
+
+export interface ArmyLoopTauntCommandPayload {
+  readonly sessionId: string;
+  readonly id: string;
+  readonly epoch: number;
+  readonly attempt: number;
+  readonly reason: string;
+  readonly skill: number | string;
+  readonly targetMonMapId: number;
+  readonly selected: ArmyLoopTauntParticipantPayload;
+}
+
 export const normalizeArmyConfigName = (fileName: string): string => {
   let normalized = fileName.trim();
   for (const extension of [".yaml", ".yml", ".json"] as const) {

--- a/app/src/shared/ipc.ts
+++ b/app/src/shared/ipc.ts
@@ -3,6 +3,10 @@ import type {
   ArmyBarrierPayload,
   ArmyConfigPayload,
   ArmyLeavePayload,
+  ArmyLoopTauntCommandPayload,
+  ArmyLoopTauntObservationPayload,
+  ArmyLoopTauntStartPayload,
+  ArmyLoopTauntStopPayload,
   ArmySessionPayload,
   ArmyStartPayload,
   ArmyStatusPayload,
@@ -50,6 +54,13 @@ export type {
   ArmyBarrierPayload,
   ArmyConfigPayload,
   ArmyLeavePayload,
+  ArmyLoopTauntCastOutcomeReason,
+  ArmyLoopTauntCommandPayload,
+  ArmyLoopTauntObservationPayload,
+  ArmyLoopTauntObservationType,
+  ArmyLoopTauntParticipantPayload,
+  ArmyLoopTauntStartPayload,
+  ArmyLoopTauntStopPayload,
   ArmySessionPayload,
   ArmyStartPayload,
   ArmyStatusPayload,
@@ -184,6 +195,10 @@ export const ArmyIpcChannels = {
   leave: "army:leave",
   barrier: "army:barrier",
   status: "army:status",
+  loopTauntStart: "army:loop-taunt:start",
+  loopTauntStop: "army:loop-taunt:stop",
+  loopTauntObservation: "army:loop-taunt:observation",
+  loopTauntCommand: "army:loop-taunt:command",
 } as const;
 
 export const EnvironmentIpcChannels = {
@@ -689,6 +704,24 @@ export interface ArmyInvokeChannels {
     [payload: ArmyStatusPayload],
     ArmyStatusResult
   >;
+  readonly [ArmyIpcChannels.loopTauntStart]: IpcInvokeDefinition<
+    [payload: ArmyLoopTauntStartPayload],
+    void
+  >;
+  readonly [ArmyIpcChannels.loopTauntStop]: IpcInvokeDefinition<
+    [payload: ArmyLoopTauntStopPayload],
+    void
+  >;
+  readonly [ArmyIpcChannels.loopTauntObservation]: IpcInvokeDefinition<
+    [payload: ArmyLoopTauntObservationPayload],
+    void
+  >;
+}
+
+export interface ArmyRendererEventChannels {
+  readonly [ArmyIpcChannels.loopTauntCommand]: [
+    payload: ArmyLoopTauntCommandPayload,
+  ];
 }
 
 export interface ArmyBridge {
@@ -697,6 +730,14 @@ export interface ArmyBridge {
   leave(payload: ArmyLeavePayload): Promise<void>;
   barrier(payload: ArmyBarrierPayload): Promise<void>;
   status(payload: ArmyStatusPayload): Promise<ArmyStatusResult>;
+  startLoopTaunt(payload: ArmyLoopTauntStartPayload): Promise<void>;
+  stopLoopTaunt(payload: ArmyLoopTauntStopPayload): Promise<void>;
+  publishLoopTauntObservation(
+    payload: ArmyLoopTauntObservationPayload,
+  ): Promise<void>;
+  onLoopTauntCommand(
+    listener: (payload: ArmyLoopTauntCommandPayload) => void,
+  ): () => void;
 }
 
 export interface EnvironmentInvokeChannels {

--- a/app/src/shared/loop-taunt.ts
+++ b/app/src/shared/loop-taunt.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_LOOP_TAUNT_CAST_SETTLE_MS = 1_500;
+export const DEFAULT_LOOP_TAUNT_DELAY_MS = 4_000;
+export const DEFAULT_LOOP_TAUNT_MESSAGE_DEBOUNCE_MS = 0;
+export const DEFAULT_LOOP_TAUNT_RESPAWN_RECOVERY_MS = 10_000;
+export const LOOP_TAUNT_SHORT_RETRY_MS = 2_500;
+export const LOOP_TAUNT_RETRY_SETTLE_MS = 1_500;
+export const LOOP_TAUNT_FOCUS_AURA_NAME = "Focus";
+export const LOOP_TAUNT_FOCUS_AURA_ICON = "iwd1,ied1"; // Scroll of Enrage
+export const LOOP_TAUNT_SCROLL_ITEM_ID = 12_917;
+export const LOOP_TAUNT_ACTION_LOCK_AURA_CATEGORIES = [
+  "disabled",
+  "stone",
+  "stun",
+] as const;

--- a/packages/game/src/types/Aura.ts
+++ b/packages/game/src/types/Aura.ts
@@ -1,4 +1,5 @@
 export type Aura = {
+  cat?: string;
   duration?: number;
   icon?: string;
   isNew?: boolean;


### PR DESCRIPTION
## Summary

- Move loop taunt turn coordination into the main-process army IPC layer.
- Harden aura-driven turns with shared coordinator state, retry handling, action-lock checks, and cast observations.
- Add packet-domain events, shared loop-taunt constants/types, scripting support, and focused coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added loop taunt coordination system enabling synchronized taunt casting across multiple players with configurable triggers
* Implemented aura-based and message-based taunt activation with debouncing support
* Added automatic retry and recovery logic for failed taunt attempts
* Introduced action lock system to prevent casting when players are in specific conditions (disabled, stone, stun)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->