### PR TITLE
feat(account-manager): persist login server preference

### DIFF
--- a/app/src/renderer/lib/accountLoginServerSelection.test.ts
+++ b/app/src/renderer/lib/accountLoginServerSelection.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { AccountGameServer } from "../../shared/ipc";
+import {
+  type StoredAccountLoginServerPreference,
+  resolveAccountLoginServerPreference,
+} from "./accountLoginServerSelection";
+
+const server = (
+  name: string,
+  options?: Partial<AccountGameServer>,
+): AccountGameServer => ({
+  name,
+  language: "en",
+  online: true,
+  upgrade: false,
+  playerCount: 100,
+  maxPlayers: 1_000,
+  ...options,
+});
+
+describe("resolveAccountLoginServerPreference", () => {
+  it("uses the saved online server when available", () => {
+    expect(
+      resolveAccountLoginServerPreference(
+        [server("Twilly"), server("Artix")],
+        "Artix",
+      ),
+    ).toBe("Artix");
+  });
+
+  it("uses the saved online server even when full", () => {
+    expect(
+      resolveAccountLoginServerPreference(
+        [
+          server("Twilly"),
+          server("Artix", { playerCount: 1_000, maxPlayers: 1_000 }),
+        ],
+        "Artix",
+      ),
+    ).toBe("Artix");
+  });
+
+  it("falls back when the saved server is offline", () => {
+    expect(
+      resolveAccountLoginServerPreference(
+        [server("Twilly"), server("Artix", { online: false })],
+        "Artix",
+      ),
+    ).toBe("Twilly");
+  });
+
+  it("falls back when the saved server is missing", () => {
+    expect(
+      resolveAccountLoginServerPreference([server("Twilly")], "Artix"),
+    ).toBe("Twilly");
+  });
+
+  it("returns no server for a saved explicit none preference", () => {
+    expect(
+      resolveAccountLoginServerPreference([server("Twilly")], null),
+    ).toBe("");
+  });
+
+  it("uses the first online non-full server without a saved preference", () => {
+    expect(
+      resolveAccountLoginServerPreference(
+        [
+          server("Offline", { online: false }),
+          server("Full", { playerCount: 1_000, maxPlayers: 1_000 }),
+          server("Artix"),
+        ],
+        undefined,
+      ),
+    ).toBe("Artix");
+  });
+
+  it("returns no server when no fallback is available", () => {
+    const preference: StoredAccountLoginServerPreference = undefined;
+
+    expect(
+      resolveAccountLoginServerPreference(
+        [
+          server("Offline", { online: false }),
+          server("Full", { playerCount: 1_000, maxPlayers: 1_000 }),
+        ],
+        preference,
+      ),
+    ).toBe("");
+  });
+});

--- a/app/src/renderer/lib/accountLoginServerSelection.test.ts
+++ b/app/src/renderer/lib/accountLoginServerSelection.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AccountGameServer } from "../../shared/ipc";
 import {
+  readStoredAccountLoginServerPreference,
   type StoredAccountLoginServerPreference,
   resolveAccountLoginServerPreference,
+  writeStoredAccountLoginServerPreference,
 } from "./accountLoginServerSelection";
+
+const STORAGE_KEY = "vexed.account-manager.login-server";
 
 const server = (
   name: string,
@@ -18,6 +22,86 @@ const server = (
   ...options,
 });
 
