### PR TITLE
refactor(ui): decouple Electron demo from app

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,6 @@
     "compile:watch": "node esbuild.config.js --watch",
     "compile:prod": "cross-env NODE_ENV=production node esbuild.config.js",
     "electron": "node scripts/start-electron.mjs",
-    "dev:ui:electron11": "node scripts/start-ui-demo-electron11.mjs",
     "build": "pnpm run compile:prod",
     "build:fast": "npm-run-all --sequential compile:prod \"electron-builder build\"",
     "electron-builder": "electron-builder"

--- a/app/src/main/app/MainApp.ts
+++ b/app/src/main/app/MainApp.ts
@@ -133,26 +133,6 @@ const removeDirectory = async (path: string): Promise<void> => {
 const clearFlashData = (flashRootPath: string): Promise<void> =>
   removeDirectory(flashRootPath);
 
-export const resolveDevRendererUrl = (
-  isDev: boolean,
-  devRendererUrl: string | undefined,
-): string | null => {
-  if (!isDev || !devRendererUrl) {
-    return null;
-  }
-
-  try {
-    const url = new URL(devRendererUrl);
-    const isLoopback =
-      url.protocol === "http:" &&
-      (url.hostname === "127.0.0.1" || url.hostname === "localhost");
-
-    return isLoopback ? url.toString() : null;
-  } catch {
-    return null;
-  }
-};
-
 const makeWindowEffectRunner = (
   services: ServiceMap.ServiceMap<WindowService>,
 ): WindowEffectRunner => {

--- a/app/src/main/app/MainEnvironment.ts
+++ b/app/src/main/app/MainEnvironment.ts
@@ -15,7 +15,6 @@ export interface MainEnvironmentConfig {
   readonly preloadPath: string;
   readonly flashPluginPathOverride?: string;
   readonly devRendererReloadPath?: string;
-  readonly devRendererUrl?: string;
   readonly isDev: boolean;
   readonly isDarwin: boolean;
   readonly isWin: boolean;

--- a/app/src/main/index.ts
+++ b/app/src/main/index.ts
@@ -9,7 +9,6 @@ import {
   configureGameWindow,
   getLatestAppearanceSnapshot,
   makeProgram,
-  resolveDevRendererUrl,
 } from "./app/MainApp";
 import {
   MainEnvironment,
@@ -147,9 +146,6 @@ const envConfig: MainEnvironmentConfig = {
   ...(process.env["VEXED_DEV_RENDERER_RELOAD"] === undefined
     ? {}
     : { devRendererReloadPath: process.env["VEXED_DEV_RENDERER_RELOAD"] }),
-  ...(process.env["VEXED_DEV_RENDERER_URL"] === undefined
-    ? {}
-    : { devRendererUrl: process.env["VEXED_DEV_RENDERER_URL"] }),
   ...(cliOptions.flashPluginPath === undefined
     ? {}
     : { flashPluginPathOverride: cliOptions.flashPluginPath }),
@@ -211,7 +207,6 @@ const windowLayer = Layer.effect(WindowService)(
       gameWindowHtmlPath: getRendererGameWindowPath(envConfig.rendererDir),
       isDev,
       preloadPath: envConfig.preloadPath,
-      rendererUrl: resolveDevRendererUrl(isDev, envConfig.devRendererUrl),
       windowHtmlPath: (id) => getRendererWindowPath(envConfig.rendererDir, id),
       getAppearanceSnapshot: getLatestAppearanceSnapshot,
       onGameWindowCreated: (window) =>

--- a/app/src/main/ipc/methods/accounts.test.ts
+++ b/app/src/main/ipc/methods/accounts.test.ts
@@ -125,7 +125,6 @@ const makeHarness = (): {
     gameWindowHtmlPath: "/renderer/game/index.html",
     isDev: false,
     preloadPath: "/preload.js",
-    rendererUrl: null,
     windowHtmlPath: (id) => `/renderer/${id}/index.html`,
     getAppearanceSnapshot: () =>
       createAppearanceSnapshot(DEFAULT_APPEARANCE, true),

--- a/app/src/main/window/WindowService.test.ts
+++ b/app/src/main/window/WindowService.test.ts
@@ -178,7 +178,6 @@ const createHarness = (
     gameWindowHtmlPath: "/renderer/game/index.html",
     isDev: false,
     preloadPath: "/preload/index.js",
-    rendererUrl: null,
     windowHtmlPath: (id: WindowId) => `/renderer/${id}/index.html`,
     getAppearanceSnapshot: () => appearanceSnapshot,
   };

--- a/app/src/main/window/WindowService.ts
+++ b/app/src/main/window/WindowService.ts
@@ -418,9 +418,7 @@ export const makeWindowService = (
   const loadGameRenderer = (
     window: BrowserWindow,
   ): Effect.Effect<void, WindowManagerError> =>
-    config.rendererUrl
-      ? loadWindow(window, config.rendererUrl, "url")
-      : loadWindow(window, config.gameWindowHtmlPath, "file");
+    loadWindow(window, config.gameWindowHtmlPath, "file");
 
   const loadCatalogRenderer = (
     window: BrowserWindow,

--- a/app/src/main/window/WindowTypes.ts
+++ b/app/src/main/window/WindowTypes.ts
@@ -12,7 +12,6 @@ export interface WindowManagerConfig {
   readonly gameWindowHtmlPath: string;
   readonly isDev: boolean;
   readonly preloadPath: string;
-  readonly rendererUrl: string | null;
   readonly windowHtmlPath: (id: WindowId) => string;
   readonly getAppearanceSnapshot: () => AppearanceSnapshot;
   readonly onGameWindowCreated?: (window: BrowserWindow) => void;

--- a/packages/ui/demo/electron/main.cjs
+++ b/packages/ui/demo/electron/main.cjs
@@ -1,0 +1,34 @@
+const { app, BrowserWindow } = require("electron");
+
+const demoUrl = process.argv[2];
+
+if (!demoUrl) {
+  throw new Error("Missing UI demo URL argument");
+}
+
+const createWindow = async () => {
+  const window = new BrowserWindow({
+    backgroundColor: "#0f1115",
+    height: 900,
+    show: false,
+    title: "Vexed UI Demo",
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+    width: 1280,
+  });
+
+  window.once("ready-to-show", () => {
+    window.show();
+  });
+
+  await window.loadURL(demoUrl);
+};
+
+app.once("window-all-closed", () => {
+  app.quit();
+});
+
+app.whenReady().then(createWindow);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,7 +40,7 @@
     "icon:print": "tsx scripts/print-lucide-icon.ts",
     "demo": "vite --config vite.demo.config.ts --host 127.0.0.1",
     "demo:build": "vite build --config vite.demo.config.ts",
-    "demo:electron11": "pnpm --dir ../../app dev:ui:electron11",
+    "demo:electron11": "node scripts/start-electron11-demo.mjs",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
@@ -55,6 +55,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
+    "electron": "workspace:*",
     "esbuild": "^0.25.5",
     "esbuild-plugin-solid": "^0.6.0",
     "happy-dom": "^20.9.0",

--- a/packages/ui/scripts/start-electron11-demo.mjs
+++ b/packages/ui/scripts/start-electron11-demo.mjs
@@ -1,14 +1,15 @@
 import { spawn } from "node:child_process";
 import { get } from "node:http";
+import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const appDir = resolve(__dirname, "..");
-const repoRoot = resolve(appDir, "..");
-const uiDir = resolve(repoRoot, "packages/ui");
-const defaultUiDemoHost = "localhost";
-const defaultUiDemoPort = 4173;
+const packageRoot = resolve(__dirname, "..");
+const demoMainPath = resolve(packageRoot, "demo/electron/main.cjs");
+const demoHost = "127.0.0.1";
+const demoPort = 4173;
 const readyTimeoutMs = 30_000;
 const readyPollMs = 250;
 const children = new Set();
@@ -73,36 +74,6 @@ function sleep(ms) {
   return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
 }
 
-function resolveDemoHost() {
-  const host = process.env["VEXED_UI_DEMO_HOST"] ?? defaultUiDemoHost;
-
-  if (host === "localhost" || host === "127.0.0.1") {
-    return host;
-  }
-
-  throw new Error(
-    `VEXED_UI_DEMO_HOST must be localhost or 127.0.0.1, received ${JSON.stringify(host)}`,
-  );
-}
-
-async function runRequired(label, command, args, cwd) {
-  const child = spawnChild(command, args, {
-    cwd,
-    env: process.env,
-  });
-  const result = await waitForChild(child);
-
-  if (result.code === 0) {
-    return;
-  }
-
-  throw new Error(
-    result.signal
-      ? `${label} exited after ${result.signal}`
-      : `${label} exited with code ${result.code}`,
-  );
-}
-
 function requestReady(url) {
   return new Promise((resolvePromise) => {
     const request = get(url, (response) => {
@@ -143,7 +114,7 @@ function waitForViteUrl(child) {
       output += text;
       process.stdout.write(chunk);
 
-      const match = output.match(/https?:\/\/(?:localhost|127\.0\.0\.1):\d+\//);
+      const match = output.match(/https?:\/\/127\.0\.0\.1:\d+\//);
       if (!match || settled) {
         return;
       }
@@ -169,38 +140,30 @@ async function waitForServer(url, isRunning) {
       return;
     }
 
-    await new Promise((resolvePromise) =>
-      setTimeout(resolvePromise, readyPollMs),
-    );
+    await sleep(readyPollMs);
   }
 
   throw new Error(`Timed out waiting for ${url}`);
 }
 
 async function main() {
-  const uiDemoHost = resolveDemoHost();
-  const uiDemoPort = defaultUiDemoPort;
-
-  console.log("[ui-demo-electron11] compiling app");
-  await runRequired("app compile", "pnpm", ["compile"], appDir);
-
   console.log(
-    `[ui-demo-electron11] starting UI demo on ${uiDemoHost}:${uiDemoPort}`,
+    `[ui-demo-electron11] starting UI demo on ${demoHost}:${demoPort}`,
   );
   const vite = spawnChild(
     "pnpm",
     [
-      "--dir",
-      uiDir,
-      "demo",
+      "exec",
+      "vite",
+      "--config",
+      "vite.demo.config.ts",
       "--host",
-      uiDemoHost,
+      demoHost,
       "--port",
-      String(uiDemoPort),
+      String(demoPort),
     ],
     {
-      cwd: repoRoot,
-      env: process.env,
+      cwd: packageRoot,
       stdio: ["inherit", "pipe", "pipe"],
     },
   );
@@ -225,12 +188,8 @@ async function main() {
   await waitForServer(uiDemoUrl, () => viteExit === null);
 
   console.log(`[ui-demo-electron11] launching Electron 11 at ${uiDemoUrl}`);
-  const electron = spawnChild("pnpm", ["electron"], {
-    cwd: appDir,
-    env: {
-      ...process.env,
-      VEXED_DEV_RENDERER_URL: uiDemoUrl,
-    },
+  const electron = spawnChild(require("electron"), [demoMainPath, uiDemoUrl], {
+    cwd: packageRoot,
   });
 
   const electronExitPromise = waitForChild(electron);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
+      electron:
+        specifier: workspace:*
+        version: link:../electron
       esbuild:
         specifier: ^0.25.5
         version: 0.25.12


### PR DESCRIPTION
## Summary
- move the Electron 11 UI demo to a standalone packages/ui harness
- remove the app-owned UI demo launcher and package script
- remove the app renderer URL override path and stale window-service config