### PR TITLE
fix(window): restore primary windows on activation

### DIFF
--- a/app/src/main/app/MainApp.ts
+++ b/app/src/main/app/MainApp.ts
@@ -235,7 +235,7 @@ export const makeProgram = (
       ) {
         yield* windowService.openWindow(WindowIds.AccountManager);
       } else {
-        yield* windowService.revealGameWindow;
+        yield* windowService.revealGameWindow();
       }
 
       yield* updates.checkNow();

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -1,6 +1,6 @@
 import "abort-controller/polyfill";
 import { randomFillSync } from "crypto";
-import { app, BrowserWindow } from "electron";
+import { app } from "electron";
 import { join } from "path";
 import process from "process";
 import { Effect, Layer, ManagedRuntime } from "effect";
@@ -315,10 +315,8 @@ app.on("activate", () => {
   ignoreRuntimeRejection(
     runtime.runPromise(
       Effect.gen(function* () {
-        if (BrowserWindow.getAllWindows().length === 0) {
-          const windows = yield* WindowService;
-          yield* windows.revealGameWindow;
-        }
+        const windows = yield* WindowService;
+        yield* windows.revealWindowForAppActivation();
       }),
     ),
   );

--- a/app/src/main/ipc/methods/accounts.ts
+++ b/app/src/main/ipc/methods/accounts.ts
@@ -627,7 +627,7 @@ export const startAccountGameLaunch = async (
   const gameWindow = await dependencies.runWindowEffect(
     Effect.gen(function* () {
       const windows = yield* WindowService;
-      return yield* windows.openGameWindow;
+      return yield* windows.openGameWindow();
     }),
   );
   const gameWindowId = gameWindow.id;

--- a/app/src/main/ipc/methods/environment.ts
+++ b/app/src/main/ipc/methods/environment.ts
@@ -360,7 +360,7 @@ export const registerEnvironmentIpcHandlers = (
           const senderWindowId = getSenderWindowId(event);
           const state = getWindowState(sourceGameWindowId);
           const windows = yield* WindowService;
-          const gameWindowIds = yield* windows.getGameWindowIds;
+          const gameWindowIds = yield* windows.getGameWindowIds();
 
           for (const gameWindowId of gameWindowIds) {
             setWindowState(gameWindowId, state);

--- a/app/src/main/window/WindowService.test.ts
+++ b/app/src/main/window/WindowService.test.ts
@@ -87,6 +87,10 @@ class FakeWindow extends EventEmitter {
     this.emit("focus");
   }
 
+  public blur(): void {
+    this.focused = false;
+  }
+
   public destroy(): void {
     if (this.destroyed) {
       return;
@@ -254,7 +258,7 @@ describe("window service", () => {
     const harness = createHarness("darwin", snapshot);
 
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     expect(gameWindow.options.backgroundColor).toBe(snapshot.backgroundColor);
@@ -266,7 +270,7 @@ describe("window service", () => {
   it("denies renderer-created windows through the Electron 11 new-window event", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     const event = {
       prevented: false,
@@ -283,7 +287,7 @@ describe("window service", () => {
   it("denies renderer-created windows through the modern window-open handler", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     expect(gameWindow.webContents.windowOpenHandler?.()).toEqual({
@@ -333,7 +337,7 @@ describe("window service", () => {
   it("tracks Environment and other game-child windows against the resolved game", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     const environment = (await run(
@@ -356,10 +360,10 @@ describe("window service", () => {
   it("resolves child senders back to their owning game", async () => {
     const harness = createHarness();
     const firstGame = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     const secondGame = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     secondGame.focus();
 
@@ -382,7 +386,7 @@ describe("window service", () => {
   it("reveals an existing game window instead of creating another one", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     gameWindow.emit("ready-to-show");
@@ -390,7 +394,7 @@ describe("window service", () => {
     gameWindow.minimized = true;
     gameWindow.focused = false;
 
-    await run(harness.service.revealGameWindow);
+    await run(harness.service.revealGameWindow());
 
     expect(gameWindow.visible).toBe(true);
     expect(gameWindow.minimized).toBe(false);
@@ -398,10 +402,134 @@ describe("window service", () => {
     expect(harness.windows).toHaveLength(1);
   });
 
+  it("reveals a hidden account manager window for app activation", async () => {
+    const harness = createHarness();
+    const accountManager = (await run(
+      harness.service.openWindow(WindowIds.AccountManager),
+    )) as unknown as FakeWindow;
+    accountManager.emit("ready-to-show");
+
+    expect(accountManager.close()).toBe(true);
+    accountManager.blur();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(accountManager.visible).toBe(true);
+    expect(accountManager.focused).toBe(true);
+    expect(harness.windows).toHaveLength(1);
+  });
+
+  it("does not restore settings as the primary app activation window", async () => {
+    const harness = createHarness();
+    const accountManager = (await run(
+      harness.service.openWindow(WindowIds.AccountManager),
+    )) as unknown as FakeWindow;
+    const settings = (await run(
+      harness.service.openWindow(WindowIds.Settings),
+    )) as unknown as FakeWindow;
+    accountManager.emit("ready-to-show");
+    settings.emit("ready-to-show");
+
+    expect(accountManager.close()).toBe(true);
+    expect(settings.close()).toBe(true);
+    accountManager.blur();
+    settings.blur();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(accountManager.visible).toBe(true);
+    expect(accountManager.focused).toBe(true);
+    expect(settings.visible).toBe(false);
+  });
+
+  it("does nothing for app activation while a primary window is presented", async () => {
+    const harness = createHarness();
+    const gameWindow = (await run(
+      harness.service.openGameWindow(),
+    )) as unknown as FakeWindow;
+    const accountManager = (await run(
+      harness.service.openWindow(WindowIds.AccountManager),
+    )) as unknown as FakeWindow;
+    gameWindow.emit("ready-to-show");
+    accountManager.emit("ready-to-show");
+    expect(accountManager.close()).toBe(true);
+    accountManager.blur();
+    gameWindow.blur();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(gameWindow.visible).toBe(true);
+    expect(gameWindow.focused).toBe(false);
+    expect(accountManager.visible).toBe(false);
+  });
+
+  it("restores a minimized last-focused game window for app activation", async () => {
+    const harness = createHarness();
+    const gameWindow = (await run(
+      harness.service.openGameWindow(),
+    )) as unknown as FakeWindow;
+    gameWindow.emit("ready-to-show");
+    gameWindow.minimized = true;
+    gameWindow.blur();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(gameWindow.visible).toBe(true);
+    expect(gameWindow.minimized).toBe(false);
+    expect(gameWindow.focused).toBe(true);
+    expect(harness.windows).toHaveLength(1);
+  });
+
+  it("creates a game window for app activation when no primary window exists", async () => {
+    const harness = createHarness();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(harness.windows).toHaveLength(1);
+    expect(harness.windows[0]?.options.webPreferences?.plugins).toBe(true);
+  });
+
+  it("ignores unusable primary windows during app activation", async () => {
+    const harness = createHarness();
+    const accountManager = (await run(
+      harness.service.openWindow(WindowIds.AccountManager),
+    )) as unknown as FakeWindow;
+    accountManager.emit("ready-to-show");
+    accountManager.webContents.destroyed = true;
+    accountManager.hide();
+    accountManager.blur();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(accountManager.visible).toBe(false);
+    expect(harness.windows).toHaveLength(2);
+    expect(harness.windows[1]?.options.webPreferences?.plugins).toBe(true);
+  });
+
+  it("ignores destroyed primary windows during app activation", async () => {
+    const harness = createHarness();
+    const accountManager = (await run(
+      harness.service.openWindow(WindowIds.AccountManager),
+    )) as unknown as FakeWindow;
+    const gameWindow = (await run(
+      harness.service.openGameWindow(),
+    )) as unknown as FakeWindow;
+    accountManager.emit("ready-to-show");
+    gameWindow.emit("ready-to-show");
+    expect(accountManager.close()).toBe(true);
+    accountManager.blur();
+    gameWindow.destroy();
+
+    await run(harness.service.revealWindowForAppActivation());
+
+    expect(accountManager.visible).toBe(true);
+    expect(accountManager.focused).toBe(true);
+  });
+
   it("destroys game children when their owning game window closes", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     const environment = (await run(
       harness.service.openWindow(WindowIds.Environment, gameWindow.id),
@@ -419,7 +547,7 @@ describe("window service", () => {
   it("requests tracked game windows to close asynchronously", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     await run(harness.service.requestCloseGameWindow(gameWindow.id));
@@ -435,7 +563,7 @@ describe("window service", () => {
   it("ignores missing or destroyed game windows when close is requested", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     gameWindow.destroy();
 
@@ -449,7 +577,7 @@ describe("window service", () => {
   it("cleans up child windows when a requested game window close runs", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     const environment = (await run(
       harness.service.openWindow(WindowIds.Environment, gameWindow.id),
@@ -468,7 +596,7 @@ describe("window service", () => {
   it("destroys game children when their owning game window is destroyed", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     const environment = (await run(
       harness.service.openWindow(WindowIds.Environment, gameWindow.id),
@@ -486,7 +614,7 @@ describe("window service", () => {
   it("lets hidden-on-close children close while quitting", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     const child = (await run(
       harness.service.openWindow(WindowIds.FastTravels, gameWindow.id),
@@ -519,7 +647,7 @@ describe("window service", () => {
   it("destroys and unregisters windows when renderer loading fails", async () => {
     const harness = createHarness();
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     harness.failNextLoad();
@@ -542,7 +670,7 @@ describe("window service", () => {
   it("ignores destroyed game windows during owner resolution", async () => {
     const harness = createHarness();
     const destroyedGame = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
     destroyedGame.destroy();
 
@@ -571,7 +699,7 @@ describe("window service", () => {
     const harness = createHarness("linux");
 
     const gameWindow = (await run(
-      harness.service.openGameWindow,
+      harness.service.openGameWindow(),
     )) as unknown as FakeWindow;
 
     expect(gameWindow.visible).toBe(true);

--- a/app/src/main/window/WindowService.ts
+++ b/app/src/main/window/WindowService.ts
@@ -14,6 +14,7 @@ import {
   isAppWindowDefinition,
   isGameChildWindowDefinition,
   isWindowId,
+  WindowIds,
   type WindowDefinition,
   type WindowId,
 } from "../../shared/windows";
@@ -63,6 +64,11 @@ const isWindowUsable = (
   window: BrowserWindow | null | undefined,
 ): window is BrowserWindow =>
   Boolean(window && !window.isDestroyed() && !window.webContents.isDestroyed());
+
+const isWindowPresented = (
+  window: BrowserWindow | null | undefined,
+): window is BrowserWindow =>
+  Boolean(isWindowUsable(window) && window.isVisible() && !window.isMinimized());
 
 const createLoadFailure = (
   target: string,
@@ -171,6 +177,7 @@ export const makeWindowService = (
   const forceClosingWindowIds = new Set<number>();
   let isQuitting = false;
   let lastFocusedGameWindowId: number | null = null;
+  let lastFocusedPrimaryWindowId: number | null = null;
 
   const getGameWindowIdSync = (windowId: number): number | undefined => {
     if (gameWindows.has(windowId)) {
@@ -267,10 +274,10 @@ export const makeWindowService = (
     };
 
     gameWindows.set(gameWindowId, entry);
-    lastFocusedGameWindowId = gameWindowId;
 
     window.on("focus", () => {
       lastFocusedGameWindowId = gameWindowId;
+      lastFocusedPrimaryWindowId = gameWindowId;
     });
 
     window.on("close", () => {
@@ -282,6 +289,9 @@ export const makeWindowService = (
       gameWindows.delete(gameWindowId);
       if (lastFocusedGameWindowId === gameWindowId) {
         lastFocusedGameWindowId = null;
+      }
+      if (lastFocusedPrimaryWindowId === gameWindowId) {
+        lastFocusedPrimaryWindowId = null;
       }
     });
   };
@@ -295,6 +305,9 @@ export const makeWindowService = (
     gameWindows.delete(window.id);
     if (lastFocusedGameWindowId === window.id) {
       lastFocusedGameWindowId = null;
+    }
+    if (lastFocusedPrimaryWindowId === window.id) {
+      lastFocusedPrimaryWindowId = null;
     }
   };
 
@@ -343,6 +356,42 @@ export const makeWindowService = (
     return null;
   };
 
+  const resolveAccountManagerWindow = (): BrowserWindow | null => {
+    const window = appWindows.get(WindowIds.AccountManager);
+    return isWindowUsable(window) ? window : null;
+  };
+
+  const isPrimaryWindow = (window: BrowserWindow): boolean => {
+    if (gameWindows.get(window.id)?.gameWindow === window) {
+      return true;
+    }
+
+    return appWindows.get(WindowIds.AccountManager) === window;
+  };
+
+  const resolveLastFocusedPrimaryWindow = (): BrowserWindow | null => {
+    if (lastFocusedPrimaryWindowId === null) {
+      return null;
+    }
+
+    const window = runtime.fromId(lastFocusedPrimaryWindowId);
+    return isWindowUsable(window) && isPrimaryWindow(window) ? window : null;
+  };
+
+  const hasPresentedPrimaryWindow = (): boolean => {
+    if (isWindowPresented(resolveAccountManagerWindow())) {
+      return true;
+    }
+
+    for (const entry of gameWindows.values()) {
+      if (isWindowPresented(entry.gameWindow)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
   const requireWindowDefinition = (
     id: WindowId,
   ): Effect.Effect<WindowDefinition, WindowManagerError> => {
@@ -381,8 +430,8 @@ export const makeWindowService = (
     return loadWindow(window, url.toString(), "url");
   };
 
-  const openGameWindow: WindowServiceShape["openGameWindow"] = Effect.gen(
-    function* () {
+  const openGameWindow: WindowServiceShape["openGameWindow"] = () =>
+    Effect.gen(function* () {
       const window = yield* createManagedWindow(
         createGameWindowOptions(config),
       );
@@ -401,8 +450,7 @@ export const makeWindowService = (
       );
 
       return window;
-    },
-  );
+    });
 
   const resolveOrCreateGameWindow = (
     senderWindowId?: number,
@@ -412,7 +460,7 @@ export const makeWindowService = (
       return Effect.succeed(resolvedGameWindow);
     }
 
-    return openGameWindow;
+    return openGameWindow();
   };
 
   const openGameChildWindow = (
@@ -486,6 +534,12 @@ export const makeWindowService = (
       appWindows.set(definition.id, appWindow);
       revealWhenReady(appWindow);
 
+      if (definition.id === WindowIds.AccountManager) {
+        appWindow.on("focus", () => {
+          lastFocusedPrimaryWindowId = appWindow.id;
+        });
+      }
+
       appWindow.on("close", (event: ElectronEvent) => {
         if (isQuitting) {
           return;
@@ -501,6 +555,9 @@ export const makeWindowService = (
         const current = appWindows.get(definition.id);
         if (current === appWindow) {
           appWindows.delete(definition.id);
+        }
+        if (lastFocusedPrimaryWindowId === appWindow.id) {
+          lastFocusedPrimaryWindowId = null;
         }
       });
 
@@ -551,30 +608,59 @@ export const makeWindowService = (
       return null;
     });
 
-  const revealGameWindow: WindowServiceShape["revealGameWindow"] = Effect.gen(
-    function* () {
+  const revealGameWindow: WindowServiceShape["revealGameWindow"] = () =>
+    Effect.gen(function* () {
       const gameWindow = resolveGameWindow();
       if (gameWindow) {
         revealWindow(runtime, gameWindow);
         return;
       }
 
-      yield* openGameWindow;
-    },
-  ).pipe(Effect.asVoid);
+      yield* openGameWindow();
+    }).pipe(Effect.asVoid);
+
+  const revealWindowForAppActivation: WindowServiceShape["revealWindowForAppActivation"] =
+    () =>
+      Effect.gen(function* () {
+        if (hasPresentedPrimaryWindow()) {
+          return;
+        }
+
+        const lastFocusedPrimaryWindow = resolveLastFocusedPrimaryWindow();
+        if (lastFocusedPrimaryWindow) {
+          revealWindow(runtime, lastFocusedPrimaryWindow);
+          return;
+        }
+
+        const accountManagerWindow = resolveAccountManagerWindow();
+        if (accountManagerWindow) {
+          revealWindow(runtime, accountManagerWindow);
+          return;
+        }
+
+        const gameWindow = resolveGameWindow();
+        if (gameWindow) {
+          revealWindow(runtime, gameWindow);
+          return;
+        }
+
+        yield* openGameWindow();
+      }).pipe(Effect.asVoid);
 
   return {
     openGameWindow,
     openWindow,
     getOpenWindow,
     revealGameWindow,
+    revealWindowForAppActivation,
     getGameWindowId: (windowId) =>
       Effect.succeed(getGameWindowIdSync(windowId)),
-    getGameWindowIds: Effect.sync(() =>
-      Array.from(gameWindows.entries())
-        .filter(([, entry]) => isWindowUsable(entry.gameWindow))
-        .map(([gameWindowId]) => gameWindowId),
-    ),
+    getGameWindowIds: () =>
+      Effect.sync(() =>
+        Array.from(gameWindows.entries())
+          .filter(([, entry]) => isWindowUsable(entry.gameWindow))
+          .map(([gameWindowId]) => gameWindowId),
+      ),
     getGameChildWindow: (gameWindowId, id) =>
       Effect.sync(() => {
         const childWindow = gameWindows.get(gameWindowId)?.childWindows.get(id);

--- a/app/src/main/window/WindowTypes.ts
+++ b/app/src/main/window/WindowTypes.ts
@@ -19,17 +19,24 @@ export interface WindowManagerConfig {
 }
 
 export interface WindowServiceShape {
-  readonly openGameWindow: Effect.Effect<BrowserWindow, WindowManagerError>;
+  readonly openGameWindow: () => Effect.Effect<
+    BrowserWindow,
+    WindowManagerError
+  >;
   readonly openWindow: (
     id: WindowId,
     senderWindowId?: number,
   ) => Effect.Effect<BrowserWindow, WindowManagerError>;
   readonly getOpenWindow: (id: WindowId) => Effect.Effect<BrowserWindow | null>;
-  readonly revealGameWindow: Effect.Effect<void, WindowManagerError>;
+  readonly revealGameWindow: () => Effect.Effect<void, WindowManagerError>;
+  readonly revealWindowForAppActivation: () => Effect.Effect<
+    void,
+    WindowManagerError
+  >;
   readonly getGameWindowId: (
     windowId: number,
   ) => Effect.Effect<number | undefined>;
-  readonly getGameWindowIds: Effect.Effect<readonly number[]>;
+  readonly getGameWindowIds: () => Effect.Effect<readonly number[]>;
   readonly getGameChildWindow: (
     gameWindowId: number,
     id: WindowId,


### PR DESCRIPTION
## Summary
- Restore the last focused primary window when the app is activated without a presented primary window
- Prefer account manager or game windows over utility windows for activation restore
- Normalize window service effect members to callable methods and cover activation paths in tests

## Why
macOS app activation could leave the app without a useful window when a primary window was hidden instead of destroyed. The window service now tracks primary focus history and restores or creates the correct primary window predictably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed game window reveal functionality on app launch and during account-based game start.
  * Corrected environment state synchronization across game windows.
  * Improved window activation handling on macOS app resume.

* **New Features**
  * Added improved window reveal behavior during app activation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->