+const makeLocalStorage = (): Storage => {
+  const storage = new Map<string, string>();
+
+  return {
+    get length() {
+      return storage.size;
+    },
+    clear: vi.fn(() => storage.clear()),
+    getItem: vi.fn((key: string) => storage.get(key) ?? null),
+    key: vi.fn((index: number) => [...storage.keys()][index] ?? null),
+    removeItem: vi.fn((key: string) => storage.delete(key)),
+    setItem: vi.fn((key: string, value: string) => {
+      storage.set(key, value);
+    }),
+  };
+};
+
+describe("account login server preference storage", () => {
+  let localStorage: Storage;
+
+  beforeEach(() => {
+    localStorage = makeLocalStorage();
+    vi.stubGlobal("window", { localStorage });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns undefined when no preference is stored", () => {
+    const preference = readStoredAccountLoginServerPreference();
+
+    expect(preference).toBeUndefined();
+    expect(resolveAccountLoginServerPreference([server("Twilly")], preference))
+      .toEqual({
+        type: "server",
+        name: "Twilly",
+      });
+  });
+
+  it("round-trips an explicit none preference", () => {
+    writeStoredAccountLoginServerPreference(null);
+    const preference = readStoredAccountLoginServerPreference();
+
+    expect(preference).toBeNull();
+    expect(resolveAccountLoginServerPreference([server("Twilly")], preference))
+      .toEqual({
+        type: "none",
+      });
+  });
+
+  it("round-trips a saved server name", () => {
+    writeStoredAccountLoginServerPreference("Artix");
+    const preference = readStoredAccountLoginServerPreference();
+
+    expect(preference).toBe("Artix");
+    expect(
+      resolveAccountLoginServerPreference(
+        [server("Twilly"), server("Artix")],
+        preference,
+      ),
+    ).toEqual({
+      type: "server",
+      name: "Artix",
+    });
+  });
+
+  it("returns undefined for malformed stored data", () => {
+    localStorage.setItem(STORAGE_KEY, "{not valid json");
+    const preference = readStoredAccountLoginServerPreference();
+
+    expect(preference).toBeUndefined();
+    expect(resolveAccountLoginServerPreference([server("Twilly")], preference))
+      .toEqual({
+        type: "server",
+        name: "Twilly",
+      });
+  });
+});
+
 describe("resolveAccountLoginServerPreference", () => {
   it("uses the saved online server when available", () => {
     expect(
@@ -25,7 +109,10 @@ describe("resolveAccountLoginServerPreference", () => {
         [server("Twilly"), server("Artix")],
         "Artix",
       ),
-    ).toBe("Artix");
+    ).toEqual({
+      type: "server",
+      name: "Artix",
+    });
   });
 
   it("uses the saved online server even when full", () => {
@@ -37,7 +124,10 @@ describe("resolveAccountLoginServerPreference", () => {
         ],
         "Artix",
       ),
-    ).toBe("Artix");
+    ).toEqual({
+      type: "server",
+      name: "Artix",
+    });
   });
 
   it("falls back when the saved server is offline", () => {
@@ -46,19 +136,27 @@ describe("resolveAccountLoginServerPreference", () => {
         [server("Twilly"), server("Artix", { online: false })],
         "Artix",
       ),
-    ).toBe("Twilly");
+    ).toEqual({
+      type: "server",
+      name: "Twilly",
+    });
   });
 
   it("falls back when the saved server is missing", () => {
     expect(
       resolveAccountLoginServerPreference([server("Twilly")], "Artix"),
-    ).toBe("Twilly");
+    ).toEqual({
+      type: "server",
+      name: "Twilly",
+    });
   });
 
   it("returns no server for a saved explicit none preference", () => {
     expect(
       resolveAccountLoginServerPreference([server("Twilly")], null),
-    ).toBe("");
+    ).toEqual({
+      type: "none",
+    });
   });
 
   it("uses the first online non-full server without a saved preference", () => {
@@ -71,7 +169,10 @@ describe("resolveAccountLoginServerPreference", () => {
         ],
         undefined,
       ),
-    ).toBe("Artix");
+    ).toEqual({
+      type: "server",
+      name: "Artix",
+    });
   });
 
   it("returns no server when no fallback is available", () => {
@@ -85,6 +186,8 @@ describe("resolveAccountLoginServerPreference", () => {
         ],
         preference,
       ),
-    ).toBe("");
+    ).toEqual({
+      type: "unavailable",
+    });
   });
 });

--- a/app/src/renderer/lib/accountLoginServerSelection.ts
+++ b/app/src/renderer/lib/accountLoginServerSelection.ts
@@ -2,6 +2,18 @@ import type { AccountGameServer } from "../../shared/ipc";
 
 export type StoredAccountLoginServerPreference = string | null | undefined;
 
