### PR TITLE
fix(packets): resolve placeholders in core sends

### DIFF
--- a/app/src/renderer/windows/game/flash/Layers/Flash.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Flash.ts
@@ -20,13 +20,17 @@ import { WorldLive } from "./World";
 
 const BridgeCoreLive = BridgeLive;
 const WaitRuntimeLive = WaitLive.pipe(Layer.provide(BridgeCoreLive));
-const PacketRuntimeLive = PacketLive.pipe(Layer.provide(BridgeCoreLive));
 
 const AuthRuntimeLive = AuthLive.pipe(
   Layer.provide(Layer.mergeAll(BridgeCoreLive, WaitRuntimeLive)),
 );
 const WorldRuntimeLive = WorldLive.pipe(
   Layer.provide(Layer.mergeAll(BridgeCoreLive, WaitRuntimeLive)),
+);
+const PacketRuntimeLive = PacketLive.pipe(
+  Layer.provide(
+    Layer.mergeAll(BridgeCoreLive, AuthRuntimeLive, WorldRuntimeLive),
+  ),
 );
 
 const CoreRuntimeLive = Layer.mergeAll(

--- a/app/src/renderer/windows/game/flash/Layers/GameEventProjector.test.ts
+++ b/app/src/renderer/windows/game/flash/Layers/GameEventProjector.test.ts
@@ -65,16 +65,19 @@ const auth = {
 } satisfies AuthShape;
 
 const bridgeLayer = Layer.succeed(Bridge)(bridge);
+const authLayer = Layer.succeed(Auth)(auth);
 const waitRuntimeLayer = WaitLive.pipe(Layer.provide(bridgeLayer));
-const packetRuntimeLayer = PacketLive.pipe(Layer.provide(bridgeLayer));
 const worldRuntimeLayer = WorldLive.pipe(
   Layer.provide(Layer.mergeAll(bridgeLayer, waitRuntimeLayer)),
+);
+const packetRuntimeLayer = PacketLive.pipe(
+  Layer.provide(Layer.mergeAll(bridgeLayer, authLayer, worldRuntimeLayer)),
 );
 const coreRuntimeLayer = Layer.mergeAll(
   waitRuntimeLayer,
   packetRuntimeLayer,
   worldRuntimeLayer,
-  Layer.succeed(Auth)(auth),
+  authLayer,
 );
 const gameEventsRuntimeLayer = GameEventsLive;
 const gameEventProjectorRuntimeLayer = GameEventProjectorLive.pipe(

--- a/app/src/renderer/windows/game/flash/Layers/Packet.test.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Packet.test.ts
@@ -1,7 +1,9 @@
 import { Data, Effect, Layer } from "effect";
 import { expect, test } from "vitest";
+import { Auth, type AuthShape } from "../Services/Auth";
 import { Bridge, type BridgeShape } from "../Services/Bridge";
 import { Packet, type PacketShape } from "../Services/Packet";
+import { World, type WorldShape } from "../Services/World";
 import { PacketLive } from "./Packet";
 
 type PacketWindow = Pick<
@@ -29,8 +31,66 @@ const bridge = {
   },
 } satisfies BridgeShape;
 
+const auth = {
+  connectTo: () =>
+    Effect.succeed({
+      message: "connected",
+      retryable: false,
+      status: "connected",
+    } as const),
+  getServers: () => Effect.succeed([]),
+  getUsername: () => Effect.succeed("Artix"),
+  getPassword: () => Effect.succeed("password"),
+  getLoginSession: () =>
+    Effect.succeed({
+      bSuccess: 1,
+      iUpg: 0,
+      servers: [],
+      sToken: "password",
+      unm: "Artix",
+    }),
+  isLoggedIn: () => Effect.succeed(true),
+  isTemporarilyKicked: () => Effect.succeed(false),
+  login: () => Effect.void,
+  logout: () => Effect.void,
+} satisfies AuthShape;
+
+const world = {
+  map: {
+    getId: () => Effect.succeed(12),
+    getName: () => Effect.succeed("battleon"),
+    getRoomNumber: () => Effect.succeed(34_567),
+  },
+} as unknown as WorldShape;
+
+const unavailableAuth = {
+  ...auth,
+  getUsername: () =>
+    Effect.die(new PacketTestError({ message: "auth should not be read" })),
+} satisfies AuthShape;
+
+const unavailableWorld = {
+  map: {
+    getId: () =>
+      Effect.die(new PacketTestError({ message: "map id should not be read" })),
+    getName: () =>
+      Effect.die(
+        new PacketTestError({ message: "map name should not be read" }),
+      ),
+    getRoomNumber: () =>
+      Effect.die(
+        new PacketTestError({ message: "room number should not be read" }),
+      ),
+  },
+} as unknown as WorldShape;
+
 const withPacket = async <A>(
   body: (packet: PacketShape) => Effect.Effect<A, unknown>,
+  testBridge: BridgeShape = bridge,
+  services: {
+    readonly auth?: AuthShape;
+    readonly world?: WorldShape;
+  } = {},
 ): Promise<A> => {
   const hadWindow = "window" in globalThis;
   const previousWindow = globalThis.window;
@@ -50,7 +110,15 @@ const withPacket = async <A>(
         }),
       ).pipe(
         Effect.provide(
-          PacketLive.pipe(Layer.provide(Layer.succeed(Bridge)(bridge))),
+          PacketLive.pipe(
+            Layer.provide(
+              Layer.mergeAll(
+                Layer.succeed(Auth)(services.auth ?? auth),
+                Layer.succeed(Bridge)(testBridge),
+                Layer.succeed(World)(services.world ?? world),
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -226,6 +294,84 @@ test("unparseable packets still reach raw listeners", async () => {
   );
 
   expect(observed).toBe("not a parseable packet");
+});
+
+test("sendServer resolves supported placeholders before forwarding", async () => {
+  const calls: Array<{ readonly functionName: string; readonly args: unknown[] }> =
+    [];
+  const capturingBridge = {
+    ...bridge,
+    callGameFunction(functionName: string, ...args: ReadonlyArray<unknown>) {
+      calls.push({ args: [...args], functionName });
+      return Effect.void;
+    },
+  } satisfies BridgeShape;
+
+  await withPacket(
+    (packet) =>
+      packet.sendServer(
+        "%xt%zm%cmd%{MAP_ID}%{ROOM_NUMBER}%{MAP_NAME}%{PLAYER_NAME}%ROOM_ID%",
+      ),
+    capturingBridge,
+  );
+
+  expect(calls).toEqual([
+    {
+      args: ["%xt%zm%cmd%12%34567%battleon%Artix%ROOM_ID%"],
+      functionName: "sfc.sendString",
+    },
+  ]);
+});
+
+test("sendServer skips context lookups without supported placeholders", async () => {
+  const calls: Array<{ readonly functionName: string; readonly args: unknown[] }> =
+    [];
+  const capturingBridge = {
+    ...bridge,
+    callGameFunction(functionName: string, ...args: ReadonlyArray<unknown>) {
+      calls.push({ args: [...args], functionName });
+      return Effect.void;
+    },
+  } satisfies BridgeShape;
+
+  await withPacket(
+    (packet) => packet.sendServer("%xt%zm%cmd%ROOM_ID%"),
+    capturingBridge,
+    { auth: unavailableAuth, world: unavailableWorld },
+  );
+
+  expect(calls).toEqual([
+    {
+      args: ["%xt%zm%cmd%ROOM_ID%"],
+      functionName: "sfc.sendString",
+    },
+  ]);
+});
+
+test("sendClient resolves supported placeholders before forwarding", async () => {
+  const calls: Array<{ readonly args: unknown; readonly path: string }> = [];
+  const capturingBridge = {
+    ...bridge,
+    call<K extends keyof Window["swf"]>(
+      path: K,
+      args?: Parameters<Window["swf"][K]>,
+    ) {
+      calls.push({ args, path });
+      return Effect.void as Effect.Effect<ReturnType<Window["swf"][K]>>;
+    },
+  } satisfies BridgeShape;
+
+  await withPacket(
+    (packet) => packet.sendClient("{PLAYER_NAME}:{ROOM_NUMBER}", "json"),
+    capturingBridge,
+  );
+
+  expect(calls).toEqual([
+    {
+      args: ["Artix:34567", "json"],
+      path: "flash.sendClientPacket",
+    },
+  ]);
 });
 
 test("internal handler failure does not prevent raw handlers", async () => {

--- a/app/src/renderer/windows/game/flash/Layers/Packet.ts
+++ b/app/src/renderer/windows/game/flash/Layers/Packet.ts
@@ -19,7 +19,13 @@ import {
   type PacketShape,
   type ServerPacketHandler,
 } from "../Services/Packet";
+import {
+  hasSupportedPacketPlaceholders,
+  resolvePacketPlaceholders,
+} from "../../../../../shared/packets";
+import { Auth } from "../Services/Auth";
 import { Bridge } from "../Services/Bridge";
+import { World } from "../Services/World";
 
 type WindowPacketHandlerKey =
   | "onExtensionResponse"
@@ -114,7 +120,9 @@ const runHandlers = <A>(
 };
 
 const make = Effect.gen(function* () {
+  const auth = yield* Auth;
   const bridge = yield* Bridge;
+  const world = yield* World;
   const runFork = Effect.runForkWith(yield* Effect.services());
 
   const extensionRawHandlers = new Set<PacketListener>();
@@ -269,11 +277,36 @@ const make = Effect.gen(function* () {
     }),
   );
 
+  const resolvePlaceholders = (packet: string) =>
+    Effect.gen(function* () {
+      if (!hasSupportedPacketPlaceholders(packet)) {
+        return packet;
+      }
+
+      const context = yield* Effect.all({
+        mapId: world.map.getId(),
+        mapName: world.map.getName(),
+        playerName: auth.getUsername(),
+        roomNumber: world.map.getRoomNumber(),
+      });
+
+      return resolvePacketPlaceholders(packet, context);
+    });
+
   const sendClient: PacketShape["sendClient"] = (packet, type = "str") =>
-    bridge.call("flash.sendClientPacket", [packet, type]);
+    resolvePlaceholders(packet).pipe(
+      Effect.flatMap((resolved) =>
+        bridge.call("flash.sendClientPacket", [resolved, type]),
+      ),
+    );
 
   const sendServer: PacketShape["sendServer"] = (packet, type = "String") =>
-    bridge.callGameFunction(`sfc.send${type}`, packet).pipe(Effect.asVoid);
+    resolvePlaceholders(packet).pipe(
+      Effect.flatMap((resolved) =>
+        bridge.callGameFunction(`sfc.send${type}`, resolved),
+      ),
+      Effect.asVoid,
+    );
 
   const onExtensionResponse: PacketShape["onExtensionResponse"] = (handler) =>
     registerSetHandler(extensionRawHandlers, handler);

--- a/app/src/renderer/windows/game/packetsBridge.ts
+++ b/app/src/renderer/windows/game/packetsBridge.ts
@@ -3,8 +3,6 @@ import {
   clampPacketQueueDelay,
   isPacketSendTarget,
   normalizePacketQueuePayload,
-  resolvePacketPlaceholders,
-  type PacketPlaceholderContext,
   type PacketQueuePayload,
   type PacketSendPayload,
   type PacketSendTarget,
@@ -14,9 +12,7 @@ import type {
   PacketsResponseMessage,
 } from "../../../shared/ipc";
 import type { runtime as gameRuntime } from "./Runtime";
-import { Auth } from "./flash/Services/Auth";
 import { Packet, type ClientPacketSendType } from "./flash/Services/Packet";
-import { World } from "./flash/Services/World";
 
 type GameRuntime = typeof gameRuntime;
 
@@ -63,24 +59,15 @@ const disposeAll = (disposers: readonly (() => void)[]): void => {
 
 const sendPacketEffect = (payload: PacketSendPayload) =>
   Effect.gen(function* () {
-    const auth = yield* Auth;
     const packets = yield* Packet;
-    const world = yield* World;
-    const context: PacketPlaceholderContext = yield* Effect.all({
-      mapId: world.map.getId(),
-      mapName: world.map.getName(),
-      playerName: auth.getUsername(),
-      roomNumber: world.map.getRoomNumber(),
-    });
-    const packet = resolvePacketPlaceholders(payload.packet, context);
 
     if (payload.target === "server-string") {
-      yield* packets.sendServer(packet, "String");
+      yield* packets.sendServer(payload.packet, "String");
       return;
     }
 
     if (payload.target === "server-json") {
-      yield* packets.sendServer(packet, "Json");
+      yield* packets.sendServer(payload.packet, "Json");
       return;
     }
 
@@ -90,7 +77,7 @@ const sendPacketEffect = (payload: PacketSendPayload) =>
         : payload.target === "client-xml"
           ? "xml"
           : "str";
-    yield* packets.sendClient(packet, clientType);
+    yield* packets.sendClient(payload.packet, clientType);
   });
 
 const publishCaptured = (

--- a/app/src/shared/packets.test.ts
+++ b/app/src/shared/packets.test.ts
@@ -3,6 +3,7 @@ import {
   PACKET_QUEUE_DEFAULT_DELAY_MS,
   PACKET_QUEUE_MIN_DELAY_MS,
   clampPacketQueueDelay,
+  hasSupportedPacketPlaceholders,
   isPacketSendTarget,
   normalizePacketQueuePayload,
   normalizePacketText,
@@ -82,6 +83,12 @@ describe("packet helpers", () => {
         placeholderContext,
       ),
     ).toBe("%xt%zm%cmd%12%34567%battleon%Artix%Artix%");
+  });
+
+  it("detects only supported packet placeholders", () => {
+    expect(hasSupportedPacketPlaceholders("%xt%{ROOM_NUMBER}%")).toBe(true);
+    expect(hasSupportedPacketPlaceholders("{ROOM_ID}:{UNKNOWN}")).toBe(false);
+    expect(hasSupportedPacketPlaceholders("%xt%zm%cmd%1%")).toBe(false);
   });
 
   it("leaves unsupported placeholders unchanged", () => {

--- a/app/src/shared/packets.ts
+++ b/app/src/shared/packets.ts
@@ -122,6 +122,11 @@ export const normalizePacketQueuePayload = (
   };
 };
 
+export const hasSupportedPacketPlaceholders = (packet: string): boolean =>
+  PACKET_PLACEHOLDER_DEFINITIONS.some((definition) =>
+    packet.includes(definition.token),
+  );
+
 export const resolvePacketPlaceholders = (
   packet: string,
   context: PacketPlaceholderContext,


### PR DESCRIPTION
## Summary

- Move packet placeholder resolution into the core `Packet` send API.
- Remove duplicate placeholder resolution from the Packets window bridge.
- Wire `PacketLive` with `Auth` and `World` so send paths can resolve existing placeholders consistently.
- Add coverage for client and server packet sends resolving supported placeholders while leaving unsupported tokens literal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Outgoing packets now resolve supported placeholders (map/room/player identifiers, username) before being sent.

* **Refactor**
  * Reorganized runtime/service wiring for packet, auth, and world dependencies to improve modularity and reliability.

* **Tests**
  * Added tests covering placeholder detection/resolution and ensuring lookups occur only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->