### PR TITLE
feat: add data clearing menu actions

### DIFF
--- a/app/src/main/app/MainApp.ts
+++ b/app/src/main/app/MainApp.ts
@@ -1,4 +1,4 @@
-import { unwatchFile, watchFile, type Stats } from "fs";
+import { unwatchFile, watchFile, promises, type Stats } from "fs";
 import {
   app,
   BrowserWindow,
@@ -110,6 +110,28 @@ const installDevDockIcon = (
 
   app.dock.setIcon(iconPath);
 };
+
+const clearAppData = (): Promise<void> =>
+  Promise.all([
+    session.defaultSession.clearCache(),
+    session.defaultSession.clearStorageData(),
+  ]).then(() => undefined);
+
+const removeDirectory = async (path: string): Promise<void> => {
+  if (typeof promises.rm === "function") {
+    await promises.rm(path, { recursive: true, force: true });
+    return;
+  }
+
+  await promises.rmdir(path, { recursive: true }).catch((cause: unknown) => {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw cause;
+    }
+  });
+};
+
+const clearFlashData = (flashRootPath: string): Promise<void> =>
+  removeDirectory(flashRootPath);
 
 export const resolveDevRendererUrl = (
   isDev: boolean,
@@ -258,9 +280,10 @@ const createApplicationMenuEffect = (
 ): Effect.Effect<
   void,
   never,
-  Observability | SettingsService | UpdateChecker
+  MainEnvironment | Observability | SettingsService | UpdateChecker
 > =>
   Effect.gen(function* () {
+    const env = yield* MainEnvironment;
     const observability = yield* Observability;
     const settings = yield* SettingsService;
     const updates = yield* UpdateChecker;
@@ -276,6 +299,8 @@ const createApplicationMenuEffect = (
         updateAppearance: (patch) =>
           runPromise(settings.updateAppearance(patch)),
         checkForUpdates: () => runPromise(updates.checkNow({ force: true })),
+        clearAppData,
+        clearFlashData: () => clearFlashData(env.flashRootPath),
         logError: (component, message, error, data) => {
           void runPromise(
             observability.error(component, message, error, data),

--- a/app/src/main/window/ApplicationMenu.ts
+++ b/app/src/main/window/ApplicationMenu.ts
@@ -20,6 +20,8 @@ export interface ApplicationMenuDependencies {
     readonly themeMode: ThemeMode;
   }) => Promise<AppSettings>;
   readonly checkForUpdates: () => Promise<UpdateCheckState>;
+  readonly clearAppData: () => Promise<void>;
+  readonly clearFlashData: () => Promise<void>;
   readonly logError: (
     component: string,
     message: string,
@@ -78,6 +80,36 @@ const showUpdateResult = async (state: UpdateCheckState): Promise<void> => {
   });
 };
 
+const showDataClearResult = async (
+  dataName: string,
+  result: "succeeded" | "failed",
+) => {
+  if (result === "succeeded") {
+    const response = await dialog.showMessageBox({
+      type: "info",
+      title: `${dataName} Data Cleared`,
+      message: `${dataName} data was cleared.`,
+      buttons: ["Relaunch Now", "Later"],
+      defaultId: 0,
+      cancelId: 1,
+    });
+
+    if (response.response === 0) {
+      app.relaunch();
+      app.quit();
+    }
+
+    return;
+  }
+
+  await dialog.showMessageBox({
+    type: "warning",
+    title: `${dataName} Data Clear Failed`,
+    message: `Vexed could not clear the ${dataName.toLowerCase()} data.`,
+    detail: "Check the logs for details.",
+  });
+};
+
 const createAccountManagerMenuItem = (
   deps: Pick<ApplicationMenuDependencies, "logError" | "runWindowEffect">,
 ): MenuItemConstructorOptions => ({
@@ -108,6 +140,22 @@ const createAppearanceMenuItem = (
   checked: currentMode === mode,
   click: () => {
     void updateAppearance({ themeMode: mode });
+  },
+});
+
+const createClearDataMenuItem = (
+  dataName: string,
+  clearData: () => Promise<void>,
+  dependencies: Pick<ApplicationMenuDependencies, "logError">,
+): MenuItemConstructorOptions => ({
+  label: `Clear ${dataName} Data`,
+  click: () => {
+    void clearData()
+      .then(() => showDataClearResult(dataName, "succeeded"))
+      .catch((error) => {
+        dependencies.logError("menu", `Failed to clear ${dataName} data`, error);
+        return showDataClearResult(dataName, "failed");
+      });
   },
 });
 
@@ -217,6 +265,27 @@ const installApplicationMenu = async (
     { type: "separator" },
     { role: "togglefullscreen" },
   ];
+  const helpSubmenu: MenuItemConstructorOptions[] = [
+    ...(!isDarwin
+      ? ([
+          { role: "about" },
+          { type: "separator" },
+          {
+            label: "Check for Updates...",
+            click: () => {
+              void dependencies.checkForUpdates().then(showUpdateResult);
+            },
+          },
+          { type: "separator" },
+        ] satisfies MenuItemConstructorOptions[])
+      : []),
+    createClearDataMenuItem("App", dependencies.clearAppData, dependencies),
+    createClearDataMenuItem(
+      "Flash",
+      dependencies.clearFlashData,
+      dependencies,
+    ),
+  ];
   const template: MenuItemConstructorOptions[] = [
     ...(isDarwin
       ? [
@@ -230,23 +299,8 @@ const installApplicationMenu = async (
     { label: "Edit", submenu: editSubmenu },
     { label: "View", submenu: viewSubmenu },
     { role: "windowMenu" },
+    { label: "Help", submenu: helpSubmenu },
   ];
-
-  if (!isDarwin) {
-    template.push({
-      label: "Help",
-      submenu: [
-        { role: "about" },
-        { type: "separator" },
-        {
-          label: "Check for Updates...",
-          click: () => {
-            void dependencies.checkForUpdates().then(showUpdateResult);
-          },
-        },
-      ],
-    });
-  }
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 };


### PR DESCRIPTION
## Summary

Adds Help menu actions for clearing app data and Flash data separately.

- Clears Electron session cache and storage data for app data resets
- Clears the resolved Pepper Flash writable root for Flash data resets
- Prompts to relaunch after a successful clear