+export type AccountLoginServerResolution =
+  | {
+      readonly type: "server";
+      readonly name: string;
+    }
+  | {
+      readonly type: "none";
+    }
+  | {
+      readonly type: "unavailable";
+    };
+
 const ACCOUNT_LOGIN_SERVER_STORAGE_KEY = "vexed.account-manager.login-server";
 
 const parseStoredAccountLoginServerPreference = (
@@ -52,26 +64,28 @@ export function readStoredAccountLoginServerPreference(): StoredAccountLoginServ
 }
 
 export function writeStoredAccountLoginServerPreference(
-  serverName: string,
+  serverName: string | null,
 ): void {
   try {
     window.localStorage.setItem(
       ACCOUNT_LOGIN_SERVER_STORAGE_KEY,
       JSON.stringify(
-        serverName === ""
+        serverName === null || serverName.trim() === ""
           ? { type: "none" }
           : { type: "server", name: serverName },
       ),
     );
-  } catch {}
+  } catch (error) {
+    console.warn("Failed to write account login server preference:", error);
+  }
 }
 
 export function resolveAccountLoginServerPreference(
   servers: readonly AccountGameServer[],
   preferredServerName: StoredAccountLoginServerPreference,
-): string {
+): AccountLoginServerResolution {
   if (preferredServerName === null) {
-    return "";
+    return { type: "none" };
   }
 
   if (preferredServerName !== undefined) {
@@ -79,12 +93,14 @@ export function resolveAccountLoginServerPreference(
       (server) => server.name === preferredServerName,
     );
     if (preferredServer?.online === true) {
-      return preferredServer.name;
+      return { type: "server", name: preferredServer.name };
     }
   }
 
-  return (
-    servers.find((server) => server.online && server.playerCount < server.maxPlayers)
-      ?.name ?? ""
+  const fallbackServer = servers.find(
+    (server) => server.online && server.playerCount < server.maxPlayers,
   );
+  return fallbackServer === undefined
+    ? { type: "unavailable" }
+    : { type: "server", name: fallbackServer.name };
 }

--- a/app/src/renderer/lib/accountLoginServerSelection.ts
+++ b/app/src/renderer/lib/accountLoginServerSelection.ts
@@ -1,0 +1,90 @@
+import type { AccountGameServer } from "../../shared/ipc";
+
+export type StoredAccountLoginServerPreference = string | null | undefined;
+
+const ACCOUNT_LOGIN_SERVER_STORAGE_KEY = "vexed.account-manager.login-server";
+
+const parseStoredAccountLoginServerPreference = (
+  value: string,
+): StoredAccountLoginServerPreference => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "type" in parsed &&
+    parsed.type === "none"
+  ) {
+    return null;
+  }
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "type" in parsed &&
+    parsed.type === "server" &&
+    "name" in parsed &&
+    typeof parsed.name === "string" &&
+    parsed.name.trim() !== ""
+  ) {
+    return parsed.name;
+  }
+
+  return undefined;
+};
+
+export function readStoredAccountLoginServerPreference(): StoredAccountLoginServerPreference {
+  try {
+    const storedValue = window.localStorage.getItem(
+      ACCOUNT_LOGIN_SERVER_STORAGE_KEY,
+    );
+    return storedValue === null
+      ? undefined
+      : parseStoredAccountLoginServerPreference(storedValue);
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeStoredAccountLoginServerPreference(
+  serverName: string,
+): void {
+  try {
+    window.localStorage.setItem(
+      ACCOUNT_LOGIN_SERVER_STORAGE_KEY,
+      JSON.stringify(
+        serverName === ""
+          ? { type: "none" }
+          : { type: "server", name: serverName },
+      ),
+    );
+  } catch {}
+}
+
+export function resolveAccountLoginServerPreference(
+  servers: readonly AccountGameServer[],
+  preferredServerName: StoredAccountLoginServerPreference,
+): string {
+  if (preferredServerName === null) {
+    return "";
+  }
+
+  if (preferredServerName !== undefined) {
+    const preferredServer = servers.find(
+      (server) => server.name === preferredServerName,
+    );
+    if (preferredServer?.online === true) {
+      return preferredServer.name;
+    }
+  }
+
+  return (
+    servers.find((server) => server.online && server.playerCount < server.maxPlayers)
+      ?.name ?? ""
+  );
+}

--- a/app/src/renderer/windows/account-manager/App.tsx
+++ b/app/src/renderer/windows/account-manager/App.tsx
@@ -961,16 +961,20 @@ function App(): JSX.Element {
       setServerRefreshCooldownUntil(nextServers.refreshAvailableAt);
       setServers(nextServers.servers);
       if (!serverSelectionInitialized()) {
-        const nextLaunchServerName = resolveAccountLoginServerPreference(
+        const nextLaunchServerResolution = resolveAccountLoginServerPreference(
           nextServers.servers,
           readStoredAccountLoginServerPreference(),
         );
+        const nextLaunchServerName =
+          nextLaunchServerResolution.type === "server"
+            ? nextLaunchServerResolution.name
+            : "";
         const nextLaunchServer =
-          nextLaunchServerName === ""
-            ? undefined
-            : nextServers.servers.find(
-                (server) => server.name === nextLaunchServerName,
-              );
+          nextLaunchServerResolution.type === "server"
+            ? nextServers.servers.find(
+                (server) => server.name === nextLaunchServerResolution.name,
+              )
+            : undefined;
         setLaunchServer(nextLaunchServerName);
         setServerInputValue(
           serverDisplayLabel(nextLaunchServer, nextLaunchServerName),
@@ -1600,7 +1604,9 @@ function App(): JSX.Element {
                     const value = details.value[0] ?? NO_SERVER_VALUE;
                     const nextLaunchServer =
                       value === NO_SERVER_VALUE ? "" : value;
-                    writeStoredAccountLoginServerPreference(nextLaunchServer);
+                    writeStoredAccountLoginServerPreference(
+                      nextLaunchServer === "" ? null : nextLaunchServer,
+                    );
                     setLaunchServer(nextLaunchServer);
                     setServerInputValue(
                       serverComboboxOpen() || serverInputFocused()

--- a/app/src/renderer/windows/account-manager/App.tsx
+++ b/app/src/renderer/windows/account-manager/App.tsx
@@ -74,6 +74,11 @@ import {
   type ManagedAccountDraft,
   type ScriptExecutePayload,
 } from "../../../shared/ipc";
+import {
+  readStoredAccountLoginServerPreference,
+  resolveAccountLoginServerPreference,
+  writeStoredAccountLoginServerPreference,
+} from "../../lib/accountLoginServerSelection";
 import { mountWindow } from "../mount";
 
 interface AccountFormState {
@@ -956,11 +961,16 @@ function App(): JSX.Element {
       setServerRefreshCooldownUntil(nextServers.refreshAvailableAt);
       setServers(nextServers.servers);
       if (!serverSelectionInitialized()) {
+        const nextLaunchServerName = resolveAccountLoginServerPreference(
+          nextServers.servers,
+          readStoredAccountLoginServerPreference(),
+        );
         const nextLaunchServer =
-          nextServers.servers.find(
-            (server) => server.online && server.playerCount < server.maxPlayers,
-          ) ?? undefined;
-        const nextLaunchServerName = nextLaunchServer?.name ?? "";
+          nextLaunchServerName === ""
+            ? undefined
+            : nextServers.servers.find(
+                (server) => server.name === nextLaunchServerName,
+              );
         setLaunchServer(nextLaunchServerName);
         setServerInputValue(
           serverDisplayLabel(nextLaunchServer, nextLaunchServerName),
@@ -1590,6 +1600,7 @@ function App(): JSX.Element {
                     const value = details.value[0] ?? NO_SERVER_VALUE;
                     const nextLaunchServer =
                       value === NO_SERVER_VALUE ? "" : value;
+                    writeStoredAccountLoginServerPreference(nextLaunchServer);
                     setLaunchServer(nextLaunchServer);
                     setServerInputValue(
                       serverComboboxOpen() || serverInputFocused()


### PR DESCRIPTION
## Summary

- persist the selected account-manager login server as a renderer-local preference
- restore saved online servers on startup, including full servers
- remember `None` as an explicit login server preference
- fall back to the first online non-full server when the saved server is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Account login server preferences are now saved automatically. The app remembers and restores your preferred server on subsequent logins.
  * If your preferred server becomes unavailable (offline or at capacity), the app automatically selects the next suitable online server.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toommyliu/vexed/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->